### PR TITLE
[DEV-2995] support amount out param

### DIFF
--- a/src/screens/buy-info.screen.tsx
+++ b/src/screens/buy-info.screen.tsx
@@ -71,7 +71,11 @@ export default function BuyInfoScreen(): JSX.Element {
   useEffect(() => fetchData(), [asset, currency, amountIn, amountOut]);
 
   function fetchData() {
-    if (!(asset && currency && (amountIn || amountOut))) return;
+    if (!(asset && currency && (amountIn || amountOut))) {
+      const inputIsComplete = (amountIn || amountOut) && assetIn && assetOut;
+      !inputIsComplete && setErrorMessage('Missing required information');
+      return;
+    }
 
     setErrorMessage(undefined);
 
@@ -132,10 +136,6 @@ export default function BuyInfoScreen(): JSX.Element {
     <Layout textStart backButton={false} scrollRef={scrollRef}>
       {showsCompletion && paymentInfo ? (
         <BuyCompletion user={user} paymentInfo={paymentInfo} navigateOnClose={false} />
-      ) : isLoading ? (
-        <div className="mt-4">
-          <StyledLoadingSpinner size={SpinnerSize.LG} />
-        </div>
       ) : errorMessage ? (
         <StyledVerticalStack center className="text-center">
           <ErrorHint message={errorMessage} />
@@ -148,6 +148,10 @@ export default function BuyInfoScreen(): JSX.Element {
             color={StyledButtonColor.STURDY_WHITE}
           />
         </StyledVerticalStack>
+      ) : isLoading ? (
+        <div className="mt-4">
+          <StyledLoadingSpinner size={SpinnerSize.LG} />
+        </div>
       ) : customAmountError ? (
         <>
           <StyledInfoText invertedIcon>{customAmountError}</StyledInfoText>

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -132,7 +132,9 @@ export default function BuyScreen(): JSX.Element {
   const [validatedData, setValidatedData] = useState<ValidatedData>();
 
   // form
-  const { control, handleSubmit, setValue, resetField } = useForm<FormData>();
+  const { control, handleSubmit, setValue, resetField } = useForm<FormData>({
+    defaultValues: { amount: '100' },
+  });
 
   const selectedAmount = useWatch({ control, name: 'amount' });
   const selectedCurrency = useWatch({ control, name: 'currency' });
@@ -318,7 +320,7 @@ export default function BuyScreen(): JSX.Element {
     return () => {
       isRunning = false;
     };
-  }, [useDebounce(validatedData, 700)]);
+  }, [useDebounce(validatedData, 500)]);
 
   function validateBuy(buy: Buy): void {
     setCustomAmountError(undefined);

--- a/src/screens/buy.screen.tsx
+++ b/src/screens/buy.screen.tsx
@@ -264,9 +264,9 @@ export default function BuyScreen(): JSX.Element {
       asset: selectedAsset,
       targetAmount: targetChanged || selectedAmount === undefined ? selectedTargetAmount : undefined,
       paymentMethod: selectedPaymentMethod,
-    }) as ValidatedData;
+    });
 
-    setValidatedData({ ...data, targetChanged });
+    data && setValidatedData({ ...data, targetChanged });
   }
 
   useEffect(() => {

--- a/src/screens/sell-info.screen.tsx
+++ b/src/screens/sell-info.screen.tsx
@@ -156,7 +156,11 @@ export default function SellInfoScreen(): JSX.Element {
   useEffect(() => fetchData(), [asset, currency, bankAccount, amountIn, amountOut]);
 
   function fetchData() {
-    if (!(asset && currency && bankAccount && (amountIn || amountOut))) return;
+    if (!(asset && currency && bankAccount && (amountIn || amountOut))) {
+      const inputIsComplete = (amountIn || amountOut) && assetIn && assetOut && bankAccountParam;
+      !inputIsComplete && setErrorMessage('Missing required information');
+      return;
+    }
 
     setErrorMessage(undefined);
 
@@ -257,6 +261,8 @@ export default function SellInfoScreen(): JSX.Element {
             color={StyledButtonColor.STURDY_WHITE}
           />
         </StyledVerticalStack>
+      ) : !paymentInfo ? (
+        <StyledLoadingSpinner size={SpinnerSize.LG} />
       ) : customAmountError ? (
         <>
           <StyledInfoText invertedIcon>{customAmountError}</StyledInfoText>

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -331,7 +331,7 @@ export default function SellScreen(): JSX.Element {
     return () => {
       isRunning = false;
     };
-  }, [useDebounce(validatedData, 700)]);
+  }, [useDebounce(validatedData, 500)]);
 
   function validateSell(sell: Sell): void {
     setCustomAmountError(undefined);


### PR DESCRIPTION
- [DEV-2995] support `amount-out` param on Buy & Sell pages + make target amount editable
- [NO-TASK] catch missing params for buy/info and sell/info page

[DEV-2995]: https://dfxswiss.atlassian.net/browse/DEV-2995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ