### PR TITLE
feat: add support dashboard UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.3.0-beta.262",
-        "@dfx.swiss/react-components": "^1.3.0-beta.262",
+        "@dfx.swiss/react": "^1.3.0-beta.267",
+        "@dfx.swiss/react-components": "^1.3.0-beta.267",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
         "@ledgerhq/hw-transport-webhid": "^6.27.19",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.3.0-beta.262",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.0-beta.262.tgz",
-      "integrity": "sha512-nZB1wIqOHAsO8M64H/c1EEsvLDDoQcwDUf0j/YVQ+3pw1U2UOE2byxeLpr+lA01TcEkukFkCsFaJJQs6DwLFDQ==",
+      "version": "1.3.0-beta.267",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.0-beta.267.tgz",
+      "integrity": "sha512-ly5OfDkxCiBLv7jFT5Q/VoKSoyfM7Yb4HhKwMHti9RfrYkCK1zZtdBWf5H8oSmo2gS/uBeh98WaF5Ns1fA5G4A==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2645,9 +2645,9 @@
       }
     },
     "node_modules/@dfx.swiss/react-components": {
-      "version": "1.3.0-beta.262",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react-components/-/react-components-1.3.0-beta.262.tgz",
-      "integrity": "sha512-NIZnERt6TwJgxARDVLJ1y1nR+nm2MoQMQqNKkKprRF9VCFb6FIyEmlNeuz5j2ZSzHqrMuVyLO//KIfR3KgAfhg==",
+      "version": "1.3.0-beta.267",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react-components/-/react-components-1.3.0-beta.267.tgz",
+      "integrity": "sha512-FRXOvxPzFpFsleRSq/RGNFRBqKM6+6DKjbTzh7k9yvDEWufoCwzfsGMIfSo40ljAMVuSWyMPTprctXsjFGqUpw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.3.0-beta.262",
-    "@dfx.swiss/react-components": "^1.3.0-beta.262",
+    "@dfx.swiss/react": "^1.3.0-beta.267",
+    "@dfx.swiss/react-components": "^1.3.0-beta.267",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",
     "@ledgerhq/hw-transport-webhid": "^6.27.19",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -393,15 +393,15 @@ export const Routes = [
         element: withSuspense(<ComplianceCompanyOnboardingScreen />),
       },
       {
-        path: 'support-dashboard',
+        path: 'support/dashboard',
         element: withSuspense(<SupportDashboardScreen />),
       },
       {
-        path: 'support-dashboard/issue/:id',
+        path: 'support/dashboard/issue/:id',
         element: withSuspense(<SupportDashboardIssueScreen />),
       },
       {
-        path: 'support-dashboard/create',
+        path: 'support/dashboard/create',
         element: withSuspense(<SupportDashboardCreateScreen />),
       },
       {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,9 @@ const ComplianceSupportIssueScreen = lazy(() => import('./screens/compliance-sup
 const ComplianceRecommendationGraphScreen = lazy(() => import('./screens/compliance-recommendation-graph.screen'));
 const ComplianceCustodyOrdersScreen = lazy(() => import('./screens/compliance-custody-orders.screen'));
 const ComplianceCompanyOnboardingScreen = lazy(() => import('./screens/compliance-company-onboarding.screen'));
+const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
+const SupportDashboardIssueScreen = lazy(() => import('./screens/support-dashboard-issue.screen'));
+const SupportDashboardCreateScreen = lazy(() => import('./screens/support-dashboard-create.screen'));
 const RealunitScreen = lazy(() => import('./screens/realunit.screen'));
 const RealunitHoldersScreen = lazy(() => import('./screens/realunit-holders.screen'));
 const RealunitQuotesScreen = lazy(() => import('./screens/realunit-quotes.screen'));
@@ -383,6 +386,18 @@ export const Routes = [
       {
         path: 'compliance/user/:id/company-onboarding',
         element: withSuspense(<ComplianceCompanyOnboardingScreen />),
+      },
+      {
+        path: 'support-dashboard',
+        element: withSuspense(<SupportDashboardScreen />),
+      },
+      {
+        path: 'support-dashboard/issue/:id',
+        element: withSuspense(<SupportDashboardIssueScreen />),
+      },
+      {
+        path: 'support-dashboard/create',
+        element: withSuspense(<SupportDashboardCreateScreen />),
       },
       {
         path: 'realunit',

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -211,7 +211,7 @@ function NavigationMenu({ setIsNavigationOpen, small = false }: NavigationMenuCo
                 <NavigationLink
                   icon={IconVariant.SUPPORT}
                   label={translate('screens/support', 'Support Dashboard')}
-                  url="/support-dashboard"
+                  url="/support/dashboard"
                   target="_self"
                   onClose={() => setIsNavigationOpen(false)}
                 />

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,4 +1,5 @@
 import { useAuthContext, UserRole, useSessionContext, useUserContext } from '@dfx.swiss/react';
+import { SUPPORT_DASHBOARD_ROLES } from 'src/hooks/guard.hook';
 import {
   DfxIcon,
   IconColor,
@@ -202,6 +203,15 @@ function NavigationMenu({ setIsNavigationOpen, small = false }: NavigationMenuCo
                   icon={IconVariant.COMPLIANCE}
                   label={translate('screens/compliance', 'Compliance')}
                   url="/compliance"
+                  target="_self"
+                  onClose={() => setIsNavigationOpen(false)}
+                />
+              )}
+              {session?.role && SUPPORT_DASHBOARD_ROLES.includes(session.role) && (
+                <NavigationLink
+                  icon={IconVariant.SUPPORT}
+                  label={translate('screens/support', 'Support Dashboard')}
+                  url="/support-dashboard"
                   target="_self"
                   onClose={() => setIsNavigationOpen(false)}
                 />

--- a/src/hooks/guard.hook.ts
+++ b/src/hooks/guard.hook.ts
@@ -23,6 +23,12 @@ export function useComplianceGuard(redirectPath = '/', isActive = true) {
   useUserRoleGuard([UserRole.ADMIN, UserRole.COMPLIANCE], redirectPath, isActive);
 }
 
+export const SUPPORT_DASHBOARD_ROLES = [UserRole.ADMIN, UserRole.COMPLIANCE, UserRole.SUPPORT, UserRole.MARKETING];
+
+export function useSupportDashboardGuard(redirectPath = '/', isActive = true) {
+  useUserRoleGuard(SUPPORT_DASHBOARD_ROLES, redirectPath, isActive);
+}
+
 function useUserRoleGuard(requiresUserRoles: UserRole[], redirectPath = '/', isActive = true) {
   const { isLoggedIn } = useSessionContext();
   const { isInitialized } = useWalletContext();

--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -112,7 +112,7 @@ export function useSupportDashboard() {
     const queryString = queryParts.length ? `?${queryParts.join('&')}` : '';
 
     return call<{ data: SupportIssueListItem[]; total: number }>({
-      url: `support/issue/support/list${queryString}`,
+      url: `support/issue/list${queryString}`,
       method: 'GET',
     });
   }

--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -1,0 +1,209 @@
+import { useApi } from '@dfx.swiss/react';
+import { useMemo } from 'react';
+
+export const CustomerAuthor = 'Customer';
+
+export interface SupportIssueListItem {
+  id: number;
+  uid: string;
+  type: string;
+  reason: string;
+  state: string;
+  name: string;
+  clerk?: string;
+  department?: string;
+  created: string;
+  messageCount: number;
+  lastMessageDate?: string;
+  lastMessageAuthor?: string;
+}
+
+export interface SupportIssueInternalAccountData {
+  id: number;
+  status: string;
+  verifiedName?: string;
+  completeName?: string;
+  accountType?: string;
+  kycLevel: string;
+  depositLimit?: number;
+  annualVolume: number;
+  kycHash: string;
+  country?: { name: string };
+}
+
+export interface SupportIssueInternalTransactionData {
+  id: number;
+  sourceType: string;
+  type: string;
+  amlCheck?: string;
+  amlReason?: string;
+  comment?: string;
+  inputAmount?: number;
+  inputAsset?: string;
+  inputBlockchain?: string;
+  outputAmount?: number;
+  outputAsset?: string;
+  outputBlockchain?: string;
+  wallet?: { name: string; amlRules: string; isKycClient: boolean };
+  isComplete?: boolean;
+}
+
+export interface SupportIssueInternalLimitRequestData {
+  id: number;
+  limit: number;
+  acceptedLimit?: number;
+  investmentDate: string;
+  fundOrigin: string;
+  decision?: string;
+}
+
+export interface SupportIssueInternalTransactionMissingData {
+  senderIban?: string;
+  receiverIban?: string;
+  date?: string;
+}
+
+export interface SupportIssueInternalData {
+  id: number;
+  created: string;
+  uid: string;
+  type: string;
+  department?: string;
+  reason: string;
+  state: string;
+  name: string;
+  clerk?: string;
+  account: SupportIssueInternalAccountData;
+  transaction?: SupportIssueInternalTransactionData;
+  limitRequest?: SupportIssueInternalLimitRequestData;
+  transactionMissing?: SupportIssueInternalTransactionMissingData;
+}
+
+export interface SupportMessageInfo {
+  id: number;
+  author: string;
+  message?: string;
+  fileName?: string;
+  created: string;
+}
+
+export interface UserSearchResult {
+  id: number;
+  kycStatus: string;
+  accountType?: string;
+  mail?: string;
+  name?: string;
+}
+
+export function useSupportDashboard() {
+  const { call } = useApi();
+
+  async function getIssueList(params?: {
+    department?: string;
+    state?: string;
+    type?: string;
+    take?: number;
+    skip?: number;
+    query?: string;
+  }): Promise<{ data: SupportIssueListItem[]; total: number }> {
+    const queryParts = Object.entries(params ?? {})
+      .filter(([, v]) => v != null && v !== '')
+      .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`);
+    const queryString = queryParts.length ? `?${queryParts.join('&')}` : '';
+
+    return call<{ data: SupportIssueListItem[]; total: number }>({
+      url: `support/issue/support/list${queryString}`,
+      method: 'GET',
+    });
+  }
+
+  async function getIssueData(issueId: number): Promise<SupportIssueInternalData> {
+    return call<SupportIssueInternalData>({
+      url: `support/issue/${issueId}/data`,
+      method: 'GET',
+    });
+  }
+
+  async function updateIssue(
+    issueId: number,
+    data: { state?: string; clerk?: string; department?: string },
+  ): Promise<void> {
+    return call<void>({
+      url: `support/issue/${issueId}`,
+      method: 'PUT',
+      data,
+    });
+  }
+
+  async function sendMessage(
+    issueId: number,
+    data: { author: string; message?: string; file?: string; fileName?: string },
+  ): Promise<SupportMessageInfo> {
+    return call<SupportMessageInfo>({
+      url: `support/issue/${issueId}/message`,
+      method: 'POST',
+      data,
+    });
+  }
+
+  async function createIssue(
+    userDataId: number,
+    data: {
+      type: string;
+      reason: string;
+      name: string;
+      department?: string;
+      author: string;
+      message?: string;
+      file?: string;
+      fileName?: string;
+    },
+  ): Promise<void> {
+    return call<void>({
+      url: `support/issue/support?userDataId=${userDataId}`,
+      method: 'POST',
+      data,
+    });
+  }
+
+  async function searchUsers(key: string): Promise<UserSearchResult[]> {
+    const result = await call<{ userDatas: UserSearchResult[] }>({
+      url: `support?key=${encodeURIComponent(key)}`,
+      method: 'GET',
+    });
+    return result.userDatas ?? [];
+  }
+
+  async function getIssueMessages(issueUid: string, fromMessageId?: number): Promise<SupportMessageInfo[]> {
+    const query = fromMessageId ? `?fromMessageId=${fromMessageId}` : '';
+    const result = await call<{ messages: SupportMessageInfo[] }>({
+      url: `support/issue/${issueUid}${query}`,
+      method: 'GET',
+    });
+    return result.messages;
+  }
+
+  async function getMessageFile(
+    issueId: string,
+    messageId: number,
+  ): Promise<{ data: { type: string; data: number[] }; contentType: string }> {
+    return call<{ data: { type: string; data: number[] }; contentType: string }>({
+      url: `support/issue/${issueId}/message/${messageId}/file`,
+      method: 'GET',
+    });
+  }
+
+  return useMemo(
+    () => ({
+      getIssueList,
+      getIssueData,
+      updateIssue,
+      sendMessage,
+      createIssue,
+      getIssueMessages,
+      getMessageFile,
+      searchUsers,
+    }),
+    [call],
+  );
+}

--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -1,7 +1,9 @@
-import { useApi } from '@dfx.swiss/react';
+import { Department, useApi } from '@dfx.swiss/react';
 import { useMemo } from 'react';
 
 export const CustomerAuthor = 'Customer';
+
+export const ASSIGNABLE_DEPARTMENTS: Department[] = [Department.SUPPORT, Department.COMPLIANCE];
 
 export interface SupportIssueListItem {
   id: number;

--- a/src/screens/support-dashboard-create.screen.tsx
+++ b/src/screens/support-dashboard-create.screen.tsx
@@ -11,7 +11,7 @@ import { UserSearchResult, useSupportDashboard } from 'src/hooks/support-dashboa
 
 const ISSUE_TYPES = Object.values(SupportIssueType);
 const ISSUE_REASONS = Object.values(SupportIssueReason);
-const DEPARTMENTS = Object.values(Department);
+const DEPARTMENTS = Object.values(Department).filter((d) => d !== Department.MARKETING);
 
 export default function SupportDashboardCreateScreen(): JSX.Element {
   useSupportDashboardGuard();

--- a/src/screens/support-dashboard-create.screen.tsx
+++ b/src/screens/support-dashboard-create.screen.tsx
@@ -1,0 +1,332 @@
+import { Department, SupportIssueReason, SupportIssueType, useAuthContext, useUserContext } from '@dfx.swiss/react';
+import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toBase64 } from 'src/util/utils';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+import { UserSearchResult, useSupportDashboard } from 'src/hooks/support-dashboard.hook';
+
+const ISSUE_TYPES = Object.values(SupportIssueType);
+const ISSUE_REASONS = Object.values(SupportIssueReason);
+const DEPARTMENTS = Object.values(Department);
+
+export default function SupportDashboardCreateScreen(): JSX.Element {
+  useSupportDashboardGuard();
+
+  const { translate } = useSettingsContext();
+  const { session } = useAuthContext();
+  const { user } = useUserContext();
+  const { createIssue, searchUsers } = useSupportDashboard();
+  const { navigate } = useNavigation();
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+
+  // User search
+  const [searchKey, setSearchKey] = useState('');
+  const [searchResults, setSearchResults] = useState<UserSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showResults, setShowResults] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<UserSearchResult>();
+  const searchRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Form fields
+  const [type, setType] = useState<string>(ISSUE_TYPES[0]);
+  const [reason, setReason] = useState<string>(ISSUE_REASONS[0]);
+  const [name, setName] = useState('');
+  const [department, setDepartment] = useState<string>(DEPARTMENTS[0]);
+  const [message, setMessage] = useState('');
+  const [selectedFile, setSelectedFile] = useState<File>();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useLayoutOptions({ title: translate('screens/support', 'Create Support Issue'), backButton: true, noMaxWidth: true });
+
+  const doSearch = useCallback(
+    (key: string): void => {
+      if (key.length < 2) {
+        setSearchResults([]);
+        setShowResults(false);
+        return;
+      }
+      setIsSearching(true);
+      searchUsers(key)
+        .then((results) => {
+          setSearchResults(results);
+          setShowResults(true);
+        })
+        .catch(() => {
+          setSearchResults([]);
+          setShowResults(true);
+        })
+        .finally(() => setIsSearching(false));
+    },
+    [searchUsers],
+  );
+
+  function handleSearchInput(value: string): void {
+    setSearchKey(value);
+    setSelectedUser(undefined);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => doSearch(value), 400);
+  }
+
+  function handleSelectUser(user: UserSearchResult): void {
+    setSelectedUser(user);
+    setSearchKey(user.name ? `${user.name} (${user.id})` : String(user.id));
+    setShowResults(false);
+  }
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent): void {
+      if (searchRef.current && !searchRef.current.contains(e.target as Node)) {
+        setShowResults(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+
+    if (!selectedUser) {
+      setError('Please select a customer');
+      return;
+    }
+    if (!name.trim() || !message.trim()) {
+      setError('Please fill all required fields');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(undefined);
+
+    try {
+      const author = user?.mail ?? session?.address ?? 'Support';
+      const fileData = selectedFile ? await toBase64(selectedFile) : undefined;
+      await createIssue(selectedUser.id, {
+        type,
+        reason,
+        name: name.trim(),
+        department,
+        author,
+        message: message.trim(),
+        file: fileData ?? undefined,
+        fileName: selectedFile?.name,
+      });
+      navigate('/support-dashboard');
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to create issue');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="w-full flex flex-col gap-4 max-w-2xl text-left">
+      {error && <ErrorHint message={error} />}
+
+      <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm p-6 flex flex-col gap-4">
+        {/* User Search */}
+        <FormField label="Customer *">
+          <div ref={searchRef} className="relative">
+            <input
+              type="text"
+              className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+              value={searchKey}
+              onChange={(e) => handleSearchInput(e.target.value)}
+              onFocus={() => searchResults.length > 0 && setShowResults(true)}
+              placeholder="Search by name, email, ID, IBAN..."
+            />
+            {isSearching && (
+              <div className="absolute right-3 top-2.5">
+                <StyledLoadingSpinner size={SpinnerSize.SM} />
+              </div>
+            )}
+
+            {/* Selected user info */}
+            {selectedUser && (
+              <div className="mt-2 px-3 py-2 bg-dfxGray-300 rounded text-xs text-dfxBlue-800 flex justify-between items-center">
+                <div>
+                  <span className="font-medium">{selectedUser.name || 'No name'}</span>
+                  <span className="text-dfxGray-700 ml-2">ID: {selectedUser.id}</span>
+                  {selectedUser.mail && <span className="text-dfxGray-700 ml-2">{selectedUser.mail}</span>}
+                  <span className="text-dfxGray-700 ml-2">KYC: {selectedUser.kycStatus}</span>
+                </div>
+                <button
+                  type="button"
+                  className="text-dfxGray-700 hover:text-dfxBlue-800"
+                  onClick={() => {
+                    setSelectedUser(undefined);
+                    setSearchKey('');
+                    setSearchResults([]);
+                  }}
+                >
+                  x
+                </button>
+              </div>
+            )}
+
+            {/* Search results dropdown */}
+            {showResults && !selectedUser && (
+              <div className="absolute z-10 w-full mt-1 bg-white border border-dfxGray-400 rounded shadow-lg max-h-[200px] overflow-auto">
+                {searchResults.length === 0 ? (
+                  <div className="px-3 py-2 text-xs text-dfxGray-700">No users found</div>
+                ) : (
+                  searchResults.map((user) => (
+                    <button
+                      key={user.id}
+                      type="button"
+                      className="w-full px-3 py-2 text-left text-xs text-dfxBlue-800 hover:bg-dfxGray-300 transition-colors flex justify-between items-center"
+                      onClick={() => handleSelectUser(user)}
+                    >
+                      <div>
+                        <span className="font-medium">{user.name || 'No name'}</span>
+                        {user.mail && <span className="text-dfxGray-700 ml-2">{user.mail}</span>}
+                      </div>
+                      <div className="text-dfxGray-700 flex gap-2">
+                        <span>ID: {user.id}</span>
+                        <span>{user.kycStatus}</span>
+                        {user.accountType && <span>{user.accountType}</span>}
+                      </div>
+                    </button>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+        </FormField>
+
+        <FormField label="Type *">
+          <select
+            className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+          >
+            {ISSUE_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <FormField label="Reason *">
+          <select
+            className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+          >
+            {ISSUE_REASONS.map((r) => (
+              <option key={r} value={r}>
+                {r}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <FormField label="Issue Title *">
+          <input
+            type="text"
+            className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Issue title"
+            required
+          />
+        </FormField>
+
+        <FormField label="Department">
+          <select
+            className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={department}
+            onChange={(e) => setDepartment(e.target.value)}
+          >
+            {DEPARTMENTS.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <FormField label="Message *">
+          <textarea
+            className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-h-[100px]"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Describe the issue..."
+            required
+            maxLength={4000}
+          />
+          <div className="text-xs text-dfxGray-700 text-right">{message.length}/4000</div>
+        </FormField>
+
+        <FormField label="File">
+          <div className="flex items-center gap-3">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".pdf,.jpeg,.jpg,.png"
+              className="hidden"
+              onChange={(e) => setSelectedFile(e.target.files?.[0])}
+            />
+            <button
+              type="button"
+              className="px-3 py-1.5 text-xs border border-dfxGray-400 rounded text-dfxBlue-800 hover:bg-dfxGray-300 transition-colors"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              Choose file
+            </button>
+            {selectedFile && (
+              <div className="flex items-center gap-2 text-xs text-dfxBlue-800">
+                <span>{selectedFile.name}</span>
+                <button
+                  type="button"
+                  className="text-dfxGray-700 hover:text-dfxBlue-800"
+                  onClick={() => {
+                    setSelectedFile(undefined);
+                    if (fileInputRef.current) fileInputRef.current.value = '';
+                  }}
+                >
+                  x
+                </button>
+              </div>
+            )}
+          </div>
+        </FormField>
+
+        <div className="flex justify-end gap-3 mt-2">
+          <button
+            type="button"
+            className="px-4 py-2 text-sm text-dfxGray-700 hover:text-dfxBlue-800 transition-colors"
+            onClick={() => navigate('/support-dashboard')}
+          >
+            {translate('general/actions', 'Cancel')}
+          </button>
+          <button
+            type="submit"
+            className="px-6 py-2 bg-dfxBlue-400 text-white rounded text-sm hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
+            disabled={isSubmitting || !selectedUser}
+          >
+            {isSubmitting ? <StyledLoadingSpinner size={SpinnerSize.SM} /> : translate('general/actions', 'Create')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function FormField({ label, children }: { label: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm font-medium text-dfxBlue-800">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/src/screens/support-dashboard-create.screen.tsx
+++ b/src/screens/support-dashboard-create.screen.tsx
@@ -1,4 +1,4 @@
-import { Department, SupportIssueReason, SupportIssueType, useAuthContext, useUserContext } from '@dfx.swiss/react';
+import { SupportIssueReason, SupportIssueType, useAuthContext, useUserContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toBase64 } from 'src/util/utils';
@@ -7,11 +7,10 @@ import { useSettingsContext } from 'src/contexts/settings.context';
 import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
-import { UserSearchResult, useSupportDashboard } from 'src/hooks/support-dashboard.hook';
+import { ASSIGNABLE_DEPARTMENTS, UserSearchResult, useSupportDashboard } from 'src/hooks/support-dashboard.hook';
 
 const ISSUE_TYPES = Object.values(SupportIssueType);
 const ISSUE_REASONS = Object.values(SupportIssueReason);
-const DEPARTMENTS = Object.values(Department).filter((d) => d !== Department.MARKETING);
 
 export default function SupportDashboardCreateScreen(): JSX.Element {
   useSupportDashboardGuard();
@@ -38,7 +37,7 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
   const [type, setType] = useState<string>(ISSUE_TYPES[0]);
   const [reason, setReason] = useState<string>(ISSUE_REASONS[0]);
   const [name, setName] = useState('');
-  const [department, setDepartment] = useState<string>(DEPARTMENTS[0]);
+  const [department, setDepartment] = useState<string>(ASSIGNABLE_DEPARTMENTS[0]);
   const [message, setMessage] = useState('');
   const [selectedFile, setSelectedFile] = useState<File>();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -247,7 +246,7 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
             value={department}
             onChange={(e) => setDepartment(e.target.value)}
           >
-            {DEPARTMENTS.map((d) => (
+            {ASSIGNABLE_DEPARTMENTS.map((d) => (
               <option key={d} value={d}>
                 {d}
               </option>

--- a/src/screens/support-dashboard-create.screen.tsx
+++ b/src/screens/support-dashboard-create.screen.tsx
@@ -119,7 +119,7 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
         file: fileData ?? undefined,
         fileName: selectedFile?.name,
       });
-      navigate('/support-dashboard');
+      navigate('/support/dashboard');
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Failed to create issue');
     } finally {
@@ -305,7 +305,7 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
           <button
             type="button"
             className="px-4 py-2 text-sm text-dfxGray-700 hover:text-dfxBlue-800 transition-colors"
-            onClick={() => navigate('/support-dashboard')}
+            onClick={() => navigate('/support/dashboard')}
           >
             {translate('general/actions', 'Cancel')}
           </button>

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -335,11 +335,13 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
                 onChange={(e) => setUpdateDepartment(e.target.value)}
               >
                 <option value="">-</option>
-                {Object.values(Department).map((d) => (
-                  <option key={d} value={d}>
-                    {d}
-                  </option>
-                ))}
+                {Object.values(Department)
+                  .filter((d) => d !== Department.MARKETING)
+                  .map((d) => (
+                    <option key={d} value={d}>
+                      {d}
+                    </option>
+                  ))}
               </select>
             </div>
             <div className="flex flex-col gap-1">

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -1,0 +1,507 @@
+import { Department, SupportIssueInternalState, useAuthContext, useUserContext } from '@dfx.swiss/react';
+import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toBase64 } from 'src/util/utils';
+import { useParams } from 'react-router-dom';
+import { FilePreviewPanel } from 'src/components/compliance/file-preview-panel';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+import {
+  CustomerAuthor,
+  SupportIssueInternalData,
+  SupportMessageInfo,
+  useSupportDashboard,
+} from 'src/hooks/support-dashboard.hook';
+import { formatDateTime, statusBadge } from 'src/util/compliance-helpers';
+
+export default function SupportDashboardIssueScreen(): JSX.Element {
+  useSupportDashboardGuard();
+
+  const { id } = useParams();
+  const { translate } = useSettingsContext();
+  const { session } = useAuthContext();
+  const { user } = useUserContext();
+  const { getIssueData, updateIssue, sendMessage, getIssueMessages, getMessageFile } = useSupportDashboard();
+  const { navigate } = useNavigation();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string>();
+  const [actionError, setActionError] = useState<string>();
+  const [issueData, setIssueData] = useState<SupportIssueInternalData>();
+  const [messages, setMessages] = useState<SupportMessageInfo[]>([]);
+
+  // Update form state
+  const [updateState, setUpdateState] = useState('');
+  const [updateDepartment, setUpdateDepartment] = useState('');
+  const [updateClerk, setUpdateClerk] = useState('');
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  // Message form state
+  const [messageText, setMessageText] = useState('');
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [isSending, setIsSending] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // File preview state
+  const [filePreview, setFilePreview] = useState<{ url: string; contentType: string; name: string }>();
+  const [splitPercent, setSplitPercent] = useState(66);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const isComplianceDept = issueData?.department === Department.COMPLIANCE;
+
+  useLayoutOptions({ title: translate('screens/support', 'Support Issue'), backButton: true, noMaxWidth: true });
+
+  const loadIssue = useCallback((): void => {
+    if (!id) return;
+    setIsLoading(true);
+    getIssueData(+id)
+      .then((data) => {
+        setIssueData(data);
+        setUpdateState(data.state);
+        setUpdateDepartment(data.department ?? '');
+        setUpdateClerk(data.clerk ?? '');
+      })
+      .catch((e: Error) => setLoadError(e.message ?? 'Unknown error'))
+      .finally(() => setIsLoading(false));
+  }, [id, getIssueData]);
+
+  const loadMessages = useCallback((): void => {
+    if (!issueData?.uid) return;
+    getIssueMessages(issueData.uid)
+      .then(setMessages)
+      .catch((e: Error) => setActionError(e.message ?? 'Failed to load messages'));
+  }, [issueData?.uid, getIssueMessages]);
+
+  useEffect(() => {
+    loadIssue();
+  }, [loadIssue]);
+
+  useEffect(() => {
+    loadMessages();
+  }, [loadMessages]);
+
+  // Polling for new messages
+  useEffect(() => {
+    const interval = setInterval(loadMessages, 15000);
+    return () => clearInterval(interval);
+  }, [loadMessages]);
+
+  // Scroll to bottom when new messages arrive
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  async function handleUpdate(): Promise<void> {
+    if (!id) return;
+    setIsUpdating(true);
+    setActionError(undefined);
+    try {
+      await updateIssue(+id, {
+        state: updateState || undefined,
+        department: updateDepartment || undefined,
+        clerk: updateClerk || undefined,
+      });
+      loadIssue();
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Update failed');
+    } finally {
+      setIsUpdating(false);
+    }
+  }
+
+  async function handleSendMessage(): Promise<void> {
+    if (!id || (!messageText.trim() && selectedFiles.length === 0)) return;
+    setIsSending(true);
+    setActionError(undefined);
+    try {
+      const author = user?.mail ?? session?.address ?? 'Support';
+      const text = messageText.trim() || undefined;
+
+      if (selectedFiles.length > 0) {
+        for (let i = 0; i < selectedFiles.length; i++) {
+          const fileData = await toBase64(selectedFiles[i]);
+          const isLast = i === selectedFiles.length - 1;
+          await sendMessage(+id, {
+            author,
+            message: isLast ? text : undefined,
+            file: fileData,
+            fileName: selectedFiles[i].name,
+          });
+        }
+      } else {
+        await sendMessage(+id, { author, message: text });
+      }
+
+      setMessageText('');
+      setSelectedFiles([]);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      loadMessages();
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Send failed');
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  async function openFile(msg: SupportMessageInfo): Promise<void> {
+    if (!issueData?.uid || !msg.fileName) return;
+    try {
+      const { data, contentType } = await getMessageFile(issueData.uid, msg.id);
+      if (!data || data.type !== 'Buffer' || !Array.isArray(data.data)) {
+        setActionError('Invalid file type');
+        return;
+      }
+      if (filePreview) URL.revokeObjectURL(filePreview.url);
+      const blob = new Blob([new Uint8Array(data.data)], { type: contentType });
+      const url = URL.createObjectURL(blob);
+      setFilePreview({ url, contentType, name: msg.fileName });
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Error loading file');
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (filePreview) URL.revokeObjectURL(filePreview.url);
+    };
+  }, [filePreview]);
+
+  if (loadError) return <ErrorHint message={loadError} />;
+  if (isLoading || !issueData) return <StyledLoadingSpinner size={SpinnerSize.LG} />;
+
+  function handleSplitDrag(e: React.MouseEvent): void {
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+
+    const onMouseMove = (moveEvent: MouseEvent): void => {
+      const rect = container.getBoundingClientRect();
+      const percent = ((moveEvent.clientX - rect.left) / rect.width) * 100;
+      setSplitPercent(Math.min(80, Math.max(30, percent)));
+    };
+
+    const onMouseUp = (): void => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }
+
+  return (
+    <div ref={containerRef} className="w-full flex text-left">
+      <div style={{ width: `${splitPercent}%` }} className="flex flex-col gap-6 min-w-0 pr-2">
+        {actionError && <ErrorHint message={actionError} />}
+        {/* Info Panels - Row 1: Issue + Account */}
+        <div className="flex gap-4 flex-wrap">
+          <InfoPanel title="Issue Details">
+            <InfoRow label="UID" value={issueData.uid} mono />
+            <InfoRow label="Name" value={issueData.name} />
+            <InfoRow label="Type" value={issueData.type} />
+            <InfoRow label="Reason" value={issueData.reason} />
+            <InfoRow label="State" value={statusBadge(issueData.state)} />
+            <InfoRow label="Department" value={issueData.department ?? '-'} />
+            <InfoRow label="Created" value={formatDateTime(issueData.created)} />
+          </InfoPanel>
+
+          <InfoPanel title="Account Data">
+            <InfoRow label="UserData ID" value={String(issueData.account.id)} />
+            <InfoRow label="Status" value={statusBadge(issueData.account.status)} />
+            <InfoRow label="Verified Name" value={issueData.account.verifiedName ?? '-'} />
+            <InfoRow label="DFX Name" value={issueData.account.completeName ?? '-'} />
+            <InfoRow label="Account Type" value={issueData.account.accountType ?? '-'} />
+            <InfoRow label="KYC Level" value={String(issueData.account.kycLevel)} />
+            <InfoRow
+              label="Deposit Limit"
+              value={
+                issueData.account.depositLimit != null ? `${issueData.account.depositLimit.toLocaleString()} CHF` : '-'
+              }
+            />
+            <InfoRow label="Annual Volume" value={`${issueData.account.annualVolume.toLocaleString()} CHF`} />
+            <InfoRow label="KYC Hash" value={issueData.account.kycHash} mono />
+            <InfoRow label="Country" value={issueData.account.country?.name ?? '-'} />
+            {isComplianceDept && (
+              <tr>
+                <td className="pr-4 py-1 font-medium whitespace-nowrap text-sm">Compliance:</td>
+                <td className="py-1">
+                  <button
+                    className="text-xs text-dfxBlue-400 underline hover:text-dfxBlue-800"
+                    onClick={() => navigate(`/compliance/user/${issueData.account.id}`)}
+                  >
+                    Open User
+                  </button>
+                </td>
+              </tr>
+            )}
+          </InfoPanel>
+        </div>
+
+        {/* Info Panels - Row 2: Transaction + Missing + Limit */}
+        {(issueData.transaction || issueData.transactionMissing || issueData.limitRequest) && (
+          <div className="flex gap-4 flex-wrap">
+            {issueData.transaction && (
+              <InfoPanel title="Transaction">
+                <InfoRow label="ID" value={String(issueData.transaction.id)} />
+                <InfoRow label="Source Type" value={issueData.transaction.sourceType} />
+                <InfoRow label="Type" value={issueData.transaction.type} />
+                {issueData.transaction.amlCheck && (
+                  <InfoRow label="AML Check" value={statusBadge(issueData.transaction.amlCheck)} />
+                )}
+                {issueData.transaction.amlReason && (
+                  <InfoRow label="AML Reason" value={issueData.transaction.amlReason} />
+                )}
+                {issueData.transaction.comment && <InfoRow label="Comment" value={issueData.transaction.comment} />}
+                {issueData.transaction.inputAmount != null && (
+                  <InfoRow
+                    label="Input"
+                    value={`${issueData.transaction.inputAmount} ${issueData.transaction.inputAsset ?? ''}`}
+                  />
+                )}
+                {issueData.transaction.outputAmount != null && (
+                  <InfoRow
+                    label="Output"
+                    value={`${issueData.transaction.outputAmount} ${issueData.transaction.outputAsset ?? ''}`}
+                  />
+                )}
+                {issueData.transaction.wallet && <InfoRow label="Wallet" value={issueData.transaction.wallet.name} />}
+                {issueData.transaction.isComplete != null && (
+                  <InfoRow label="Complete" value={issueData.transaction.isComplete ? 'Yes' : 'No'} />
+                )}
+              </InfoPanel>
+            )}
+
+            {issueData.transactionMissing && (
+              <InfoPanel title="Transaction Missing">
+                {issueData.transactionMissing.senderIban && (
+                  <InfoRow label="Sender IBAN" value={issueData.transactionMissing.senderIban} mono />
+                )}
+                {issueData.transactionMissing.receiverIban && (
+                  <InfoRow label="Receiver IBAN" value={issueData.transactionMissing.receiverIban} mono />
+                )}
+                {issueData.transactionMissing.date && (
+                  <InfoRow label="Date" value={formatDateTime(issueData.transactionMissing.date)} />
+                )}
+              </InfoPanel>
+            )}
+
+            {issueData.limitRequest && (
+              <InfoPanel title="Limit Request">
+                <InfoRow label="Requested" value={`${issueData.limitRequest.limit.toLocaleString()} CHF`} />
+                {issueData.limitRequest.acceptedLimit != null && (
+                  <InfoRow label="Accepted" value={`${issueData.limitRequest.acceptedLimit.toLocaleString()} CHF`} />
+                )}
+                <InfoRow label="Fund Origin" value={issueData.limitRequest.fundOrigin} />
+                <InfoRow label="Investment Date" value={issueData.limitRequest.investmentDate} />
+                {issueData.limitRequest.decision && (
+                  <InfoRow label="Decision" value={statusBadge(issueData.limitRequest.decision)} />
+                )}
+              </InfoPanel>
+            )}
+          </div>
+        )}
+
+        {/* Update Controls */}
+        <div className="bg-white rounded-lg shadow-sm p-4">
+          <h2 className="text-dfxGray-700 mb-3">Update Issue</h2>
+          <div className="flex gap-3 flex-wrap items-end">
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-dfxGray-700">State</label>
+              <select
+                className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+                value={updateState}
+                onChange={(e) => setUpdateState(e.target.value)}
+              >
+                {Object.values(SupportIssueInternalState).map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-dfxGray-700">Department</label>
+              <select
+                className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+                value={updateDepartment}
+                onChange={(e) => setUpdateDepartment(e.target.value)}
+              >
+                <option value="">-</option>
+                {Object.values(Department).map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-xs text-dfxGray-700">Clerk</label>
+              <input
+                className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+                value={updateClerk}
+                onChange={(e) => setUpdateClerk(e.target.value)}
+                placeholder="Clerk name"
+              />
+            </div>
+            <button
+              className="px-4 py-1.5 bg-dfxBlue-400 text-white rounded text-xs hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
+              onClick={handleUpdate}
+              disabled={isUpdating}
+            >
+              {isUpdating ? 'Updating...' : 'Update'}
+            </button>
+          </div>
+        </div>
+
+        {/* Messages / Chat */}
+        <div className="bg-white rounded-lg shadow-sm p-4">
+          <h2 className="text-dfxGray-700 mb-3">Messages ({messages.length})</h2>
+          <div className="flex flex-col gap-2 max-h-[40vh] overflow-auto mb-4 p-2">
+            {[...messages]
+              .sort((a, b) => a.id - b.id)
+              .map((msg) => {
+                const isCustomer = msg.author === CustomerAuthor;
+                return (
+                  <div key={msg.id} className={`flex ${isCustomer ? 'justify-start' : 'justify-end'}`}>
+                    <div
+                      className={`max-w-[70%] rounded-lg p-3 ${
+                        isCustomer
+                          ? 'bg-dfxGray-300 text-dfxBlue-800'
+                          : 'bg-dfxBlue-800/10 text-dfxBlue-800 border border-dfxBlue-800/20'
+                      }`}
+                    >
+                      <div className="flex justify-between items-center gap-4 mb-1">
+                        <span className="text-xs font-medium">{msg.author}</span>
+                        <span className="text-xs opacity-70">{formatDateTime(msg.created)}</span>
+                      </div>
+                      <div className="text-sm">{msg.message || '-'}</div>
+                      {msg.fileName && (
+                        <button
+                          className="text-xs mt-1 text-dfxBlue-400 underline hover:text-dfxBlue-800"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openFile(msg);
+                          }}
+                        >
+                          {msg.fileName}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {/* Message Input */}
+          {selectedFiles.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {selectedFiles.map((file, i) => (
+                <div
+                  key={i}
+                  className="flex items-center gap-1 px-2 py-1 bg-dfxGray-300 rounded text-xs text-dfxBlue-800"
+                >
+                  <span className="truncate max-w-[150px]">{file.name}</span>
+                  <button
+                    className="text-dfxGray-700 hover:text-dfxRed-100"
+                    onClick={() => {
+                      setSelectedFiles((prev) => prev.filter((_, idx) => idx !== i));
+                      if (fileInputRef.current) fileInputRef.current.value = '';
+                    }}
+                  >
+                    &times;
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <input
+              type="file"
+              multiple
+              ref={fileInputRef}
+              className="hidden"
+              onChange={(e) => setSelectedFiles((prev) => [...prev, ...Array.from(e.target.files ?? [])])}
+            />
+            <button
+              className="px-2 py-2 text-dfxGray-700 hover:text-dfxBlue-800 transition-colors"
+              onClick={() => fileInputRef.current?.click()}
+              title="Attach file"
+            >
+              &#128206;
+            </button>
+            <input
+              className="flex-1 px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+              value={messageText}
+              onChange={(e) => setMessageText(e.target.value)}
+              placeholder="Type a message..."
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSendMessage();
+                }
+              }}
+            />
+            <button
+              className="px-4 py-2 bg-dfxBlue-400 text-white rounded text-sm hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
+              onClick={handleSendMessage}
+              disabled={isSending || (!messageText.trim() && selectedFiles.length === 0)}
+            >
+              {isSending ? '...' : 'Send'}
+            </button>
+          </div>
+          <div className="text-xs text-dfxGray-700 mt-1">
+            Customer will be notified by email when you send a message.
+          </div>
+        </div>
+      </div>
+
+      {/* Draggable Splitter */}
+      <div className="w-1.5 cursor-col-resize flex-shrink-0 group flex items-stretch" onMouseDown={handleSplitDrag}>
+        <div className="w-0.5 mx-auto bg-dfxGray-400 group-hover:bg-dfxBlue-400 transition-colors rounded-full" />
+      </div>
+
+      {/* File Preview - always visible, sticky right */}
+      <div style={{ width: `${100 - splitPercent}%` }} className="min-w-0 sticky top-4 self-start pl-2">
+        <FilePreviewPanel
+          preview={filePreview}
+          label="File Preview"
+          onClose={() => {
+            if (filePreview) URL.revokeObjectURL(filePreview.url);
+            setFilePreview(undefined);
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// --- Sub-components ---
+
+function InfoPanel({ title, children }: { title: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-4 flex-1 min-w-[250px]">
+      <h2 className="text-dfxGray-700 mb-3">{title}</h2>
+      <table className="text-sm text-dfxBlue-800 text-left">
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+function InfoRow({ label, value, mono }: { label: string; value: string | JSX.Element; mono?: boolean }): JSX.Element {
+  return (
+    <tr>
+      <td className="pr-4 py-1 font-medium whitespace-nowrap text-sm">{label}:</td>
+      <td className={`py-1 text-sm break-all ${mono ? 'font-mono' : ''}`}>{value}</td>
+    </tr>
+  );
+}

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -10,6 +10,7 @@ import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import {
+  ASSIGNABLE_DEPARTMENTS,
   CustomerAuthor,
   SupportIssueInternalData,
   SupportMessageInfo,
@@ -335,13 +336,11 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
                 onChange={(e) => setUpdateDepartment(e.target.value)}
               >
                 <option value="">-</option>
-                {Object.values(Department)
-                  .filter((d) => d !== Department.MARKETING)
-                  .map((d) => (
-                    <option key={d} value={d}>
-                      {d}
-                    </option>
-                  ))}
+                {ASSIGNABLE_DEPARTMENTS.map((d) => (
+                  <option key={d} value={d}>
+                    {d}
+                  </option>
+                ))}
               </select>
             </div>
             <div className="flex flex-col gap-1">

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -180,7 +180,7 @@ export default function SupportDashboardScreen(): JSX.Element {
         <div className="flex gap-2 ml-auto">
           <button
             className="px-4 py-2 bg-dfxBlue-400 text-white rounded-lg text-sm hover:bg-dfxBlue-800 transition-colors"
-            onClick={() => navigate('/support-dashboard/create')}
+            onClick={() => navigate('/support/dashboard/create')}
           >
             + {translate('screens/support', 'Create Issue')}
           </button>
@@ -257,14 +257,14 @@ export default function SupportDashboardScreen(): JSX.Element {
         <GroupedIssueTable
           groups={openIssueGroups}
           showDepartment={isAdmin}
-          onRowClick={(issue) => navigate(`/support-dashboard/issue/${issue.id}`)}
+          onRowClick={(issue) => navigate(`/support/dashboard/issue/${issue.id}`)}
         />
       ) : (
         <>
           <IssueTable
             issues={displayedIssues}
             showDepartment={isAdmin}
-            onRowClick={(issue) => navigate(`/support-dashboard/issue/${issue.id}`)}
+            onRowClick={(issue) => navigate(`/support/dashboard/issue/${issue.id}`)}
           />
           {hasMore && (
             <button

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -1,0 +1,483 @@
+import { Department, SupportIssueInternalState, SupportIssueType, useAuthContext, UserRole } from '@dfx.swiss/react';
+import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+import { CustomerAuthor, SupportIssueListItem, useSupportDashboard } from 'src/hooks/support-dashboard.hook';
+import { formatDateTime, statusBadge } from 'src/util/compliance-helpers';
+
+type Tab = 'open' | 'canceled' | 'completed';
+
+const OPEN_STATES = [
+  SupportIssueInternalState.CREATED,
+  SupportIssueInternalState.PENDING,
+  SupportIssueInternalState.ON_HOLD,
+];
+const PAGE_SIZE = 20;
+
+export default function SupportDashboardScreen(): JSX.Element {
+  useSupportDashboardGuard();
+
+  const { translate } = useSettingsContext();
+  const { session } = useAuthContext();
+  const { getIssueList } = useSupportDashboard();
+  const { navigate } = useNavigation();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [openIssuesRaw, setOpenIssuesRaw] = useState<SupportIssueListItem[]>([]);
+  const [activeTab, setActiveTab] = useState<Tab>('open');
+
+  // Filters (only apply to Open tab)
+  const [typeFilter, setTypeFilter] = useState<string>('');
+  const [stateFilter, setStateFilter] = useState<string>('');
+  const [departmentFilter, setDepartmentFilter] = useState<string>('');
+
+  // Canceled/Completed paging state
+  const [canceledIssues, setCanceledIssues] = useState<SupportIssueListItem[]>([]);
+  const [canceledTotal, setCanceledTotal] = useState(0);
+  const [canceledLoaded, setCanceledLoaded] = useState(false);
+  const [canceledLoading, setCanceledLoading] = useState(false);
+
+  const [completedIssues, setCompletedIssues] = useState<SupportIssueListItem[]>([]);
+  const [completedTotal, setCompletedTotal] = useState(0);
+  const [completedLoaded, setCompletedLoaded] = useState(false);
+  const [completedLoading, setCompletedLoading] = useState(false);
+
+  // Search (server-side for canceled/completed)
+  const [searchQuery, setSearchQuery] = useState('');
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const isAdmin = session?.role === UserRole.ADMIN;
+
+  // Load open issues (all, no paging)
+  const loadOpenIssues = useCallback((): void => {
+    setIsLoading(true);
+    setError(undefined);
+
+    const params: Record<string, string> = {};
+    if (typeFilter) params.type = typeFilter;
+    if (departmentFilter) params.department = departmentFilter;
+
+    getIssueList(params)
+      .then((res) => setOpenIssuesRaw(res.data))
+      .catch((e: Error) => setError(e.message ?? 'Unknown error'))
+      .finally(() => setIsLoading(false));
+  }, [typeFilter, departmentFilter, getIssueList]);
+
+  useEffect(() => {
+    loadOpenIssues();
+  }, [loadOpenIssues]);
+
+  // Load counts for canceled/completed tabs on mount
+  useEffect(() => {
+    getIssueList({ state: 'Canceled', take: 1, skip: 0 }).then((res) => setCanceledTotal(res.total));
+    getIssueList({ state: 'Completed', take: 1, skip: 0 }).then((res) => setCompletedTotal(res.total));
+  }, [getIssueList]);
+
+  // Load canceled/completed (paged, server-side search)
+  const loadPaged = useCallback(
+    (state: 'Canceled' | 'Completed', skip: number, query: string, append: boolean): void => {
+      const setLoading = state === 'Canceled' ? setCanceledLoading : setCompletedLoading;
+      const setIssues = state === 'Canceled' ? setCanceledIssues : setCompletedIssues;
+      const setTotal = state === 'Canceled' ? setCanceledTotal : setCompletedTotal;
+      const setLoaded = state === 'Canceled' ? setCanceledLoaded : setCompletedLoaded;
+
+      setLoading(true);
+      setError(undefined);
+
+      getIssueList({ state, take: PAGE_SIZE, skip, query: query || undefined })
+        .then((res) => {
+          setIssues((prev) => (append ? [...prev, ...res.data] : res.data));
+          setTotal(res.total);
+          setLoaded(true);
+        })
+        .catch((e: Error) => setError(e.message ?? 'Unknown error'))
+        .finally(() => setLoading(false));
+    },
+    [getIssueList],
+  );
+
+  // Lazy load on tab switch
+  useEffect(() => {
+    if (activeTab === 'canceled' && !canceledLoaded) {
+      loadPaged('Canceled', 0, '', false);
+    }
+    if (activeTab === 'completed' && !completedLoaded) {
+      loadPaged('Completed', 0, '', false);
+    }
+  }, [activeTab, loadPaged, canceledLoaded, completedLoaded]);
+
+  // Debounced search for canceled/completed
+  useEffect(() => {
+    if (activeTab === 'open') return;
+
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const state = activeTab === 'canceled' ? 'Canceled' : 'Completed';
+      loadPaged(state, 0, searchQuery, false);
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [searchQuery, activeTab, loadPaged]);
+
+  useLayoutOptions({ title: translate('screens/support', 'Support Dashboard'), backButton: true, noMaxWidth: true });
+
+  const openIssueGroups = useMemo(() => {
+    let filtered = openIssuesRaw.filter((i) => (OPEN_STATES as string[]).includes(i.state));
+    if (stateFilter) filtered = filtered.filter((i) => i.state === stateFilter);
+
+    const customerWaiting = filtered
+      .filter((i) => i.lastMessageAuthor === CustomerAuthor)
+      .sort((a, b) => new Date(b.lastMessageDate ?? 0).getTime() - new Date(a.lastMessageDate ?? 0).getTime());
+
+    const rest = filtered.filter((i) => i.lastMessageAuthor !== CustomerAuthor);
+    const byCreated = (a: SupportIssueListItem, b: SupportIssueListItem): number =>
+      new Date(b.created).getTime() - new Date(a.created).getTime();
+
+    return {
+      customerWaiting,
+      created: rest.filter((i) => i.state === SupportIssueInternalState.CREATED).sort(byCreated),
+      pending: rest.filter((i) => i.state === SupportIssueInternalState.PENDING).sort(byCreated),
+      onHold: rest.filter((i) => i.state === SupportIssueInternalState.ON_HOLD).sort(byCreated),
+    };
+  }, [openIssuesRaw, stateFilter]);
+
+  const openIssueCount =
+    openIssueGroups.customerWaiting.length +
+    openIssueGroups.created.length +
+    openIssueGroups.pending.length +
+    openIssueGroups.onHold.length;
+
+  const displayedIssues = activeTab === 'canceled' ? canceledIssues : completedIssues;
+  const displayedTotal = activeTab === 'canceled' ? canceledTotal : completedTotal;
+  const isTabLoading = activeTab === 'open' ? isLoading : activeTab === 'canceled' ? canceledLoading : completedLoading;
+  const hasMore = activeTab !== 'open' && displayedIssues.length < displayedTotal;
+
+  function handleLoadMore(): void {
+    const state = activeTab === 'canceled' ? 'Canceled' : 'Completed';
+    loadPaged(state, displayedIssues.length, searchQuery, true);
+  }
+
+  function handleTabChange(tab: Tab): void {
+    setActiveTab(tab);
+    if (tab === 'open') setSearchQuery('');
+  }
+
+  return (
+    <div className="w-full flex flex-col gap-4 max-w-6xl text-left">
+      {/* Stats & Actions */}
+      <div className="flex items-center gap-4 flex-wrap">
+        <div className="bg-white rounded-lg shadow-sm p-3 flex-1 min-w-[150px]">
+          <div className="text-xs text-dfxGray-700">Open Issues</div>
+          <div className="text-2xl font-bold text-dfxBlue-800">{openIssueCount}</div>
+        </div>
+        <div className="flex gap-2 ml-auto">
+          <button
+            className="px-4 py-2 bg-dfxBlue-400 text-white rounded-lg text-sm hover:bg-dfxBlue-800 transition-colors"
+            onClick={() => navigate('/support-dashboard/create')}
+          >
+            + {translate('screens/support', 'Create Issue')}
+          </button>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 border-b border-dfxGray-400">
+        <TabButton
+          label={`Open (${openIssueCount})`}
+          active={activeTab === 'open'}
+          onClick={() => handleTabChange('open')}
+        />
+        <TabButton
+          label={`Canceled (${canceledTotal})`}
+          active={activeTab === 'canceled'}
+          onClick={() => handleTabChange('canceled')}
+        />
+        <TabButton
+          label={`Completed (${completedTotal})`}
+          active={activeTab === 'completed'}
+          onClick={() => handleTabChange('completed')}
+        />
+      </div>
+
+      {/* Filters - only for Open tab */}
+      {activeTab === 'open' && (
+        <div className="flex gap-3 flex-wrap items-end">
+          <FilterSelect
+            label="Type"
+            value={typeFilter}
+            onChange={setTypeFilter}
+            options={Object.values(SupportIssueType)}
+          />
+          <FilterSelect label="State" value={stateFilter} onChange={setStateFilter} options={OPEN_STATES} />
+          {isAdmin && (
+            <FilterSelect
+              label="Department"
+              value={departmentFilter}
+              onChange={setDepartmentFilter}
+              options={Object.values(Department)}
+            />
+          )}
+          <button
+            className="px-3 py-1.5 text-xs text-dfxGray-700 hover:text-dfxBlue-800 transition-colors"
+            onClick={() => {
+              setTypeFilter('');
+              setStateFilter('');
+              setDepartmentFilter('');
+            }}
+          >
+            Reset
+          </button>
+        </div>
+      )}
+
+      {/* Search - for Canceled and Completed tabs */}
+      {(activeTab === 'canceled' || activeTab === 'completed') && (
+        <div className="flex flex-col gap-1">
+          <input
+            className="px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search by UID, name, clerk, message..."
+          />
+        </div>
+      )}
+
+      {/* Content */}
+      {error && <ErrorHint message={error} />}
+      {isTabLoading && (activeTab !== 'open' ? displayedIssues.length === 0 : openIssueCount === 0) ? (
+        <StyledLoadingSpinner size={SpinnerSize.LG} />
+      ) : activeTab === 'open' ? (
+        <GroupedIssueTable
+          groups={openIssueGroups}
+          showDepartment={isAdmin}
+          onRowClick={(issue) => navigate(`/support-dashboard/issue/${issue.id}`)}
+        />
+      ) : (
+        <>
+          <IssueTable
+            issues={displayedIssues}
+            showDepartment={isAdmin}
+            onRowClick={(issue) => navigate(`/support-dashboard/issue/${issue.id}`)}
+          />
+          {hasMore && (
+            <button
+              className="px-4 py-2 text-sm text-dfxBlue-400 hover:text-dfxBlue-800 transition-colors self-center disabled:opacity-50"
+              onClick={handleLoadMore}
+              disabled={isTabLoading}
+            >
+              {isTabLoading ? 'Loading...' : `Load more (${displayedIssues.length} / ${displayedTotal})`}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// --- Sub-components ---
+
+function TabButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }): JSX.Element {
+  return (
+    <button
+      className={`px-4 py-2 text-sm font-medium transition-colors ${
+        active ? 'text-dfxBlue-800 border-b-2 border-dfxBlue-800' : 'text-dfxGray-700 hover:text-dfxBlue-800'
+      }`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: string[];
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-xs text-dfxGray-700">{label}</label>
+      <select
+        className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="">All</option>
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+interface IssueGroups {
+  customerWaiting: SupportIssueListItem[];
+  created: SupportIssueListItem[];
+  pending: SupportIssueListItem[];
+  onHold: SupportIssueListItem[];
+}
+
+const COLUMN_COUNT = 9;
+
+function IssueTableHeader({ showDepartment }: { showDepartment: boolean }): JSX.Element {
+  return (
+    <thead className="sticky top-0 bg-dfxGray-300">
+      <tr>
+        <th className="px-2 py-1.5 text-left text-xs font-semibold text-dfxBlue-800">Type</th>
+        <th className="px-2 py-1.5 text-left text-xs font-semibold text-dfxBlue-800">Reason</th>
+        <th className="px-2 py-1.5 text-left text-xs font-semibold text-dfxBlue-800">Name</th>
+        <th className="px-2 py-1.5 text-left text-xs font-semibold text-dfxBlue-800">Clerk</th>
+        {showDepartment && <th className="px-2 py-1.5 text-left text-xs font-semibold text-dfxBlue-800">Dept</th>}
+        <th className="px-2 py-1.5 text-center text-xs font-semibold text-dfxBlue-800">State</th>
+        <th className="px-2 py-1.5 text-center text-xs font-semibold text-dfxBlue-800">Msgs</th>
+        <th className="px-2 py-1.5 text-center text-xs font-semibold text-dfxBlue-800">Created</th>
+        <th className="px-2 py-1.5 text-center text-xs font-semibold text-dfxBlue-800">Last Msg</th>
+      </tr>
+    </thead>
+  );
+}
+
+function IssueRow({
+  issue,
+  showDepartment,
+  onRowClick,
+}: {
+  issue: SupportIssueListItem;
+  showDepartment: boolean;
+  onRowClick: (issue: SupportIssueListItem) => void;
+}): JSX.Element {
+  return (
+    <tr
+      className="border-b border-dfxGray-300 transition-colors hover:bg-dfxBlue-400 cursor-pointer group"
+      onClick={() => onRowClick(issue)}
+    >
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">{issue.type}</td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">{issue.reason}</td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white max-w-[200px] truncate">
+        {issue.name}
+      </td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">{issue.clerk || '-'}</td>
+      {showDepartment && (
+        <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">
+          {issue.department || '-'}
+        </td>
+      )}
+      <td className="px-2 py-1.5 text-xs text-center">{statusBadge(issue.state)}</td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-center group-hover:text-white">
+        <span className="inline-flex items-center gap-1">
+          {issue.messageCount}
+          {issue.lastMessageAuthor === CustomerAuthor && (
+            <span className="w-2 h-2 rounded-full bg-dfxRed-100 inline-block" title="Awaiting reply" />
+          )}
+        </span>
+      </td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-center whitespace-nowrap group-hover:text-white">
+        {formatDateTime(issue.created)}
+      </td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-center whitespace-nowrap group-hover:text-white">
+        {issue.lastMessageDate ? formatDateTime(issue.lastMessageDate) : '-'}
+      </td>
+    </tr>
+  );
+}
+
+function SectionHeader({ label, count, colSpan }: { label: string; count: number; colSpan: number }): JSX.Element {
+  return (
+    <tr>
+      <td colSpan={colSpan} className="px-2 py-1.5 bg-dfxGray-400/30 text-xs font-semibold text-dfxGray-700">
+        {label} ({count})
+      </td>
+    </tr>
+  );
+}
+
+function GroupedIssueTable({
+  groups,
+  showDepartment,
+  onRowClick,
+}: {
+  groups: IssueGroups;
+  showDepartment: boolean;
+  onRowClick: (issue: SupportIssueListItem) => void;
+}): JSX.Element {
+  const total = groups.customerWaiting.length + groups.created.length + groups.pending.length + groups.onHold.length;
+  if (total === 0) return <div className="p-4 text-dfxGray-700 text-sm">No issues found</div>;
+
+  const colSpan = showDepartment ? COLUMN_COUNT + 1 : COLUMN_COUNT;
+  const sections: { label: string; issues: SupportIssueListItem[] }[] = [
+    { label: 'Created', issues: groups.created },
+    { label: 'Pending', issues: groups.pending },
+    { label: 'OnHold', issues: groups.onHold },
+  ];
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm max-h-[60vh] overflow-auto scroll-shadow">
+      <table className="w-full border-collapse">
+        <IssueTableHeader showDepartment={showDepartment} />
+        <tbody>
+          {groups.customerWaiting.length > 0 && (
+            <>
+              <SectionHeader label="Awaiting reply" count={groups.customerWaiting.length} colSpan={colSpan} />
+              {groups.customerWaiting.map((issue) => (
+                <IssueRow key={issue.id} issue={issue} showDepartment={showDepartment} onRowClick={onRowClick} />
+              ))}
+            </>
+          )}
+          {sections
+            .filter((s) => s.issues.length > 0)
+            .map((section) => (
+              <React.Fragment key={section.label}>
+                <SectionHeader label={section.label} count={section.issues.length} colSpan={colSpan} />
+                {section.issues.map((issue) => (
+                  <IssueRow key={issue.id} issue={issue} showDepartment={showDepartment} onRowClick={onRowClick} />
+                ))}
+              </React.Fragment>
+            ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function IssueTable({
+  issues,
+  showDepartment,
+  onRowClick,
+}: {
+  issues: SupportIssueListItem[];
+  showDepartment: boolean;
+  onRowClick: (issue: SupportIssueListItem) => void;
+}): JSX.Element {
+  if (issues.length === 0) {
+    return <div className="p-4 text-dfxGray-700 text-sm">No issues found</div>;
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm max-h-[60vh] overflow-auto scroll-shadow">
+      <table className="w-full border-collapse">
+        <IssueTableHeader showDepartment={showDepartment} />
+        <tbody>
+          {issues.map((issue) => (
+            <IssueRow key={issue.id} issue={issue} showDepartment={showDepartment} onRowClick={onRowClick} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add support dashboard with grouped issue list (Awaiting reply, Created, Pending, OnHold sections)
- Add issue detail screen with chat view, file upload (multiple files), update controls and info panels
- Add create issue screen with user search
- Role-based access for Admin, Compliance, Support and Marketing
- Non-blocking error handling for action errors (send, update)
- Memory leak fix for Object URL cleanup

## Test plan
- [ ] Verify dashboard shows correct issue grouping and counts
- [ ] Verify filters (type, state, department) work correctly
- [ ] Verify search on canceled/completed tabs
- [ ] Verify issue detail loads with all info panels
- [ ] Verify chat messaging with text and file attachments
- [ ] Verify issue update (state, department, clerk)
- [ ] Verify create issue flow with user search
- [ ] Run full test suite