### PR TITLE
fix: Fix back button navigation for mail login

### DIFF
--- a/src/screens/home.screen.tsx
+++ b/src/screens/home.screen.tsx
@@ -1,6 +1,6 @@
 import { Blockchain, useAuthContext, useSessionContext, useUserContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { Fragment, Suspense, useEffect, useState } from 'react';
+import { Fragment, Suspense, useEffect, useState, useRef } from 'react';
 import { Trans } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { CustodyAssets } from 'src/components/home/wallet/connect-address';
@@ -80,6 +80,7 @@ function HomeScreenContent(): JSX.Element {
   const [connectTo, setConnectTo] = useState<Wallet>();
   const [loginSuccessful, setLoginSuccessful] = useState(false);
   const [pages, setPages] = useState(new Stack<Page>());
+  const connectToRef = useRef<Wallet>();
 
   const currentPageId = pages.current?.page;
   const allowedTiles = pages.current?.allowedTiles;
@@ -136,6 +137,7 @@ function HomeScreenContent(): JSX.Element {
   function handleNext(tile: Tile) {
     if (isWallet(tile)) {
       const wallet = getWallet(tile, appParams);
+      connectToRef.current = wallet;  // Store in ref
       setConnectTo(wallet);
     } else if (tile.next) {
       if (tile.next.options) setOptions(tile.next.options);
@@ -148,8 +150,12 @@ function HomeScreenContent(): JSX.Element {
   }
 
   function handleBack() {
-    if (connectTo && connectTo.type !== WalletType.ADDRESS) {
+    // Check ref if state is undefined (happens with Mail)
+    const actualConnectTo = connectTo || connectToRef.current;
+
+    if (actualConnectTo && actualConnectTo.type !== WalletType.ADDRESS) {
       setConnectTo(undefined);
+      connectToRef.current = undefined;
     } else if (specialMode === SpecialMode.CONNECT && isLoggedIn) {
       connectTo || !CustodyAssets.includes(appParams.assetOut ?? '')
         ? goBack()

--- a/src/screens/home.screen.tsx
+++ b/src/screens/home.screen.tsx
@@ -1,6 +1,6 @@
 import { Blockchain, useAuthContext, useSessionContext, useUserContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { Fragment, Suspense, useEffect, useState, useRef } from 'react';
+import { Fragment, Suspense, useEffect, useRef, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { CustodyAssets } from 'src/components/home/wallet/connect-address';
@@ -137,7 +137,7 @@ function HomeScreenContent(): JSX.Element {
   function handleNext(tile: Tile) {
     if (isWallet(tile)) {
       const wallet = getWallet(tile, appParams);
-      connectToRef.current = wallet;  // Store in ref
+      connectToRef.current = wallet;
       setConnectTo(wallet);
     } else if (tile.next) {
       if (tile.next.options) setOptions(tile.next.options);
@@ -150,7 +150,6 @@ function HomeScreenContent(): JSX.Element {
   }
 
   function handleBack() {
-    // Check ref if state is undefined (happens with Mail)
     const actualConnectTo = connectTo || connectToRef.current;
 
     if (actualConnectTo && actualConnectTo.type !== WalletType.ADDRESS) {


### PR DESCRIPTION
## Problem

When navigating to the mail login option through the UI (Menu → Login → Mail), the back button in the top navigation bar does not work. Clicking it has no effect and users cannot return to the login selection screen.

### Steps to reproduce:
1. Open the menu (top right)
2. Click "Login"
3. Select "Mail" option
4. Try to click the back button (top left) → Nothing happens

**Note:** The back button works correctly when navigating directly to `/login/mail` URL.

## Root Cause Analysis

The issue occurs due to a state management problem in the `home.screen.tsx` component:

1. When a user clicks on the Mail tile, the `handleNext` function is called, which sets `connectTo` state to `{ type: 'Mail' }`
2. This triggers a re-render and the `ConnectMail` component is displayed
3. However, during the component lifecycle, `connectTo` is immediately reset to `undefined` (likely due to some effect or state synchronization)
4. When the user clicks the back button, `handleBack` is called, but `connectTo` is now `undefined`
5. The function falls through to the page stack logic instead of properly handling the wallet disconnect
6. The page stack manipulation doesn't work correctly for this scenario, leaving the user stuck

### Why it works with direct URL navigation (`/login/mail`):
- Direct URL navigation triggers a different code path through `specialMode === SpecialMode.LOGIN_MAIL`
- This sets up the state differently and maintains the `connectTo` value properly

## Solution

The fix uses a `useRef` to preserve the `connectTo` value even when the state is reset:

1. **Added `connectToRef`**: A ref that persists the wallet selection across re-renders
2. **Store value in ref**: When user selects Mail, we store it in both state AND ref
3. **Use ref as fallback**: In `handleBack`, we check both state and ref to determine if we need to clear the wallet selection

This ensures that even if the state is cleared, we still know that the user selected Mail and can properly navigate back when they click the back button.

## Changes Made

- Import `useRef` from React
- Create `connectToRef` to store the wallet selection
- Update `handleNext` to store the wallet in the ref when selected
- Update `handleBack` to use the ref as a fallback when state is undefined

## Testing

✅ Tested: Menu → Login → Mail → Back button now works correctly
✅ Tested: Direct navigation to `/login/mail` → Back button still works
✅ Tested: Other wallet selections still work as expected