### PR TITLE
Fix swap blockchain address selection from URL parameters

### DIFF
--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -217,7 +217,7 @@ export default function SwapScreen(): JSX.Element {
     if (amountIn) setVal('amount', amountIn);
   }, [amountIn]);
 
-  useEffect(() => setAddress(), [session?.address, translate]);
+  useEffect(() => setAddress(), [session?.address, translate, blockchain, addressItems]);
 
   useEffect(() => {
     if (selectedAddress) {
@@ -452,7 +452,7 @@ export default function SwapScreen(): JSX.Element {
   }
 
   function setAddress() {
-    if (session?.address) {
+    if (session?.address && addressItems.length > 0) {
       const address = addressItems.find((a) => blockchain && a.chain === blockchain) ?? addressItems[0];
       setVal('address', address);
     }


### PR DESCRIPTION
## Problem
The deposit blockchain address dropdown was not automatically selecting the correct blockchain when provided via URL parameters.

## Solution
- Add blockchain and addressItems as dependencies to the address update effect to ensure it triggers when these values change
- Add safety check for addressItems length before attempting to set address
- This ensures the deposit blockchain address is correctly set when using the blockchain URL parameter

## Testing
Test with URL: `/swap?asset-in=Sepolia/ETH&asset-out=CitreaTestnet/cBTC&blockchain=CitreaTestnet`
The CitreaTestnet address should be automatically selected in the dropdown.