### PR TITLE
Separate blockchain and address selection into individual dropdowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@trezor/connect-web": "^9.1.1",
     "@tronweb3/tronwallet-adapter-tronlink": "^1.1.12",
     "@tronweb3/tronwallet-adapter-trust": "^1.0.1",
+    "@types/lodash": "^4.17.20",
     "@wagmi/connectors": "^5.0.7",
     "@wagmi/core": "^2.10.5",
     "@walletconnect/ethereum-provider": "^2.11.0",
@@ -43,12 +44,15 @@
     "i18next": "^22.4.13",
     "i18next-browser-languagedetector": "^7.1.0",
     "ledger-bitcoin": "^0.2.3",
+    "lodash": "^4.17.21",
     "process": "^0.11.10",
     "react": "18.2.0",
     "react-apexcharts": "^1.7.0",
+    "react-device-detect": "^2.2.3",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.40.0",
     "react-i18next": "^12.2.0",
+    "react-icons": "^5.5.0",
     "react-lazy-load-image-component": "^1.6.3",
     "react-qr-code": "^2.0.11",
     "react-router-dom": "^6.10.0",
@@ -108,6 +112,12 @@
         }
       }
     ]
+  },
+  "resolutions": {
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@types/react": "^18.0.25",
+    "@types/react-dom": "^18.0.9"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@trezor/connect-web": "^9.1.1",
     "@tronweb3/tronwallet-adapter-tronlink": "^1.1.12",
     "@tronweb3/tronwallet-adapter-trust": "^1.0.1",
-    "@types/lodash": "^4.17.20",
     "@wagmi/connectors": "^5.0.7",
     "@wagmi/core": "^2.10.5",
     "@walletconnect/ethereum-provider": "^2.11.0",
@@ -44,15 +43,12 @@
     "i18next": "^22.4.13",
     "i18next-browser-languagedetector": "^7.1.0",
     "ledger-bitcoin": "^0.2.3",
-    "lodash": "^4.17.21",
     "process": "^0.11.10",
     "react": "18.2.0",
     "react-apexcharts": "^1.7.0",
-    "react-device-detect": "^2.2.3",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.40.0",
     "react-i18next": "^12.2.0",
-    "react-icons": "^5.5.0",
     "react-lazy-load-image-component": "^1.6.3",
     "react-qr-code": "^2.0.11",
     "react-router-dom": "^6.10.0",
@@ -112,12 +108,6 @@
         }
       }
     ]
-  },
-  "resolutions": {
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "@types/react": "^18.0.25",
-    "@types/react-dom": "^18.0.9"
   },
   "browserslist": {
     "production": [

--- a/src/components/order/address-selector.tsx
+++ b/src/components/order/address-selector.tsx
@@ -1,0 +1,61 @@
+import { Blockchain, useAuthContext } from '@dfx.swiss/react';
+import { StyledDropdown } from '@dfx.swiss/react-components';
+import React, { useMemo } from 'react';
+import { Control } from 'react-hook-form';
+import { addressLabel } from 'src/config/labels';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useWindowContext } from 'src/contexts/window.context';
+import { blankedAddress } from 'src/util/utils';
+
+interface Address {
+  address: string;
+  label: string;
+  chain?: Blockchain;
+}
+
+interface AddressSelectorProps {
+  control: Control<any>;
+  name: string;
+  selectedBlockchain?: Blockchain;
+}
+
+export const AddressSelector: React.FC<AddressSelectorProps> = ({
+  control,
+  name,
+  selectedBlockchain,
+}) => {
+  const { session } = useAuthContext();
+  const { rootRef } = useLayoutContext();
+  const { width } = useWindowContext();
+
+  const addressItems: Address[] = useMemo(() => {
+    if (!session?.address || !selectedBlockchain) return [];
+
+    return [
+      {
+        address: addressLabel(session),
+        label: 'Current address',
+        chain: selectedBlockchain,
+      },
+      {
+        address: 'Switch address',
+        label: 'Login with a different address',
+      },
+    ];
+  }, [session, selectedBlockchain]);
+
+  return (
+    <StyledDropdown<Address>
+      control={control}
+      rootRef={rootRef}
+      name={name}
+      placeholder="Select address..."
+      items={addressItems}
+      labelFunc={(item) => blankedAddress(item.address, { width: width || 0 })}
+      descriptionFunc={(item) => item.label}
+      disabled={!selectedBlockchain}
+      full
+      forceEnable
+    />
+  );
+};

--- a/src/components/order/blockchain-selector.tsx
+++ b/src/components/order/blockchain-selector.tsx
@@ -1,0 +1,35 @@
+import { Blockchain } from '@dfx.swiss/react';
+import { StyledDropdown } from '@dfx.swiss/react-components';
+import React from 'react';
+import { Control } from 'react-hook-form';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useBlockchain } from 'src/hooks/blockchain.hook';
+
+interface BlockchainSelectorProps {
+  control: Control<any>;
+  name: string;
+  availableBlockchains: Blockchain[];
+  selectedBlockchain?: Blockchain;
+}
+
+export const BlockchainSelector: React.FC<BlockchainSelectorProps> = ({
+  control,
+  name,
+  availableBlockchains,
+}) => {
+  const { rootRef } = useLayoutContext();
+  const { toString, toHeader } = useBlockchain();
+
+  return (
+    <StyledDropdown<Blockchain>
+      control={control}
+      rootRef={rootRef}
+      name={name}
+      placeholder="Select blockchain..."
+      items={availableBlockchains}
+      labelFunc={(blockchain) => toString(blockchain)}
+      descriptionFunc={(blockchain) => toHeader(blockchain)}
+      full
+    />
+  );
+};

--- a/src/components/order/order-interface.tsx
+++ b/src/components/order/order-interface.tsx
@@ -13,6 +13,7 @@ import {
   StyledButton,
   StyledButtonWidth,
   StyledDropdown,
+  StyledHorizontalStack,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
 import React, { useCallback, useEffect, useMemo } from 'react';
@@ -30,6 +31,8 @@ import { OrderFormData, OrderType, Side, useOrder } from 'src/hooks/order.hook';
 import { blankedAddress } from 'src/util/utils';
 import { AssetInput } from './asset-input';
 import { BankAccountSelector } from './bank-account-selector';
+import { BlockchainSelector } from './blockchain-selector';
+import { AddressSelector } from './address-selector';
 import { PaymentInfo } from './payment-info';
 
 interface Address {
@@ -75,6 +78,7 @@ export const OrderInterface: React.FC<OrderInterfaceProps> = ({
   const {
     isBuy,
     isSell,
+    availableBlockchains,
     addressItems,
     cryptoBalances,
     paymentInfo,
@@ -116,11 +120,17 @@ export const OrderInterface: React.FC<OrderInterfaceProps> = ({
   }, [availablePaymentMethods, setValue]);
 
   useEffect(() => {
-    if (isInitialized && session?.address && addressItems) {
-      const address = addressItems.find((a) => blockchain && a.chain === blockchain) ?? addressItems[0];
-      setValue('address', address);
+    if (isInitialized && availableBlockchains.length) {
+      const selectedBlockchain = availableBlockchains.find((b) => b === blockchain) ?? availableBlockchains[0];
+      setValue('blockchain', selectedBlockchain);
     }
-  }, [isInitialized, session, addressItems, blockchain, setValue]);
+  }, [isInitialized, availableBlockchains, blockchain, setValue]);
+
+  useEffect(() => {
+    if (isInitialized && session?.address && addressItems.length) {
+      setValue('address', addressItems[0]);
+    }
+  }, [isInitialized, session, addressItems, setValue]);
 
   useEffect(() => {
     const defaultCurrency = getDefaultCurrency(availableCurrencies) ?? availableCurrencies?.[0];
@@ -203,17 +213,24 @@ export const OrderInterface: React.FC<OrderInterfaceProps> = ({
               onAmountChange={() => (lastEditedFieldRef.current = Side.TARGET)}
             />
           ) : null}
-          {!hideTargetSelection && addressItems?.length ? (
-            <StyledDropdown<Address>
-              control={control}
-              rootRef={rootRef}
-              name="address"
-              items={addressItems}
-              labelFunc={(item) => blankedAddress(item.address, { width })}
-              descriptionFunc={(item) => item.label}
-              full
-              forceEnable
-            />
+          {!hideTargetSelection ? (
+            <StyledHorizontalStack gap={1}>
+              <div className="flex-[3_1_9rem] min-w-0">
+                <AddressSelector
+                  control={control}
+                  name="address"
+                  selectedBlockchain={data.blockchain}
+                />
+              </div>
+              <div className="flex-[1_0_9rem] min-w-0">
+                <BlockchainSelector
+                  control={control}
+                  name="blockchain"
+                  availableBlockchains={availableBlockchains}
+                  selectedBlockchain={data.blockchain}
+                />
+              </div>
+            </StyledHorizontalStack>
           ) : null}
         </div>
         {isSell && (

--- a/src/hooks/blockchain.hook.ts
+++ b/src/hooks/blockchain.hook.ts
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 export interface BlockchainInterface {
   toHeader: (blockchain: Blockchain) => string;
-  toProtocol: (blockchain: Blockchain) => Protocol;
+  toProtocol: (blockchain: Blockchain) => Protocol | undefined;
   toMainToken: (blockchain: Blockchain) => string;
   toString: (blockchain: Blockchain) => string;
 }
@@ -83,10 +83,10 @@ export function useBlockchain(): BlockchainInterface {
 
   return useMemo(
     () => ({
-      toHeader: (blockchain: Blockchain) => definitions.headings[blockchain],
+      toHeader: (blockchain: Blockchain) => definitions.headings[blockchain] || '',
       toProtocol: (blockchain: Blockchain) => definitions.protocols[blockchain],
-      toMainToken: (blockchain: Blockchain) => definitions.mainToken[blockchain],
-      toString: (blockchain: Blockchain) => definitions.stringValue[blockchain],
+      toMainToken: (blockchain: Blockchain) => definitions.mainToken[blockchain] || '',
+      toString: (blockchain: Blockchain) => definitions.stringValue[blockchain] || '',
     }),
     [],
   );

--- a/src/hooks/order.hook.ts
+++ b/src/hooks/order.hook.ts
@@ -20,7 +20,6 @@ import { useSettingsContext } from 'src/contexts/settings.context';
 import { OrderPaymentData, OrderPaymentInfo } from 'src/dto/order.dto';
 import { deepEqual } from 'src/util/utils';
 import { useAppParams } from './app-params.hook';
-import { useBlockchain } from './blockchain.hook';
 import { useNavigation } from './navigation.hook';
 import { useTxHelper } from './tx-helper.hook';
 
@@ -102,7 +101,6 @@ export function useOrder({ orderType, sourceAssets, targetAssets }: UseOrderPara
   const { getBalances } = useTxHelper();
   const { navigate } = useNavigation();
   const { translate } = useSettingsContext();
-  const { toString: blockchainToString } = useBlockchain();
   const { isEmbedded, isDfxHosted } = useAppHandlingContext();
   const { wallet, availableBlockchains } = useAppParams();
 

--- a/src/hooks/wallets/trezor.hook.ts
+++ b/src/hooks/wallets/trezor.hook.ts
@@ -76,7 +76,7 @@ export function useTrezor(): TrezorInterface {
       return result.payload.address;
     }
 
-    handlePayloadError('Trezor not connected', result.payload.error);
+    handlePayloadError('Trezor not connected', (result.payload as any).error);
   }
 
   async function fetchAddresses(
@@ -107,7 +107,7 @@ export function useTrezor(): TrezorInterface {
       return result.payload.map((p) => p.address);
     }
 
-    handlePayloadError('Trezor not connected', result.payload.error);
+    handlePayloadError('Trezor not connected', (result.payload as any).error);
   }
 
   async function signMessage(
@@ -133,7 +133,7 @@ export function useTrezor(): TrezorInterface {
       return result.payload.signature;
     }
 
-    handlePayloadError('Cannot sign message', result.payload.error);
+    handlePayloadError('Cannot sign message', (result.payload as any).error);
   }
 
   function handlePayloadError(message: string, payloadError: string): never {

--- a/src/hooks/wallets/trezor.hook.ts
+++ b/src/hooks/wallets/trezor.hook.ts
@@ -43,7 +43,7 @@ export function useTrezor(): TrezorInterface {
         email: 'support@dfx.swiss',
         appUrl: window.location.origin,
         appName: 'DFX.swiss',
-      },
+      } as any,
       transports: ['WebUsbTransport'],
     })
       .then(() => initialized(true))

--- a/src/hooks/wallets/trezor.hook.ts
+++ b/src/hooks/wallets/trezor.hook.ts
@@ -42,6 +42,7 @@ export function useTrezor(): TrezorInterface {
       manifest: {
         email: 'support@dfx.swiss',
         appUrl: window.location.origin,
+        appName: 'DFX.swiss',
       },
       transports: ['WebUsbTransport'],
     })

--- a/src/screens/payment-link.screen.tsx
+++ b/src/screens/payment-link.screen.tsx
@@ -42,8 +42,6 @@ import copy from 'copy-to-clipboard';
 import { useEffect, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { GoCheckCircleFill, GoClockFill, GoSkip, GoXCircleFill } from 'react-icons/go';
-import { LazyLoadImage } from 'react-lazy-load-image-component';
-import 'react-lazy-load-image-component/src/effects/opacity.css';
 import { useSearchParams } from 'react-router-dom';
 import { ErrorHint } from 'src/components/error-hint';
 import { QrBasic } from 'src/components/payment/qr-code';
@@ -913,14 +911,13 @@ function DividerWithHeader({ header, py }: { header: string; py?: number }): JSX
 
 function WalletLogo({ wallet, size }: { wallet: WalletInfo; size: number }): JSX.Element {
   return (
-    <LazyLoadImage
+    <img
       className="border border-dfxGray-400 shadow-md bg-white rounded-md"
       src={wallet.iconUrl}
       alt={wallet.name}
-      effect="opacity"
       width={size}
       height={size}
-      placeholderSrc={`data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 ${size} ${size}'%3E%3Crect width='${size}' height='${size}' fill='%23f4f5f6'/%3E%3C/svg%3E`}
+      loading="lazy"
     />
   );
 }

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -33,10 +33,11 @@ import {
 } from '@dfx.swiss/react-components';
 import { useEffect, useState } from 'react';
 import { FieldPath, FieldPathValue, useForm, useWatch } from 'react-hook-form';
-// import { AddressSelector } from 'src/components/order/address-selector';
-// import { BlockchainSelector } from 'src/components/order/blockchain-selector';
+import { AddressSelector } from 'src/components/order/address-selector';
+import { BlockchainSelector } from 'src/components/order/blockchain-selector';
 import { PaymentInformationContent } from 'src/components/payment/payment-info-sell';
 import { PrivateAssetHint } from 'src/components/private-asset-hint';
+import { addressLabel } from '../config/labels';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import useDebounce from 'src/hooks/debounce.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
@@ -61,8 +62,7 @@ enum Side {
 }
 
 interface Address {
-  address?: string;
-  addressLabel: string;
+  address: string;
   label: string;
   chain?: Blockchain;
 }
@@ -145,7 +145,7 @@ export default function SwapScreen(): JSX.Element {
       // getBalances(sourceAssets, selectedAddress.address, selectedAddress?.chain).then(setBalances);
       console.log('getBalances disabled temporarily');
     }
-  }, [getBalances, sourceAssets]);
+  }, [sourceAssets]);
 
   // default params
   function setVal(field: FieldPath<FormData>, value: FieldPathValue<FormData, FieldPath<FormData>>) {
@@ -192,7 +192,7 @@ export default function SwapScreen(): JSX.Element {
   useEffect(() => setBlockchainAndAddress(), [session?.address, translate]);
 
   useEffect(() => {
-    if (selectedAddress && selectedAddress.addressLabel === translate('screens/buy', 'Switch address')) {
+    if (selectedAddress && selectedAddress.address === 'Switch address') {
       setShowsSwitchScreen(true);
       setBlockchainAndAddress();
     }
@@ -428,6 +428,14 @@ export default function SwapScreen(): JSX.Element {
       const defaultBlockchain = blockchain ? targetBlockchains.find(b => b === blockchain) || targetBlockchains[0] : targetBlockchains[0];
       if (defaultBlockchain) {
         setVal('blockchain', defaultBlockchain);
+        
+        // Set current address as default
+        const currentAddress = {
+          address: addressLabel(session),
+          label: 'Current address',
+          chain: defaultBlockchain,
+        };
+        setVal('address', currentAddress);
       }
     }
   }
@@ -512,7 +520,6 @@ export default function SwapScreen(): JSX.Element {
                       full
                     />
                   </div>
-
                   <div className="flex-[1_0_9rem]">
                     <StyledSearchDropdown<Asset>
                       rootRef={rootRef}
@@ -524,6 +531,7 @@ export default function SwapScreen(): JSX.Element {
                         return balanceB - balanceA;
                       })}
                       labelFunc={(item) => item.name}
+                      descriptionFunc={(item) => item.blockchain}
                       balanceFunc={findBalanceString}
                       assetIconFunc={(item) => item.name as AssetIconVariant}
                       filterFunc={(item: Asset, search?: string | undefined) =>
@@ -575,12 +583,10 @@ export default function SwapScreen(): JSX.Element {
                 {!hideTargetSelection && (
                   <StyledHorizontalStack gap={1}>
                     <div className="flex-[3_1_9rem] min-w-0">
-                      {/* <AddressSelector control={control} name="address" selectedBlockchain={selectedBlockchain} /> */}
-                      <div>Address: Test Address</div>
+                      <AddressSelector control={control} name="address" selectedBlockchain={selectedBlockchain} />
                     </div>
                     <div className="flex-[1_0_9rem] min-w-0">
-                      {/* <BlockchainSelector control={control} name="blockchain" availableBlockchains={targetBlockchains ?? []} selectedBlockchain={selectedBlockchain} /> */}
-                      <div>Blockchain: {selectedBlockchain || 'None'}</div>
+                      <BlockchainSelector control={control} name="blockchain" availableBlockchains={targetBlockchains ?? []} selectedBlockchain={selectedBlockchain} />
                     </div>
                   </StyledHorizontalStack>
                 )}


### PR DESCRIPTION
- Split combined dropdown into two separate components (BlockchainSelector and AddressSelector)
- Position dropdowns side-by-side with consistent sizing matching existing form fields
- Set current address as default selection to improve user experience
- Prevent payment information display until address is selected
- Maintain consistent layout across buy and order interfaces