### PR TITLE
feat: add view network button to recommendation panel

### DIFF
--- a/src/components/compliance/recommendation-panel.tsx
+++ b/src/components/compliance/recommendation-panel.tsx
@@ -13,7 +13,15 @@ export function RecommendationPanel({ kycSteps, userDataId, navigate }: Recommen
 
   return (
     <div>
-      <h2 className="text-dfxGray-700 mb-2">Recommendation ({recommendations.length})</h2>
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-dfxGray-700">Recommendation ({recommendations.length})</h2>
+        <button
+          className="text-xs text-dfxBlue-800 hover:underline"
+          onClick={() => navigate(`/compliance/recommendations/${userDataId}`)}
+        >
+          View Network
+        </button>
+      </div>
       <div className="bg-white rounded-lg shadow-sm max-h-[35vh] overflow-auto scroll-shadow">
         {recommendations.length > 0 ? (
           <table className="w-full border-collapse">


### PR DESCRIPTION
## Summary
- Adds a "View Network" button directly in the RecommendationPanel header on the compliance user data page
- Allows navigating to the recommendation network graph even when a user has no outgoing recommendations
- Users who were recommended by others (but have no own recommendations) can now access the network view

## Test plan
- [ ] Navigate to a user with 0 recommendations (e.g. Hans Muster) and verify the "View Network" button is visible
- [ ] Click the button and verify the network graph loads correctly with the user as root node
- [ ] Verify the button also works for users with existing recommendations (e.g. Lisa Weber)