### PR TITLE
[NO-TASK] Add Bridge Wallet to payment link wallets

### DIFF
--- a/src/config/payment-link-wallets.ts
+++ b/src/config/payment-link-wallets.ts
@@ -37,6 +37,17 @@ export const PaymentLinkWallets: WalletInfo[] = [
     category: WalletCategory.MULTI_CHAIN,
   },
   {
+    id: WalletAppId.BRIDGEWALLET,
+    name: 'Bridge Wallet',
+    websiteUrl: 'https://www.mtpelerin.com/de/bridge-wallet',
+    iconUrl: 'https://dfx.swiss/images/app/BridgeWallet.webp',
+    deepLink: 'bridgewallet:',
+    appStoreUrl: 'https://apps.apple.com/app/bridge-wallet/id1481859680',
+    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.mtpelerin.bridge',
+    recommended: true,
+    category: WalletCategory.MULTI_CHAIN,
+  },
+  {
     id: WalletAppId.FRANKENCOIN,
     name: 'Frankencoin',
     websiteUrl: 'https://frankencoin.app/',

--- a/src/dto/payment-link.dto.ts
+++ b/src/dto/payment-link.dto.ts
@@ -119,6 +119,7 @@ export enum WalletAppId {
   BINANCE = 'binance',
   MUUN = 'muun',
   KUCOINPAY = 'kucoinpay',
+  BRIDGEWALLET = 'bridgewallet',
 }
 
 export interface WalletInfo {


### PR DESCRIPTION
## Summary
- Added Bridge Wallet as a recommended multi-chain wallet
- Positioned next to Cake Wallet in the recommended apps section
- Configured as MULTI_CHAIN category (supports all blockchains including Lightning)

## Changes
- Added `BRIDGEWALLET` to `WalletAppId` enum
- Added Bridge Wallet configuration with app store links and deeplink support
- Set as recommended wallet with multi-chain support

## Note
The Bridge Wallet logo needs to be uploaded to `https://dfx.swiss/images/app/BridgeWallet.webp` (120x120 WebP format).

🤖 Generated with [Claude Code](https://claude.ai/code)