### PR TITLE
feat: add userAddresses support for linked address selection

### DIFF
--- a/src/hooks/address-items.hook.ts
+++ b/src/hooks/address-items.hook.ts
@@ -17,7 +17,7 @@ interface UseAddressItemsParams {
 
 interface UseAddressItemsResult {
   addressItems: AddressItem[];
-  userSessions: (Session | UserAddress)[];
+  availableBlockchains: Blockchain[];
 }
 
 /**
@@ -80,5 +80,5 @@ export function useAddressItems({ availableBlockchains }: UseAddressItemsParams 
     return items;
   }, [userAddressItems, validBlockchains, toString, translate]);
 
-  return { addressItems, userSessions };
+  return { addressItems, availableBlockchains: validBlockchains };
 }

--- a/src/hooks/address-items.hook.ts
+++ b/src/hooks/address-items.hook.ts
@@ -1,0 +1,84 @@
+import { Blockchain, Session, UserAddress, useAuthContext, useUserContext } from '@dfx.swiss/react';
+import { useMemo } from 'react';
+import { addressLabel } from 'src/config/labels';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useBlockchain } from './blockchain.hook';
+
+export interface AddressItem {
+  address?: string;
+  addressLabel: string;
+  label: string;
+  chain?: Blockchain;
+}
+
+interface UseAddressItemsParams {
+  availableBlockchains?: Blockchain[];
+}
+
+interface UseAddressItemsResult {
+  addressItems: AddressItem[];
+  userSessions: (Session | UserAddress)[];
+}
+
+/**
+ * Hook to generate address items for blockchain/address selection.
+ * Supports linked addresses (userAddresses) for cross-chain operations.
+ */
+export function useAddressItems({ availableBlockchains }: UseAddressItemsParams = {}): UseAddressItemsResult {
+  const { session } = useAuthContext();
+  const { userAddresses } = useUserContext();
+  const { translate } = useSettingsContext();
+  const { toString } = useBlockchain();
+
+  // Combine current session with linked addresses, removing duplicates
+  const userSessions = useMemo(() => {
+    return [session, ...userAddresses].filter(
+      (a, i, arr) => a && arr.findIndex((b) => b?.address === a.address) === i,
+    ) as (Session | UserAddress)[];
+  }, [session, userAddresses]);
+
+  // Create address items with their blockchains
+  const userAddressItems = useMemo(() => {
+    return userSessions.map((a) => ({
+      address: a.address,
+      addressLabel: addressLabel(a),
+      blockchains: a.blockchains,
+    }));
+  }, [userSessions]);
+
+  // Filter blockchains based on available blockchains and user's linked addresses
+  const validBlockchains = useMemo(() => {
+    const userBlockchains = userAddressItems.flatMap((a) => a.blockchains).filter((b, i, arr) => arr.indexOf(b) === i);
+
+    return availableBlockchains
+      ? userBlockchains.filter((b) => availableBlockchains.includes(b))
+      : userBlockchains;
+  }, [userAddressItems, availableBlockchains]);
+
+  // Generate address items for dropdown
+  const addressItems: AddressItem[] = useMemo(() => {
+    if (userAddressItems.length === 0 || validBlockchains.length === 0) {
+      return [];
+    }
+
+    const items: AddressItem[] = validBlockchains.flatMap((blockchain) => {
+      const addressesForBlockchain = userAddressItems.filter((a) => a.blockchains.includes(blockchain));
+      return addressesForBlockchain.map((a) => ({
+        address: a.address,
+        addressLabel: a.addressLabel,
+        label: toString(blockchain),
+        chain: blockchain,
+      }));
+    });
+
+    // Add "Switch address" option
+    items.push({
+      addressLabel: translate('screens/buy', 'Switch address'),
+      label: translate('screens/buy', 'Login with a different address'),
+    });
+
+    return items;
+  }, [userAddressItems, validBlockchains, toString, translate]);
+
+  return { addressItems, userSessions };
+}

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -556,9 +556,8 @@ export default function SwapScreen(): JSX.Element {
   }
 
   const rules = Utils.createRules({
-    bankAccount: Validations.Required,
-    asset: Validations.Required,
-    currency: Validations.Required,
+    sourceAsset: Validations.Required,
+    targetAsset: Validations.Required,
     amount: Validations.Required,
   });
 
@@ -652,23 +651,21 @@ export default function SwapScreen(): JSX.Element {
                     />
                   </div>
                   <div className="flex-[1_0_9rem]">
-                    <div className="flex-[1_0_9rem]">
-                      <StyledSearchDropdown<Asset>
-                        rootRef={rootRef}
-                        name="targetAsset"
-                        placeholder={translate('general/actions', 'Select') + '...'}
-                        items={targetAssets}
-                        labelFunc={(item) => item.name}
-                        balanceFunc={findBalanceString}
-                        assetIconFunc={(item) => item.name as AssetIconVariant}
-                        descriptionFunc={(item) => item.description}
-                        filterFunc={(item: Asset, search?: string | undefined) =>
-                          !search || item.name.toLowerCase().includes(search.toLowerCase())
-                        }
-                        hideBalanceWhenClosed
-                        full
-                      />
-                    </div>
+                    <StyledSearchDropdown<Asset>
+                      rootRef={rootRef}
+                      name="targetAsset"
+                      placeholder={translate('general/actions', 'Select') + '...'}
+                      items={targetAssets}
+                      labelFunc={(item) => item.name}
+                      balanceFunc={findBalanceString}
+                      assetIconFunc={(item) => item.name as AssetIconVariant}
+                      descriptionFunc={(item) => item.description}
+                      filterFunc={(item: Asset, search?: string | undefined) =>
+                        !search || item.name.toLowerCase().includes(search.toLowerCase())
+                      }
+                      hideBalanceWhenClosed
+                      full
+                    />
                   </div>
                 </StyledHorizontalStack>
 

--- a/src/screens/swap.screen.tsx
+++ b/src/screens/swap.screen.tsx
@@ -3,12 +3,10 @@ import {
   Asset,
   AssetCategory,
   Blockchain,
-  Session,
   Swap,
   SwapPaymentInfo,
   TransactionError,
   TransactionType,
-  UserAddress,
   Utils,
   Validations,
   useAsset,
@@ -16,7 +14,6 @@ import {
   useAuthContext,
   useSessionContext,
   useSwap,
-  useUserContext,
 } from '@dfx.swiss/react';
 import {
   AssetIconVariant,
@@ -37,7 +34,6 @@ import { useEffect, useState } from 'react';
 import { FieldPath, FieldPathValue, useForm, useWatch } from 'react-hook-form';
 import { PaymentInformationContent } from 'src/components/payment/payment-info-sell';
 import { PrivateAssetHint } from 'src/components/private-asset-hint';
-import { addressLabel } from 'src/config/labels';
 import { Urls } from 'src/config/urls';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { useWindowContext } from 'src/contexts/window.context';
@@ -55,6 +51,7 @@ import { CloseType, useAppHandlingContext } from '../contexts/app-handling.conte
 import { AssetBalance } from '../contexts/balance.context';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useWalletContext } from '../contexts/wallet.context';
+import { AddressItem, useAddressItems } from '../hooks/address-items.hook';
 import { useAppParams } from '../hooks/app-params.hook';
 import { useBlockchain } from '../hooks/blockchain.hook';
 import { useAddressGuard } from '../hooks/guard.hook';
@@ -66,19 +63,12 @@ enum Side {
   GET = 'GET',
 }
 
-interface Address {
-  address?: string;
-  addressLabel: string;
-  label: string;
-  chain?: Blockchain;
-}
-
 interface FormData {
   sourceAsset: Asset;
   targetAsset: Asset;
   amount: string;
   targetAmount: string;
-  address: Address;
+  address: AddressItem;
 }
 
 interface CustomAmountError {
@@ -102,7 +92,6 @@ export default function SwapScreen(): JSX.Element {
   const { logout } = useSessionContext();
   const { session } = useAuthContext();
   const { width } = useWindowContext();
-  const { userAddresses } = useUserContext();
   const { assets, getAssets } = useAssetContext();
   const { getAsset, isSameAsset } = useAsset();
   const { navigate } = useNavigation();
@@ -171,53 +160,20 @@ export default function SwapScreen(): JSX.Element {
   const availableBalance = selectedSourceAsset && findBalance(selectedSourceAsset);
 
   const filteredAssets = assets && filterAssets(Array.from(assets.values()).flat(), assetFilter);
+  const filteredBlockchains = filteredAssets
+    ?.map((a) => a.blockchain)
+    .filter((b, i, arr) => arr.indexOf(b) === i);
 
-  const userSessions = [session, ...userAddresses].filter(
-    (a, i, arr) => a && arr.findIndex((b) => b?.address === a.address) === i,
-  ) as (Session | UserAddress)[];
-
-  const userAddressItems = userSessions.map((a) => ({
-    address: a.address,
-    addressLabel: addressLabel(a),
-    blockchains: a.blockchains,
-  }));
-
-  // Source blockchains: all blockchains from user addresses (including linked addresses like Lightning)
-  const sourceBlockchains = userAddressItems
-    .flatMap((a) => a.blockchains)
-    .filter((b, i, arr) => arr.indexOf(b) === i)
-    .filter((b) => filteredAssets?.some((a) => a.blockchain === b));
-
-  const targetBlockchains = userAddressItems
-    .flatMap((a) => a.blockchains)
-    .filter((b, i, arr) => arr.indexOf(b) === i)
-    .filter((b) => filteredAssets?.some((a) => a.blockchain === b));
-
-  const addressItems: Address[] =
-    userAddressItems.length > 0 && targetBlockchains?.length
-      ? [
-          ...targetBlockchains.flatMap((b) => {
-            const addresses = userAddressItems.filter((a) => a.blockchains.includes(b));
-            return addresses.map((a) => ({
-              address: a.address,
-              addressLabel: a.addressLabel,
-              label: toString(b),
-              chain: b,
-            }));
-          }),
-          {
-            addressLabel: translate('screens/buy', 'Switch address'),
-            label: translate('screens/buy', 'Login with a different address'),
-          },
-        ]
-      : [];
+  const { addressItems, availableBlockchains: swapBlockchains } = useAddressItems({
+    availableBlockchains: filteredBlockchains,
+  });
 
   useEffect(() => {
-    const blockchainSourceAssets = getAssets(sourceBlockchains ?? [], { sellable: true, comingSoon: false });
+    const blockchainSourceAssets = getAssets(swapBlockchains ?? [], { sellable: true, comingSoon: false });
     const activeSourceAssets = filterAssets(blockchainSourceAssets, assetFilter);
     setSourceAssets(activeSourceAssets);
 
-    const activeTargetBlockchains = blockchain ? [blockchain as Blockchain] : (targetBlockchains ?? []);
+    const activeTargetBlockchains = blockchain ? [blockchain as Blockchain] : (swapBlockchains ?? []);
     const blockchainTargetAssets = getAssets(activeTargetBlockchains ?? [], { buyable: true, comingSoon: false });
     const activeTargetAssets = filterAssets(blockchainTargetAssets, assetFilter);
     setTargetAssets(activeTargetAssets);
@@ -237,9 +193,7 @@ export default function SwapScreen(): JSX.Element {
     getAssets,
     blockchain,
     walletBlockchain,
-    sourceBlockchains?.length,
-    targetBlockchains?.length,
-    userAddresses.length,
+    swapBlockchains?.length,
   ]);
 
   useEffect(() => {
@@ -252,11 +206,11 @@ export default function SwapScreen(): JSX.Element {
     }
   }, [amountIn, selectedSourceAsset]);
 
-  useEffect(() => setAddress(), [session?.address, translate, blockchain, userAddresses, addressItems.length]);
+  useEffect(() => setAddress(), [session?.address, translate, blockchain, addressItems.length]);
 
-  // When assetOut is set and userAddresses are loaded, ensure the correct blockchain is selected
+  // When assetOut is set and addresses are loaded, ensure the correct blockchain is selected
   useEffect(() => {
-    if (assetOut && userAddresses.length > 0) {
+    if (assetOut && addressItems.length > 1) {
       const assetOutBlockchain = assetOut.split('/')[0];
       const hasAddressForBlockchain = addressItems.some((a) => a.chain === assetOutBlockchain);
 
@@ -266,7 +220,7 @@ export default function SwapScreen(): JSX.Element {
         switchBlockchain(assetOutBlockchain as Blockchain);
       }
     }
-  }, [assetOut, userAddresses.length, addressItems.length]);
+  }, [assetOut, addressItems.length]);
 
   useEffect(() => {
     if (selectedAddress) {
@@ -670,7 +624,7 @@ export default function SwapScreen(): JSX.Element {
                 </StyledHorizontalStack>
 
                 {!hideTargetSelection && (
-                  <StyledDropdown<Address>
+                  <StyledDropdown<AddressItem>
                     rootRef={rootRef}
                     name="address"
                     items={addressItems}


### PR DESCRIPTION
## Summary
This PR replaces the closed PR #702 with a cleaner implementation that properly supports linked addresses (userAddresses).

### Changes:
- Create `useAddressItems` hook for consistent address handling across all screens
- Update `buy.screen.tsx` to support linked addresses
- Update `sell.screen.tsx` to support linked addresses  
- Fix double div in `swap.screen.tsx`
- Fix incorrect form rules in `swap.screen.tsx` (was validating non-existent fields)

### How it works:
The new `useAddressItems` hook generates address items that include:
- All addresses from linked wallets (userAddresses from useUserContext)
- Current session address
- "Switch address" option for wallet switching

This enables cross-chain operations where users can receive funds on linked addresses (e.g., Lightning via Bitcoin wallet).

### Why this approach vs PR #702:
PR #702 tried to separate blockchain and address selection into two dropdowns, but:
1. The AddressSelector only showed 2 hardcoded options (current address, switch)
2. It didn't support userAddresses/linked addresses
3. Code was duplicated 3x across screens

This PR keeps the single dropdown pattern (which works well) but adds userAddresses support consistently across buy, sell, and swap screens.

## Test plan
- [ ] Test buy flow with linked addresses
- [ ] Test sell flow with linked addresses
- [ ] Test swap flow (already had userAddresses support)
- [ ] Verify "Switch address" option still works
- [ ] Test blockchain switching via address selection