### PR TITLE
[DEV-4303] Fix TypeScript and CORS errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.3.0-beta.181",
+        "@dfx.swiss/react": "file:../packages/packages/react",
         "@dfx.swiss/react-components": "^1.3.0-beta.181",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -79,6 +79,18 @@
         "tailwindcss": "^3.2.4",
         "wasm-loader": "^1.3.0",
         "webpack": "^5.75.0"
+      }
+    },
+    "../packages/packages/react": {
+      "name": "@dfx.swiss/react",
+      "version": "1.3.0-beta.182",
+      "license": "MIT",
+      "dependencies": {
+        "ibantools": "^4.2.1",
+        "jwt-decode": "^3.1.2",
+        "libphonenumber-js": "^1.10.39",
+        "react": "^18.2.0",
+        "typescript": "^4.9.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2477,17 +2489,8 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.3.0-beta.181",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.0-beta.181.tgz",
-      "integrity": "sha512-zjzjY2T0BeddBpUx+1cjdi3m+5HQrmLCyk8N2NngN0OnGjksP8EvvrkfTPqXYIJJtkhipDKT8RKc1dCEsIm5kQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ibantools": "^4.2.1",
-        "jwt-decode": "^3.1.2",
-        "libphonenumber-js": "^1.10.39",
-        "react": "^18.2.0",
-        "typescript": "^4.9.3"
-      }
+      "resolved": "../packages/packages/react",
+      "link": true
     },
     "node_modules/@dfx.swiss/react-components": {
       "version": "1.3.0-beta.181",
@@ -2513,18 +2516,6 @@
       }
     },
     "node_modules/@dfx.swiss/react-components/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/@dfx.swiss/react/node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
@@ -20280,11 +20271,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
-    },
     "node_modules/keccak": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
@@ -20440,11 +20426,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/libphonenumber-js": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.4.tgz",
-      "integrity": "sha512-F/R50HQuWWYcmU/esP5jrH5LiWYaN7DpN0a/99U8+mnGGtnx8kmRE+649dQh3v+CowXXZc8vpkf5AmYkO0AQ7Q=="
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.3.0-beta.181",
+    "@dfx.swiss/react": "file:../packages/packages/react",
     "@dfx.swiss/react-components": "^1.3.0-beta.181",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",

--- a/src/hooks/kyc-helper.hook.ts
+++ b/src/hooks/kyc-helper.hook.ts
@@ -58,14 +58,13 @@ export function useKycHelper(): KycHelperInterface {
     [AccountType.SOLE_PROPRIETORSHIP]: 'Sole proprietorship',
   };
 
-  const stepMap: Record<KycStepName, string> = {
+  const stepMap: Partial<Record<KycStepName, string>> = {
     [KycStepName.CONTACT_DATA]: 'Contact data',
     [KycStepName.PERSONAL_DATA]: 'Personal data',
     [KycStepName.LEGAL_ENTITY]: 'Legal entity',
     [KycStepName.OWNER_DIRECTORY]: 'Owner directory',
     [KycStepName.NATIONALITY_DATA]: 'Nationality',
     [KycStepName.COMMERCIAL_REGISTER]: 'Commercial register',
-    [KycStepName.SOLE_PROPRIETORSHIP_CONFIRMATION]: 'Sole proprietorship confirmation',
     [KycStepName.SIGNATORY_POWER]: 'Signatory power',
     [KycStepName.AUTHORITY]: 'Power of Attorney',
     [KycStepName.BENEFICIAL_OWNER]: 'Beneficial owners',
@@ -153,7 +152,7 @@ export function useKycHelper(): KycHelperInterface {
   }
 
   function nameToString(stepName: KycStepName): string {
-    return translate('screens/kyc', stepMap[stepName]);
+    return translate('screens/kyc', stepMap[stepName] ?? 'Unknown step');
   }
 
   function typeToString(stepType: KycStepType): string {

--- a/src/hooks/kyc-helper.hook.ts
+++ b/src/hooks/kyc-helper.hook.ts
@@ -65,6 +65,7 @@ export function useKycHelper(): KycHelperInterface {
     [KycStepName.OWNER_DIRECTORY]: 'Owner directory',
     [KycStepName.NATIONALITY_DATA]: 'Nationality',
     [KycStepName.COMMERCIAL_REGISTER]: 'Commercial register',
+    [KycStepName.SOLE_PROPRIETORSHIP_CONFIRMATION]: 'Sole proprietorship confirmation',
     [KycStepName.SIGNATORY_POWER]: 'Signatory power',
     [KycStepName.AUTHORITY]: 'Power of Attorney',
     [KycStepName.BENEFICIAL_OWNER]: 'Beneficial owners',

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -534,6 +534,12 @@ function KycEdit(props: EditProps): JSX.Element {
 
     case KycStepName.PAYMENT_AGREEMENT:
       return <PaymentAgreement {...props} />;
+      
+    case KycStepName.SOLE_PROPRIETORSHIP_CONFIRMATION:
+      return <></>;
+      
+    default:
+      return <></>;
   }
 }
 

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -535,9 +535,6 @@ function KycEdit(props: EditProps): JSX.Element {
     case KycStepName.PAYMENT_AGREEMENT:
       return <PaymentAgreement {...props} />;
       
-    case KycStepName.SOLE_PROPRIETORSHIP_CONFIRMATION:
-      return <></>;
-      
     default:
       return <></>;
   }


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation errors related to missing SOLE_PROPRIETORSHIP_CONFIRMATION enum
- Prepared for CORS fix from packages PR #99

## Changes
### TypeScript Fixes
- Changed `Record<KycStepName, string>` to `Partial<Record<KycStepName, string>>` in kyc-helper.hook.ts
- Added fallback for unknown KycStepName values
- Added default case to switch statement in kyc.screen.tsx

### Temporary Changes (for testing)
- Using local @dfx.swiss/react package to test CORS fix
- Will revert to npm version once DFXswiss/packages#99 is merged and published

## Related PRs
- DFXswiss/packages#99 - CORS fix for empty query strings

## Test plan
- [x] TypeScript compilation passes
- [x] Build completes successfully
- [ ] Test KYC flow still works correctly
- [ ] Verify CORS errors are resolved when packages#99 is merged

Co-Authored-By: davidleoMay <141653892+davidleoMay@users.noreply.github.com>