### PR TITLE
[NO-TASK] Add Bridge Wallet to payment link wallets

### DIFF
--- a/src/config/payment-link-wallets.ts
+++ b/src/config/payment-link-wallets.ts
@@ -268,7 +268,7 @@ export const PaymentLinkWallets: WalletInfo[] = [
     id: WalletAppId.BRIDGEWALLET,
     name: 'Bridge Wallet',
     websiteUrl: 'https://www.mtpelerin.com/de/bridge-wallet',
-    iconUrl: 'https://dfx.swiss/images/app/BridgeWallet.webp',
+    iconUrl: 'https://dfx.swiss/images/app/bridge-wallet-icon.webp',
     deepLink: 'bridgewallet:',
     appStoreUrl: 'https://apps.apple.com/app/bridge-wallet/id1481859680',
     playStoreUrl: 'https://play.google.com/store/apps/details?id=com.mtpelerin.bridge',

--- a/src/config/payment-link-wallets.ts
+++ b/src/config/payment-link-wallets.ts
@@ -264,4 +264,15 @@ export const PaymentLinkWallets: WalletInfo[] = [
     category: WalletCategory.C2B,
     deepLink: 'kucoinpay:',
   },
+  {
+    id: WalletAppId.BRIDGEWALLET,
+    name: 'Bridge Wallet',
+    websiteUrl: 'https://www.mtpelerin.com/de/bridge-wallet',
+    iconUrl: 'https://dfx.swiss/images/app/BridgeWallet.webp',
+    deepLink: 'bridgewallet:',
+    appStoreUrl: 'https://apps.apple.com/app/bridge-wallet/id1481859680',
+    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.mtpelerin.bridge',
+    semiCompatible: true,
+    category: WalletCategory.BITCOIN,
+  },
 ];

--- a/src/config/payment-link-wallets.ts
+++ b/src/config/payment-link-wallets.ts
@@ -37,17 +37,6 @@ export const PaymentLinkWallets: WalletInfo[] = [
     category: WalletCategory.MULTI_CHAIN,
   },
   {
-    id: WalletAppId.BRIDGEWALLET,
-    name: 'Bridge Wallet',
-    websiteUrl: 'https://www.mtpelerin.com/de/bridge-wallet',
-    iconUrl: 'https://dfx.swiss/images/app/BridgeWallet.webp',
-    deepLink: 'bridgewallet:',
-    appStoreUrl: 'https://apps.apple.com/app/bridge-wallet/id1481859680',
-    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.mtpelerin.bridge',
-    recommended: true,
-    category: WalletCategory.MULTI_CHAIN,
-  },
-  {
     id: WalletAppId.FRANKENCOIN,
     name: 'Frankencoin',
     websiteUrl: 'https://frankencoin.app/',

--- a/src/config/payment-link-wallets.ts
+++ b/src/config/payment-link-wallets.ts
@@ -37,6 +37,17 @@ export const PaymentLinkWallets: WalletInfo[] = [
     category: WalletCategory.MULTI_CHAIN,
   },
   {
+    id: WalletAppId.BRIDGEWALLET,
+    name: 'Bridge Wallet',
+    websiteUrl: 'https://www.mtpelerin.com/de/bridge-wallet',
+    iconUrl: 'https://dfx.swiss/images/app/BridgeWallet.webp',
+    deepLink: 'bridgewallet:',
+    appStoreUrl: 'https://apps.apple.com/app/bridge-wallet/id1481859680',
+    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.mtpelerin.bridge',
+    recommended: true,
+    category: WalletCategory.MULTI_CHAIN,
+  },
+  {
     id: WalletAppId.FRANKENCOIN,
     name: 'Frankencoin',
     websiteUrl: 'https://frankencoin.app/',

--- a/src/dto/payment-link.dto.ts
+++ b/src/dto/payment-link.dto.ts
@@ -119,6 +119,7 @@ export enum WalletAppId {
   BINANCE = 'binance',
   MUUN = 'muun',
   KUCOINPAY = 'kucoinpay',
+  BRIDGEWALLET = 'bridgewallet',
 }
 
 export interface WalletInfo {

--- a/src/dto/payment-link.dto.ts
+++ b/src/dto/payment-link.dto.ts
@@ -119,7 +119,6 @@ export enum WalletAppId {
   BINANCE = 'binance',
   MUUN = 'muun',
   KUCOINPAY = 'kucoinpay',
-  BRIDGEWALLET = 'bridgewallet',
 }
 
 export interface WalletInfo {


### PR DESCRIPTION
## Summary
- Added Bridge Wallet to semi-compatible wallets section
- Positioned after KuCoin Pay
- Configured as BITCOIN category (supports Bitcoin + Lightning)

## Changes
- Added `BRIDGEWALLET` to `WalletAppId` enum
- Added Bridge Wallet configuration with app store links and deeplink support
- Set as semi-compatible wallet

## Note
The Bridge Wallet logo needs to be uploaded to `https://dfx.swiss/images/app/BridgeWallet.webp` (120x120 WebP format).