### PR TITLE
[DEV-3427] limit support message length to 4000 chars

### DIFF
--- a/src/contexts/settings.context.tsx
+++ b/src/contexts/settings.context.tsx
@@ -23,6 +23,7 @@ import { useAppHandlingContext } from './app-handling.context';
 const ValidationErrors: Record<string, string> = {
   required: 'Mandatory field',
   pattern: 'Invalid pattern',
+  message_length: 'Maximum allowed characters: 4000.',
   code_and_number: 'Area code and number required',
   iban_blocked: 'IBAN not allowed',
   iban_country_blocked: 'IBAN country not allowed',

--- a/src/contexts/settings.context.tsx
+++ b/src/contexts/settings.context.tsx
@@ -23,7 +23,7 @@ import { useAppHandlingContext } from './app-handling.context';
 const ValidationErrors: Record<string, string> = {
   required: 'Mandatory field',
   pattern: 'Invalid pattern',
-  message_length: 'Maximum allowed characters: 4000.',
+  message_length: 'Maximum allowed characters: 4000',
   code_and_number: 'Area code and number required',
   iban_blocked: 'IBAN not allowed',
   iban_country_blocked: 'IBAN country not allowed',

--- a/src/screens/chat.screen.tsx
+++ b/src/screens/chat.screen.tsx
@@ -241,12 +241,15 @@ interface InputComponentProps {
 }
 
 function InputComponent({ replyToMessage, setReplyToMessage }: InputComponentProps): JSX.Element {
-  const { translate } = useSettingsContext();
+  const { translate, translateError } = useSettingsContext();
   const { submitMessage } = useSupportChatContext();
   const [inputValue, setInputValue] = useState<string>();
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [error, setError] = useState<string>();
 
   function handleSend() {
+    if (!inputValue || error) return;
+
     submitMessage(inputValue, selectedFiles, replyToMessage);
 
     setInputValue('');
@@ -277,6 +280,18 @@ function InputComponent({ replyToMessage, setReplyToMessage }: InputComponentPro
         handleSend();
       }
     }
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const value = e.target.value;
+
+    if (value.length > 4000) {
+      setError(translateError('message_length'));
+    } else if (error) {
+      setError(undefined);
+    }
+
+    setInputValue(value);
   }
 
   return (
@@ -369,13 +384,15 @@ function InputComponent({ replyToMessage, setReplyToMessage }: InputComponentPro
             value={inputValue}
             onInput={(e) => setInputValue(e.currentTarget.value)}
             onKeyDown={handleKeyDown}
+            onChange={handleChange}
             placeholder={translate('screens/support', 'Write a message...')}
             required
           />
+          {error && <p className="text-dfxRed-150 text-xs px-3.5 text-left">{error}</p>}
         </div>
 
-        <button onClick={handleSend} className="items-center p-2 cursor-pointer">
-          <MdSend className="text-2xl text-dfxBlue-800" />
+        <button onClick={handleSend} className="items-center p-2">
+          <MdSend className={`text-2xl ${!inputValue || !!error ? 'text-dfxBlue-800/40' : 'text-dfxBlue-800'}`} />
         </button>
       </div>
     </div>

--- a/src/screens/support-issue.screen.tsx
+++ b/src/screens/support-issue.screen.tsx
@@ -258,7 +258,7 @@ export default function SupportIssueScreen(): JSX.Element {
     name: Validations.Required,
     transaction: Validations.Required,
     reason: Validations.Required,
-    message: Validations.Required,
+    message: [Validations.Required, Validations.Custom((message) => message.length <= 4000 || 'message_length')],
     limit: Validations.Required,
     investmentDate: Validations.Required,
     fundOrigin: Validations.Required,

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -53,7 +53,7 @@
     "Only JSON files are allowed": "Nur JSON-Dateien sind erlaubt",
     "Allowed formats: PDF, JPG, JPEG, PNG": "Erlaubte Formate: PDF, JPG, JPEG, PNG",
     "Invalid date format": "Ungültiges Datumsformat",
-    "Maximum allowed characters: 4000.": "Maximal erlaubte Zeichen: 4000.",
+    "Maximum allowed characters: 4000": "Maximal erlaubte Zeichen: 4000",
 
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Irgendwas hat nicht funktioniert, bitte versuche es noch einmal. Wenn das Problem weiterhin besteht, wende Dich bitte an unseren Support.",
     "invoice": "DFX kennt keinen Empfänger mit dem Namen <strong>{{recipient}}</strong>. Dieser Service kann nur für Empfänger verwendet werden, die ein aktives Konto bei DFX haben und für den Rechnungsservice aktiviert sind. Solltest Du dich als Empfänger bei DFX registrieren wollen, dann melde Dich beim Support unter <link>{{supportLink}}</link>."

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -53,6 +53,7 @@
     "Only JSON files are allowed": "Nur JSON-Dateien sind erlaubt",
     "Allowed formats: PDF, JPG, JPEG, PNG": "Erlaubte Formate: PDF, JPG, JPEG, PNG",
     "Invalid date format": "Ungültiges Datumsformat",
+    "Maximum allowed characters: 4000.": "Maximal erlaubte Zeichen: 4000.",
 
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Irgendwas hat nicht funktioniert, bitte versuche es noch einmal. Wenn das Problem weiterhin besteht, wende Dich bitte an unseren Support.",
     "invoice": "DFX kennt keinen Empfänger mit dem Namen <strong>{{recipient}}</strong>. Dieser Service kann nur für Empfänger verwendet werden, die ein aktives Konto bei DFX haben und für den Rechnungsservice aktiviert sind. Solltest Du dich als Empfänger bei DFX registrieren wollen, dann melde Dich beim Support unter <link>{{supportLink}}</link>."

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -53,7 +53,7 @@
     "Only JSON files are allowed": "Seuls les fichiers JSON sont autorisés",
     "Allowed formats: PDF, JPG, JPEG, PNG": "Formats autorisés : PDF, JPG, JPEG, PNG",
     "Invalid date format": "Format de date invalide",
-    "Maximum allowed characters: 4000.": "Nombre maximum de caractères autorisés : 4000.",
+    "Maximum allowed characters: 4000": "Nombre maximum de caractères autorisés : 4000",
 
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Un problème s'est produit. Veuillez réessayer. Si le problème persiste, veuillez contacter notre service d'assistance.",
     "invoice": "DFX ne reconnaît pas un destinataire nommé <strong>{{recipient}}</strong>. Ce service ne peut être utilisé que pour des destinataires ayant un compte actif chez DFX et activés pour le service de facturation. Si vous souhaitez vous inscrire en tant que destinataire chez DFX, veuillez contacter le support à <link>{{supportLink}}</link>."

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -53,6 +53,7 @@
     "Only JSON files are allowed": "Seuls les fichiers JSON sont autorisés",
     "Allowed formats: PDF, JPG, JPEG, PNG": "Formats autorisés : PDF, JPG, JPEG, PNG",
     "Invalid date format": "Format de date invalide",
+    "Maximum allowed characters: 4000.": "Nombre maximum de caractères autorisés : 4000.",
 
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Un problème s'est produit. Veuillez réessayer. Si le problème persiste, veuillez contacter notre service d'assistance.",
     "invoice": "DFX ne reconnaît pas un destinataire nommé <strong>{{recipient}}</strong>. Ce service ne peut être utilisé que pour des destinataires ayant un compte actif chez DFX et activés pour le service de facturation. Si vous souhaitez vous inscrire en tant que destinataire chez DFX, veuillez contacter le support à <link>{{supportLink}}</link>."

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -53,7 +53,7 @@
     "Only JSON files are allowed": "Sono consentiti solo file JSON",
     "Allowed formats: PDF, JPG, JPEG, PNG": "Formati consentiti: PDF, JPG, JPEG, PNG",
     "Invalid date format": "Formato data non valido",
-    "Maximum allowed characters: 4000.": "Caratteri massimi consentiti: 4000.",
+    "Maximum allowed characters: 4000": "Caratteri massimi consentiti: 4000",
 
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Qualcosa è andato storto. Riprovare. Se il problema persiste, contattate il nostro supporto.",
     "invoice": "DFX non riconosce un destinatario con il nome <strong>{{recipient}}</strong>. Questo servizio può essere utilizzato solo per i destinatari che hanno un account attivo con DFX e sono attivati per il servizio di fatturazione. Se desideri registrarti come destinatario presso DFX, contatta l’assistenza all’indirizzo <link>{{supportLink}}</link>."

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -53,6 +53,7 @@
     "Only JSON files are allowed": "Sono consentiti solo file JSON",
     "Allowed formats: PDF, JPG, JPEG, PNG": "Formati consentiti: PDF, JPG, JPEG, PNG",
     "Invalid date format": "Formato data non valido",
+    "Maximum allowed characters: 4000.": "Caratteri massimi consentiti: 4000.",
 
     "Something went wrong. Please try again. If the issue persists please reach out to our support.": "Qualcosa è andato storto. Riprovare. Se il problema persiste, contattate il nostro supporto.",
     "invoice": "DFX non riconosce un destinatario con il nome <strong>{{recipient}}</strong>. Questo servizio può essere utilizzato solo per i destinatari che hanno un account attivo con DFX e sono attivati per il servizio di fatturazione. Se desideri registrarti come destinatario presso DFX, contatta l’assistenza all’indirizzo <link>{{supportLink}}</link>."


### PR DESCRIPTION
- [DEV-3427] Limit support message length to 4000 chars

[DEV-3427]: https://dfxswiss.atlassian.net/browse/DEV-3427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ