### PR TITLE
Add Bridge Wallet to payment link wallets

### DIFF
--- a/src/config/payment-link-wallets.ts
+++ b/src/config/payment-link-wallets.ts
@@ -264,4 +264,15 @@ export const PaymentLinkWallets: WalletInfo[] = [
     category: WalletCategory.C2B,
     deepLink: 'kucoinpay:',
   },
+  {
+    id: WalletAppId.BRIDGEWALLET,
+    name: 'Bridge Wallet',
+    websiteUrl: 'https://www.mtpelerin.com/de/bridge-wallet',
+    iconUrl: 'https://dfx.swiss/images/app/bridge-wallet-icon.webp',
+    deepLink: 'bridgewallet:',
+    appStoreUrl: 'https://apps.apple.com/app/bridge-wallet/id1481859680',
+    playStoreUrl: 'https://play.google.com/store/apps/details?id=com.mtpelerin.bridge',
+    semiCompatible: true,
+    category: WalletCategory.BITCOIN,
+  },
 ];

--- a/src/dto/payment-link.dto.ts
+++ b/src/dto/payment-link.dto.ts
@@ -119,6 +119,7 @@ export enum WalletAppId {
   BINANCE = 'binance',
   MUUN = 'muun',
   KUCOINPAY = 'kucoinpay',
+  BRIDGEWALLET = 'bridgewallet',
 }
 
 export interface WalletInfo {


### PR DESCRIPTION
## Summary
- Add Bridge Wallet as a new payment option
- Configure as semi-compatible Bitcoin category wallet
- Include app store links and deeplink support

## Changes
- Added Bridge Wallet configuration to `payment-link-wallets.ts`
- Added `BRIDGEWALLET` enum value to `WalletAppId` in `payment-link.dto.ts`