### PR TITLE
feat: add manual bank transaction entry page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ const TransactionScreen = lazy(() => import('./screens/transaction.screen'));
 const AccountMerge = lazy(() => import('./screens/account-merge.screen'));
 const MailLoginScreen = lazy(() => import('./screens/mail-login.screen'));
 const SepaScreen = lazy(() => import('./screens/sepa.screen'));
+const SepaManualScreen = lazy(() => import('./screens/sepa-manual.screen'));
 const StickersScreen = lazy(() => import('./screens/stickers.screen'));
 const BlockchainTransactionScreen = lazy(() => import('./screens/blockchain-tx.screen'));
 const EditMailScreen = lazy(() => import('./screens/edit-mail.screen'));
@@ -316,6 +317,10 @@ export const Routes = [
       {
         path: 'sepa',
         element: withSuspense(<SepaScreen />),
+      },
+      {
+        path: 'sepa/manuell',
+        element: withSuspense(<SepaManualScreen />),
       },
       {
         path: 'stickers',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -319,7 +319,7 @@ export const Routes = [
         element: withSuspense(<SepaScreen />),
       },
       {
-        path: 'sepa/manuell',
+        path: 'sepa/manual',
         element: withSuspense(<SepaManualScreen />),
       },
       {

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -54,7 +54,7 @@ function escapeXml(str?: string): string {
     .replace(/'/g, '&apos;');
 }
 
-function buildPartyXml(name: string, iban: string, address?: { street?: string; buildingNumber?: string; postalCode?: string; city?: string; country?: string }): string {
+function buildPartyXml(name: string, address?: { street?: string; buildingNumber?: string; postalCode?: string; city?: string; country?: string }): string {
   const hasAddress = address?.street || address?.buildingNumber || address?.postalCode || address?.city || address?.country;
 
   const addressXml = hasAddress
@@ -92,7 +92,7 @@ function buildCamt053Xml(data: ManualBankTxForm): string {
   const cleanIban = data.iban.replace(/\s/g, '');
 
   const debtorXml = isCredit
-    ? `<Dbtr>${buildPartyXml(data.name, cleanIban, counterpartyAddress)}</Dbtr>
+    ? `<Dbtr>${buildPartyXml(data.name, counterpartyAddress)}</Dbtr>
                             <DbtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></DbtrAcct>`
     : `<Dbtr><Nm>${ACCOUNT_OWNER}</Nm></Dbtr>
                             <DbtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></DbtrAcct>`;
@@ -100,7 +100,7 @@ function buildCamt053Xml(data: ManualBankTxForm): string {
   const creditorXml = isCredit
     ? `<Cdtr><Nm>${ACCOUNT_OWNER}</Nm></Cdtr>
                             <CdtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></CdtrAcct>`
-    : `<Cdtr>${buildPartyXml(data.name, cleanIban, counterpartyAddress)}</Cdtr>
+    : `<Cdtr>${buildPartyXml(data.name, counterpartyAddress)}</Cdtr>
                             <CdtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></CdtrAcct>`;
 
   const txCode = isCredit

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -419,7 +419,6 @@ export default function SepaManualScreen(): JSX.Element {
         )}
 
         <StyledButton
-          type="submit"
           label={translate('general/actions', 'Next')}
           onClick={handleSubmit(onSubmit)}
           width={StyledButtonWidth.FULL}

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -1,0 +1,335 @@
+import { ApiError, useApi, Utils, Validations } from '@dfx.swiss/react';
+import {
+  DfxIcon,
+  Form,
+  IconSize,
+  IconVariant,
+  StyledButton,
+  StyledButtonWidth,
+  StyledDropdown,
+  StyledInput,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorHint } from 'src/components/error-hint';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useSettingsContext } from '../contexts/settings.context';
+import { useAdminGuard } from '../hooks/guard.hook';
+
+enum CreditDebitIndicator {
+  CRDT = 'CRDT',
+  DBIT = 'DBIT',
+}
+
+interface ManualBankTxForm {
+  bookingDate: string;
+  valueDate: string;
+  amount: string;
+  currency: string;
+  direction: CreditDebitIndicator;
+  name: string;
+  street: string;
+  buildingNumber: string;
+  postalCode: string;
+  city: string;
+  country: string;
+  iban: string;
+  remittanceInfo: string;
+}
+
+const CURRENCIES = ['EUR', 'CHF', 'USD'];
+
+const ACCOUNT_IBAN = 'CH7780808002608614092';
+const ACCOUNT_OWNER = 'DFX AG';
+const ACCOUNT_BANK = 'Raiffeisenbank Waldkirch';
+
+export default function SepaManualScreen(): JSX.Element {
+  const { translate, translateError } = useSettingsContext();
+  const { call } = useApi();
+
+  const [isUploading, setIsUploading] = useState(false);
+  const [showNotification, setShowNotification] = useState(false);
+  const [error, setError] = useState<string>();
+
+  useAdminGuard();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isValid, errors },
+  } = useForm<ManualBankTxForm>({
+    mode: 'onChange',
+    defaultValues: {
+      currency: 'EUR',
+      direction: CreditDebitIndicator.CRDT,
+      country: 'DE',
+    },
+  });
+
+  function buildCamt053Xml(data: ManualBankTxForm): string {
+    const now = new Date();
+    const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
+    const isoTimestamp = now.toISOString().replace('Z', '+00:00');
+    const ref = `${Date.now()}`;
+
+    const isCredit = data.direction === CreditDebitIndicator.CRDT;
+
+    const debtor = isCredit
+      ? `<Dbtr><Nm>${escapeXml(data.name)}</Nm><PstlAdr><StrtNm>${escapeXml(data.street)}</StrtNm><BldgNb>${escapeXml(data.buildingNumber)}</BldgNb><PstCd>${escapeXml(data.postalCode)}</PstCd><TwnNm>${escapeXml(data.city)}</TwnNm><Ctry>${escapeXml(data.country)}</Ctry></PstlAdr></Dbtr><DbtrAcct><Id><IBAN>${escapeXml(data.iban.replace(/\s/g, ''))}</IBAN></Id></DbtrAcct>`
+      : `<Dbtr><Nm>${ACCOUNT_OWNER}</Nm></Dbtr><DbtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></DbtrAcct>`;
+
+    const creditor = isCredit
+      ? `<Cdtr><Nm>${ACCOUNT_OWNER}</Nm></Cdtr><CdtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></CdtrAcct>`
+      : `<Cdtr><Nm>${escapeXml(data.name)}</Nm><PstlAdr><StrtNm>${escapeXml(data.street)}</StrtNm><BldgNb>${escapeXml(data.buildingNumber)}</BldgNb><PstCd>${escapeXml(data.postalCode)}</PstCd><TwnNm>${escapeXml(data.city)}</TwnNm><Ctry>${escapeXml(data.country)}</Ctry></PstlAdr></Cdtr><CdtrAcct><Id><IBAN>${escapeXml(data.iban.replace(/\s/g, ''))}</IBAN></Id></CdtrAcct>`;
+
+    const txCode = isCredit ? '<Cd>RCDT</Cd><SubFmlyCd>XBCT</SubFmlyCd>' : '<Cd>ICDT</Cd><SubFmlyCd>DMCT</SubFmlyCd>';
+
+    const amount = parseFloat(data.amount);
+
+    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Document xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04 camt.053.001.04.xsd" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>MSG-C053-${timestamp}-01</MsgId>
+            <CreDtTm>${isoTimestamp}</CreDtTm>
+            <AddtlInf>PRODUCTIVE</AddtlInf>
+        </GrpHdr>
+        <Stmt>
+            <Id>STM-C053-${timestamp}-01</Id>
+            <ElctrncSeqNb>1</ElctrncSeqNb>
+            <CreDtTm>${isoTimestamp}</CreDtTm>
+            <FrToDt>
+                <FrDtTm>${data.bookingDate}T00:00:00.000+00:00</FrDtTm>
+                <ToDtTm>${data.bookingDate}T23:59:59.999+00:00</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <IBAN>${ACCOUNT_IBAN}</IBAN>
+                </Id>
+                <Ownr>
+                    <Nm>${ACCOUNT_OWNER}</Nm>
+                </Ownr>
+                <Svcr>
+                    <FinInstnId>
+                        <Nm>${ACCOUNT_BANK}</Nm>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="${escapeXml(data.currency)}">0</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>${data.bookingDate}</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="${escapeXml(data.currency)}">0</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>${data.bookingDate}</Dt>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <Amt Ccy="${escapeXml(data.currency)}">${amount}</Amt>
+                <CdtDbtInd>${data.direction}</CdtDbtInd>
+                <RvslInd>false</RvslInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>${data.bookingDate}</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>${data.valueDate}</Dt>
+                </ValDt>
+                <AcctSvcrRef>${ref}</AcctSvcrRef>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            ${txCode}
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>1000</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <AmtDtls>
+                    <TxAmt>
+                        <Amt Ccy="${escapeXml(data.currency)}">${amount}</Amt>
+                    </TxAmt>
+                </AmtDtls>
+                <NtryDtls>
+                    <TxDtls>
+                        <Amt Ccy="${escapeXml(data.currency)}">${amount}</Amt>
+                        <CdtDbtInd>${data.direction}</CdtDbtInd>
+                        <BkTxCd>
+                            <Domn>
+                                <Cd>PMNT</Cd>
+                                <Fmly>
+                                    ${txCode}
+                                </Fmly>
+                            </Domn>
+                        </BkTxCd>
+                        <RltdPties>
+                            ${debtor}
+                            ${creditor}
+                        </RltdPties>
+                        <RmtInf>
+                            <Ustrd>${escapeXml(data.remittanceInfo)}</Ustrd>
+                        </RmtInf>
+                    </TxDtls>
+                </NtryDtls>
+                <AddtlNtryInf>${isCredit ? 'Gutschrift' : 'Zahlung'} ${escapeXml(data.name)}</AddtlNtryInf>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>`;
+  }
+
+  function escapeXml(str: string): string {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  async function onSubmit(data: ManualBankTxForm) {
+    const xml = buildCamt053Xml(data);
+    const file = new File([xml], 'manual-bank-tx.xml', { type: 'text/xml' });
+
+    const fileData = new FormData();
+    fileData.append('files', file);
+
+    setIsUploading(true);
+    setError(undefined);
+    call({
+      url: 'bankTx',
+      method: 'POST',
+      data: fileData,
+      noJson: true,
+    })
+      .then(() => {
+        setIsUploading(false);
+        toggleNotification();
+        reset();
+      })
+      .catch((e: ApiError) => {
+        setIsUploading(false);
+        setError(e.message);
+      });
+  }
+
+  const toggleNotification = () => {
+    setShowNotification(true);
+    setTimeout(() => setShowNotification(false), 2000);
+  };
+
+  const rules = Utils.createRules({
+    bookingDate: [Validations.Required],
+    valueDate: [Validations.Required],
+    amount: [Validations.Required],
+    currency: [Validations.Required],
+    direction: [Validations.Required],
+    name: [Validations.Required],
+    iban: [Validations.Required],
+    remittanceInfo: [Validations.Required],
+  });
+
+  useLayoutOptions({ title: translate('screens/kyc', 'Manual bank transaction') });
+
+  return (
+    <Form control={control} rules={rules} errors={errors} onSubmit={handleSubmit(onSubmit)} translate={translateError}>
+      <StyledVerticalStack gap={6} full center>
+        <StyledVerticalStack gap={2} full>
+          <p className="flex flex-row justify-between w-full text-dfxGray-700 text-xs font-semibold uppercase text-start px-3">
+            <span>{translate('screens/kyc', 'Transaction details')}</span>
+            <span
+              className={`flex flex-row gap-1 items-center text-dfxRed-100 font-normal transition-opacity duration-200 ${
+                showNotification ? 'opacity-100' : 'opacity-0'
+              }`}
+            >
+              <DfxIcon icon={IconVariant.CHECK} size={IconSize.SM} />
+              {translate('screens/kyc', 'Uploaded')}
+            </span>
+          </p>
+
+          <StyledInput name="bookingDate" type="date" label={translate('screens/kyc', 'Booking date')} full smallLabel />
+          <StyledInput name="valueDate" type="date" label={translate('screens/kyc', 'Value date')} full smallLabel />
+          <StyledInput name="amount" type="number" label={translate('screens/kyc', 'Amount')} placeholder="0.00" full smallLabel />
+          <StyledDropdown
+            name="currency"
+            label={translate('screens/kyc', 'Currency')}
+            items={CURRENCIES}
+            labelFunc={(item) => item}
+            full
+            smallLabel
+          />
+          <StyledDropdown
+            name="direction"
+            label={translate('screens/kyc', 'Direction')}
+            items={Object.values(CreditDebitIndicator)}
+            labelFunc={(item) => (item === CreditDebitIndicator.CRDT ? 'Credit (incoming)' : 'Debit (outgoing)')}
+            full
+            smallLabel
+          />
+        </StyledVerticalStack>
+
+        <StyledVerticalStack gap={2} full>
+          <p className="w-full text-dfxGray-700 text-xs font-semibold uppercase text-start px-3">
+            {translate('screens/kyc', 'Counterparty')}
+          </p>
+
+          <StyledInput name="name" label={translate('screens/kyc', 'Name')} placeholder="Max Mustermann GmbH" full smallLabel />
+          <StyledInput name="street" label={translate('screens/kyc', 'Street')} placeholder="Musterstr." full smallLabel />
+          <StyledInput name="buildingNumber" label={translate('screens/kyc', 'Building number')} placeholder="1" full smallLabel />
+          <StyledInput name="postalCode" label={translate('screens/kyc', 'Postal code')} placeholder="80000" full smallLabel />
+          <StyledInput name="city" label={translate('screens/kyc', 'City')} placeholder="München" full smallLabel />
+          <StyledInput name="country" label={translate('screens/kyc', 'Country')} placeholder="DE" full smallLabel />
+          <StyledInput name="iban" label={translate('screens/kyc', 'IBAN')} placeholder="DE89 3704 0044 0532 0130 00" full smallLabel />
+        </StyledVerticalStack>
+
+        <StyledVerticalStack gap={2} full>
+          <p className="w-full text-dfxGray-700 text-xs font-semibold uppercase text-start px-3">
+            {translate('screens/kyc', 'Payment details')}
+          </p>
+
+          <StyledInput
+            name="remittanceInfo"
+            label={translate('screens/kyc', 'Remittance info')}
+            placeholder="XXXX-XXXX-XXXX"
+            full
+            smallLabel
+          />
+        </StyledVerticalStack>
+
+        {error && (
+          <div>
+            <ErrorHint message={error} />
+          </div>
+        )}
+
+        <StyledButton
+          type="submit"
+          label={translate('general/actions', 'Next')}
+          onClick={handleSubmit(onSubmit)}
+          width={StyledButtonWidth.FULL}
+          disabled={!isValid}
+          isLoading={isUploading}
+        />
+      </StyledVerticalStack>
+    </Form>
+  );
+}

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, useApi, Utils, Validations } from '@dfx.swiss/react';
+import { ApiError, Country, useApi, Utils, Validations } from '@dfx.swiss/react';
 import {
   DfxIcon,
   Form,
@@ -7,12 +7,15 @@ import {
   StyledButton,
   StyledButtonWidth,
   StyledDropdown,
+  StyledHorizontalStack,
   StyledInput,
+  StyledSearchDropdown,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { ErrorHint } from 'src/components/error-hint';
+import { useLayoutContext } from 'src/contexts/layout.context';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useAdminGuard } from '../hooks/guard.hook';
@@ -28,21 +31,20 @@ interface ManualBankTxForm {
   amount: string;
   currency: string;
   direction: CreditDebitIndicator;
+  accountIban: string;
+  accountOwner: string;
+  accountBank: string;
   name: string;
   street: string;
-  buildingNumber: string;
-  postalCode: string;
+  houseNumber: string;
+  zip: string;
   city: string;
-  country: string;
+  country: Country;
   iban: string;
   remittanceInfo: string;
 }
 
 const CURRENCIES = ['EUR', 'CHF', 'USD'];
-
-const ACCOUNT_IBAN = 'CH7780808002608614092';
-const ACCOUNT_OWNER = 'DFX AG';
-const ACCOUNT_BANK = 'Raiffeisenbank Waldkirch';
 
 function escapeXml(str?: string): string {
   if (!str) return '';
@@ -54,15 +56,15 @@ function escapeXml(str?: string): string {
     .replace(/'/g, '&apos;');
 }
 
-function buildPartyXml(name: string, address?: { street?: string; buildingNumber?: string; postalCode?: string; city?: string; country?: string }): string {
-  const hasAddress = address?.street || address?.buildingNumber || address?.postalCode || address?.city || address?.country;
+function buildPartyXml(name: string, address?: { street?: string; houseNumber?: string; zip?: string; city?: string; country?: string }): string {
+  const hasAddress = address?.street || address?.houseNumber || address?.zip || address?.city || address?.country;
 
   const addressXml = hasAddress
     ? [
         '<PstlAdr>',
         address?.street ? `<StrtNm>${escapeXml(address.street)}</StrtNm>` : '',
-        address?.buildingNumber ? `<BldgNb>${escapeXml(address.buildingNumber)}</BldgNb>` : '',
-        address?.postalCode ? `<PstCd>${escapeXml(address.postalCode)}</PstCd>` : '',
+        address?.houseNumber ? `<BldgNb>${escapeXml(address.houseNumber)}</BldgNb>` : '',
+        address?.zip ? `<PstCd>${escapeXml(address.zip)}</PstCd>` : '',
         address?.city ? `<TwnNm>${escapeXml(address.city)}</TwnNm>` : '',
         address?.country ? `<Ctry>${escapeXml(address.country)}</Ctry>` : '',
         '</PstlAdr>',
@@ -79,27 +81,31 @@ function buildCamt053Xml(data: ManualBankTxForm): string {
   const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
   const isoTimestamp = now.toISOString().replace('Z', '+00:00');
   const ref = `${Date.now()}`;
-  const amount = parseFloat(data.amount);
+  const amount = parseFloat(data.amount).toFixed(2);
   const isCredit = data.direction === CreditDebitIndicator.CRDT;
+
+  const accountIban = data.accountIban.replace(/\s/g, '');
+  const accountOwner = data.accountOwner;
+  const accountBank = data.accountBank;
 
   const counterpartyAddress = {
     street: data.street,
-    buildingNumber: data.buildingNumber,
-    postalCode: data.postalCode,
+    houseNumber: data.houseNumber,
+    zip: data.zip,
     city: data.city,
-    country: data.country,
+    country: data.country?.symbol,
   };
   const cleanIban = data.iban.replace(/\s/g, '');
 
   const debtorXml = isCredit
     ? `<Dbtr>${buildPartyXml(data.name, counterpartyAddress)}</Dbtr>
                             <DbtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></DbtrAcct>`
-    : `<Dbtr><Nm>${ACCOUNT_OWNER}</Nm></Dbtr>
-                            <DbtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></DbtrAcct>`;
+    : `<Dbtr><Nm>${escapeXml(accountOwner)}</Nm></Dbtr>
+                            <DbtrAcct><Id><IBAN>${escapeXml(accountIban)}</IBAN></Id></DbtrAcct>`;
 
   const creditorXml = isCredit
-    ? `<Cdtr><Nm>${ACCOUNT_OWNER}</Nm></Cdtr>
-                            <CdtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></CdtrAcct>`
+    ? `<Cdtr><Nm>${escapeXml(accountOwner)}</Nm></Cdtr>
+                            <CdtrAcct><Id><IBAN>${escapeXml(accountIban)}</IBAN></Id></CdtrAcct>`
     : `<Cdtr>${buildPartyXml(data.name, counterpartyAddress)}</Cdtr>
                             <CdtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></CdtrAcct>`;
 
@@ -125,14 +131,14 @@ function buildCamt053Xml(data: ManualBankTxForm): string {
             </FrToDt>
             <Acct>
                 <Id>
-                    <IBAN>${ACCOUNT_IBAN}</IBAN>
+                    <IBAN>${escapeXml(accountIban)}</IBAN>
                 </Id>
                 <Ownr>
-                    <Nm>${ACCOUNT_OWNER}</Nm>
+                    <Nm>${escapeXml(accountOwner)}</Nm>
                 </Ownr>
                 <Svcr>
                     <FinInstnId>
-                        <Nm>${ACCOUNT_BANK}</Nm>
+                        <Nm>${escapeXml(accountBank)}</Nm>
                     </FinInstnId>
                 </Svcr>
             </Acct>
@@ -217,8 +223,9 @@ function buildCamt053Xml(data: ManualBankTxForm): string {
 }
 
 export default function SepaManualScreen(): JSX.Element {
-  const { translate, translateError } = useSettingsContext();
+  const { translate, translateError, allowedCountries } = useSettingsContext();
   const { call } = useApi();
+  const { rootRef } = useLayoutContext();
 
   const [isUploading, setIsUploading] = useState(false);
   const [showNotification, setShowNotification] = useState(false);
@@ -236,11 +243,10 @@ export default function SepaManualScreen(): JSX.Element {
     defaultValues: {
       currency: 'EUR',
       direction: CreditDebitIndicator.CRDT,
-      country: 'DE',
     },
   });
 
-  async function onSubmit(data: ManualBankTxForm) {
+  function onSubmit(data: ManualBankTxForm) {
     const xml = buildCamt053Xml(data);
     const file = new File([xml], 'manual-bank-tx.xml', { type: 'text/xml' });
 
@@ -277,6 +283,9 @@ export default function SepaManualScreen(): JSX.Element {
     amount: [Validations.Required],
     currency: [Validations.Required],
     direction: [Validations.Required],
+    accountIban: [Validations.Required],
+    accountOwner: [Validations.Required],
+    accountBank: [Validations.Required],
     name: [Validations.Required],
     iban: [Validations.Required],
     remittanceInfo: [Validations.Required],
@@ -323,15 +332,69 @@ export default function SepaManualScreen(): JSX.Element {
 
         <StyledVerticalStack gap={2} full>
           <p className="w-full text-dfxGray-700 text-xs font-semibold uppercase text-start px-3">
+            {translate('screens/kyc', 'Account')}
+          </p>
+
+          <StyledInput name="accountOwner" label={translate('screens/kyc', 'Account owner')} placeholder="DFX AG" full smallLabel />
+          <StyledInput name="accountIban" label={translate('screens/kyc', 'Account IBAN')} placeholder="CH78 8080 8002 6086 1409 2" full smallLabel />
+          <StyledInput name="accountBank" label={translate('screens/kyc', 'Bank name')} placeholder="Raiffeisenbank" full smallLabel />
+        </StyledVerticalStack>
+
+        <StyledVerticalStack gap={2} full>
+          <p className="w-full text-dfxGray-700 text-xs font-semibold uppercase text-start px-3">
             {translate('screens/kyc', 'Counterparty')}
           </p>
 
-          <StyledInput name="name" label={translate('screens/kyc', 'Name')} placeholder="Max Mustermann GmbH" full smallLabel />
-          <StyledInput name="street" label={translate('screens/kyc', 'Street')} placeholder="Musterstr." full smallLabel />
-          <StyledInput name="buildingNumber" label={translate('screens/kyc', 'Building number')} placeholder="1" full smallLabel />
-          <StyledInput name="postalCode" label={translate('screens/kyc', 'Postal code')} placeholder="80000" full smallLabel />
-          <StyledInput name="city" label={translate('screens/kyc', 'City')} placeholder="München" full smallLabel />
-          <StyledInput name="country" label={translate('screens/kyc', 'Country')} placeholder="DE" full smallLabel />
+          <StyledInput name="name" autocomplete="name" label={translate('screens/kyc', 'Name')} placeholder={translate('screens/kyc', 'John Doe')} full smallLabel />
+          <StyledHorizontalStack gap={2}>
+            <StyledInput
+              name="street"
+              autocomplete="street"
+              label={translate('screens/kyc', 'Street')}
+              placeholder={translate('screens/kyc', 'Street')}
+              full
+              smallLabel
+            />
+            <StyledInput
+              name="houseNumber"
+              autocomplete="house-number"
+              label={translate('screens/kyc', 'House nr.')}
+              placeholder="xx"
+              small
+              smallLabel
+            />
+          </StyledHorizontalStack>
+          <StyledHorizontalStack gap={2}>
+            <StyledInput
+              name="zip"
+              autocomplete="zip"
+              label={translate('screens/kyc', 'ZIP code')}
+              placeholder="12345"
+              small
+              smallLabel
+            />
+            <StyledInput
+              name="city"
+              autocomplete="city"
+              label={translate('screens/kyc', 'City')}
+              placeholder={translate('screens/kyc', 'City')}
+              full
+              smallLabel
+            />
+          </StyledHorizontalStack>
+          <StyledSearchDropdown<Country>
+            rootRef={rootRef}
+            name="country"
+            autocomplete="country"
+            label={translate('screens/kyc', 'Country')}
+            placeholder={translate('general/actions', 'Select') + '...'}
+            items={allowedCountries}
+            labelFunc={(item) => item.name}
+            filterFunc={(i, s) => !s || [i.name, i.symbol].some((w) => w.toLowerCase().includes(s.toLowerCase()))}
+            matchFunc={(i, s) => i.name.toLowerCase() === s?.toLowerCase()}
+            full
+            smallLabel
+          />
           <StyledInput name="iban" label={translate('screens/kyc', 'IBAN')} placeholder="DE89 3704 0044 0532 0130 00" full smallLabel />
         </StyledVerticalStack>
 

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -17,6 +17,7 @@ import { useForm } from 'react-hook-form';
 import { ErrorHint } from 'src/components/error-hint';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { buildCamt053Xml } from 'src/util/camt053-builder';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useAdminGuard } from '../hooks/guard.hook';
 
@@ -46,182 +47,6 @@ interface ManualBankTxForm {
 
 const CURRENCIES = ['EUR', 'CHF', 'USD'];
 
-function escapeXml(str?: string): string {
-  if (!str) return '';
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;');
-}
-
-function buildPartyXml(name: string, address?: { street?: string; houseNumber?: string; zip?: string; city?: string; country?: string }): string {
-  const hasAddress = address?.street || address?.houseNumber || address?.zip || address?.city || address?.country;
-
-  const addressXml = hasAddress
-    ? [
-        '<PstlAdr>',
-        address?.street ? `<StrtNm>${escapeXml(address.street)}</StrtNm>` : '',
-        address?.houseNumber ? `<BldgNb>${escapeXml(address.houseNumber)}</BldgNb>` : '',
-        address?.zip ? `<PstCd>${escapeXml(address.zip)}</PstCd>` : '',
-        address?.city ? `<TwnNm>${escapeXml(address.city)}</TwnNm>` : '',
-        address?.country ? `<Ctry>${escapeXml(address.country)}</Ctry>` : '',
-        '</PstlAdr>',
-      ]
-        .filter(Boolean)
-        .join('')
-    : '';
-
-  return `<Nm>${escapeXml(name)}</Nm>${addressXml}`;
-}
-
-function buildCamt053Xml(data: ManualBankTxForm): string {
-  const now = new Date();
-  const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
-  const isoTimestamp = now.toISOString().replace('Z', '+00:00');
-  const ref = `${Date.now()}`;
-  const amount = parseFloat(data.amount).toFixed(2);
-  const isCredit = data.direction === CreditDebitIndicator.CRDT;
-
-  const accountIban = data.accountIban.replace(/\s/g, '');
-  const accountOwner = data.accountOwner;
-  const accountBank = data.accountBank;
-
-  const counterpartyAddress = {
-    street: data.street,
-    houseNumber: data.houseNumber,
-    zip: data.zip,
-    city: data.city,
-    country: data.country?.symbol,
-  };
-  const cleanIban = data.iban.replace(/\s/g, '');
-
-  const debtorXml = isCredit
-    ? `<Dbtr>${buildPartyXml(data.name, counterpartyAddress)}</Dbtr>
-                            <DbtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></DbtrAcct>`
-    : `<Dbtr><Nm>${escapeXml(accountOwner)}</Nm></Dbtr>
-                            <DbtrAcct><Id><IBAN>${escapeXml(accountIban)}</IBAN></Id></DbtrAcct>`;
-
-  const creditorXml = isCredit
-    ? `<Cdtr><Nm>${escapeXml(accountOwner)}</Nm></Cdtr>
-                            <CdtrAcct><Id><IBAN>${escapeXml(accountIban)}</IBAN></Id></CdtrAcct>`
-    : `<Cdtr>${buildPartyXml(data.name, counterpartyAddress)}</Cdtr>
-                            <CdtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></CdtrAcct>`;
-
-  const txCode = isCredit
-    ? '<Cd>RCDT</Cd><SubFmlyCd>XBCT</SubFmlyCd>'
-    : '<Cd>ICDT</Cd><SubFmlyCd>DMCT</SubFmlyCd>';
-
-  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Document xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04 camt.053.001.04.xsd" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <BkToCstmrStmt>
-        <GrpHdr>
-            <MsgId>MSG-C053-${timestamp}-01</MsgId>
-            <CreDtTm>${isoTimestamp}</CreDtTm>
-            <AddtlInf>PRODUCTIVE</AddtlInf>
-        </GrpHdr>
-        <Stmt>
-            <Id>STM-C053-${timestamp}-01</Id>
-            <ElctrncSeqNb>1</ElctrncSeqNb>
-            <CreDtTm>${isoTimestamp}</CreDtTm>
-            <FrToDt>
-                <FrDtTm>${data.bookingDate}T00:00:00.000+00:00</FrDtTm>
-                <ToDtTm>${data.bookingDate}T23:59:59.999+00:00</ToDtTm>
-            </FrToDt>
-            <Acct>
-                <Id>
-                    <IBAN>${escapeXml(accountIban)}</IBAN>
-                </Id>
-                <Ownr>
-                    <Nm>${escapeXml(accountOwner)}</Nm>
-                </Ownr>
-                <Svcr>
-                    <FinInstnId>
-                        <Nm>${escapeXml(accountBank)}</Nm>
-                    </FinInstnId>
-                </Svcr>
-            </Acct>
-            <Bal>
-                <Tp>
-                    <CdOrPrtry>
-                        <Cd>OPBD</Cd>
-                    </CdOrPrtry>
-                </Tp>
-                <Amt Ccy="${escapeXml(data.currency)}">0</Amt>
-                <CdtDbtInd>CRDT</CdtDbtInd>
-                <Dt>
-                    <Dt>${data.bookingDate}</Dt>
-                </Dt>
-            </Bal>
-            <Bal>
-                <Tp>
-                    <CdOrPrtry>
-                        <Cd>CLBD</Cd>
-                    </CdOrPrtry>
-                </Tp>
-                <Amt Ccy="${escapeXml(data.currency)}">0</Amt>
-                <CdtDbtInd>CRDT</CdtDbtInd>
-                <Dt>
-                    <Dt>${data.bookingDate}</Dt>
-                </Dt>
-            </Bal>
-            <Ntry>
-                <Amt Ccy="${escapeXml(data.currency)}">${amount}</Amt>
-                <CdtDbtInd>${data.direction}</CdtDbtInd>
-                <RvslInd>false</RvslInd>
-                <Sts>BOOK</Sts>
-                <BookgDt>
-                    <Dt>${data.bookingDate}</Dt>
-                </BookgDt>
-                <ValDt>
-                    <Dt>${data.valueDate}</Dt>
-                </ValDt>
-                <AcctSvcrRef>${ref}</AcctSvcrRef>
-                <BkTxCd>
-                    <Domn>
-                        <Cd>PMNT</Cd>
-                        <Fmly>
-                            ${txCode}
-                        </Fmly>
-                    </Domn>
-                    <Prtry>
-                        <Cd>1000</Cd>
-                    </Prtry>
-                </BkTxCd>
-                <AmtDtls>
-                    <TxAmt>
-                        <Amt Ccy="${escapeXml(data.currency)}">${amount}</Amt>
-                    </TxAmt>
-                </AmtDtls>
-                <NtryDtls>
-                    <TxDtls>
-                        <Amt Ccy="${escapeXml(data.currency)}">${amount}</Amt>
-                        <CdtDbtInd>${data.direction}</CdtDbtInd>
-                        <BkTxCd>
-                            <Domn>
-                                <Cd>PMNT</Cd>
-                                <Fmly>
-                                    ${txCode}
-                                </Fmly>
-                            </Domn>
-                        </BkTxCd>
-                        <RltdPties>
-                            ${debtorXml}
-                            ${creditorXml}
-                        </RltdPties>
-                        <RmtInf>
-                            <Ustrd>${escapeXml(data.remittanceInfo)}</Ustrd>
-                        </RmtInf>
-                    </TxDtls>
-                </NtryDtls>
-                <AddtlNtryInf>${isCredit ? 'Gutschrift' : 'Zahlung'} ${escapeXml(data.name)}</AddtlNtryInf>
-            </Ntry>
-        </Stmt>
-    </BkToCstmrStmt>
-</Document>`;
-}
-
 export default function SepaManualScreen(): JSX.Element {
   const { translate, translateError, allowedCountries } = useSettingsContext();
   const { call } = useApi();
@@ -247,7 +72,7 @@ export default function SepaManualScreen(): JSX.Element {
   });
 
   function onSubmit(data: ManualBankTxForm) {
-    const xml = buildCamt053Xml(data);
+    const xml = buildCamt053Xml({ ...data, country: data.country?.symbol });
     const file = new File([xml], 'manual-bank-tx.xml', { type: 'text/xml' });
 
     const fileData = new FormData();
@@ -283,11 +108,11 @@ export default function SepaManualScreen(): JSX.Element {
     amount: [Validations.Required],
     currency: [Validations.Required],
     direction: [Validations.Required],
-    accountIban: [Validations.Required],
+    accountIban: [Validations.Required, Validations.Iban(allowedCountries)],
     accountOwner: [Validations.Required],
     accountBank: [Validations.Required],
     name: [Validations.Required],
-    iban: [Validations.Required],
+    iban: [Validations.Required, Validations.Iban(allowedCountries)],
     remittanceInfo: [Validations.Required],
   });
 
@@ -419,7 +244,7 @@ export default function SepaManualScreen(): JSX.Element {
         )}
 
         <StyledButton
-          label={translate('general/actions', 'Next')}
+          label={translate('general/actions', 'Upload')}
           onClick={handleSubmit(onSubmit)}
           width={StyledButtonWidth.FULL}
           disabled={!isValid}

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -44,51 +44,70 @@ const ACCOUNT_IBAN = 'CH7780808002608614092';
 const ACCOUNT_OWNER = 'DFX AG';
 const ACCOUNT_BANK = 'Raiffeisenbank Waldkirch';
 
-export default function SepaManualScreen(): JSX.Element {
-  const { translate, translateError } = useSettingsContext();
-  const { call } = useApi();
+function escapeXml(str?: string): string {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
 
-  const [isUploading, setIsUploading] = useState(false);
-  const [showNotification, setShowNotification] = useState(false);
-  const [error, setError] = useState<string>();
+function buildPartyXml(name: string, iban: string, address?: { street?: string; buildingNumber?: string; postalCode?: string; city?: string; country?: string }): string {
+  const hasAddress = address?.street || address?.buildingNumber || address?.postalCode || address?.city || address?.country;
 
-  useAdminGuard();
+  const addressXml = hasAddress
+    ? [
+        '<PstlAdr>',
+        address?.street ? `<StrtNm>${escapeXml(address.street)}</StrtNm>` : '',
+        address?.buildingNumber ? `<BldgNb>${escapeXml(address.buildingNumber)}</BldgNb>` : '',
+        address?.postalCode ? `<PstCd>${escapeXml(address.postalCode)}</PstCd>` : '',
+        address?.city ? `<TwnNm>${escapeXml(address.city)}</TwnNm>` : '',
+        address?.country ? `<Ctry>${escapeXml(address.country)}</Ctry>` : '',
+        '</PstlAdr>',
+      ]
+        .filter(Boolean)
+        .join('')
+    : '';
 
-  const {
-    control,
-    handleSubmit,
-    reset,
-    formState: { isValid, errors },
-  } = useForm<ManualBankTxForm>({
-    mode: 'onChange',
-    defaultValues: {
-      currency: 'EUR',
-      direction: CreditDebitIndicator.CRDT,
-      country: 'DE',
-    },
-  });
+  return `<Nm>${escapeXml(name)}</Nm>${addressXml}`;
+}
 
-  function buildCamt053Xml(data: ManualBankTxForm): string {
-    const now = new Date();
-    const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
-    const isoTimestamp = now.toISOString().replace('Z', '+00:00');
-    const ref = `${Date.now()}`;
+function buildCamt053Xml(data: ManualBankTxForm): string {
+  const now = new Date();
+  const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
+  const isoTimestamp = now.toISOString().replace('Z', '+00:00');
+  const ref = `${Date.now()}`;
+  const amount = parseFloat(data.amount);
+  const isCredit = data.direction === CreditDebitIndicator.CRDT;
 
-    const isCredit = data.direction === CreditDebitIndicator.CRDT;
+  const counterpartyAddress = {
+    street: data.street,
+    buildingNumber: data.buildingNumber,
+    postalCode: data.postalCode,
+    city: data.city,
+    country: data.country,
+  };
+  const cleanIban = data.iban.replace(/\s/g, '');
 
-    const debtor = isCredit
-      ? `<Dbtr><Nm>${escapeXml(data.name)}</Nm><PstlAdr><StrtNm>${escapeXml(data.street)}</StrtNm><BldgNb>${escapeXml(data.buildingNumber)}</BldgNb><PstCd>${escapeXml(data.postalCode)}</PstCd><TwnNm>${escapeXml(data.city)}</TwnNm><Ctry>${escapeXml(data.country)}</Ctry></PstlAdr></Dbtr><DbtrAcct><Id><IBAN>${escapeXml(data.iban.replace(/\s/g, ''))}</IBAN></Id></DbtrAcct>`
-      : `<Dbtr><Nm>${ACCOUNT_OWNER}</Nm></Dbtr><DbtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></DbtrAcct>`;
+  const debtorXml = isCredit
+    ? `<Dbtr>${buildPartyXml(data.name, cleanIban, counterpartyAddress)}</Dbtr>
+                            <DbtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></DbtrAcct>`
+    : `<Dbtr><Nm>${ACCOUNT_OWNER}</Nm></Dbtr>
+                            <DbtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></DbtrAcct>`;
 
-    const creditor = isCredit
-      ? `<Cdtr><Nm>${ACCOUNT_OWNER}</Nm></Cdtr><CdtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></CdtrAcct>`
-      : `<Cdtr><Nm>${escapeXml(data.name)}</Nm><PstlAdr><StrtNm>${escapeXml(data.street)}</StrtNm><BldgNb>${escapeXml(data.buildingNumber)}</BldgNb><PstCd>${escapeXml(data.postalCode)}</PstCd><TwnNm>${escapeXml(data.city)}</TwnNm><Ctry>${escapeXml(data.country)}</Ctry></PstlAdr></Cdtr><CdtrAcct><Id><IBAN>${escapeXml(data.iban.replace(/\s/g, ''))}</IBAN></Id></CdtrAcct>`;
+  const creditorXml = isCredit
+    ? `<Cdtr><Nm>${ACCOUNT_OWNER}</Nm></Cdtr>
+                            <CdtrAcct><Id><IBAN>${ACCOUNT_IBAN}</IBAN></Id></CdtrAcct>`
+    : `<Cdtr>${buildPartyXml(data.name, cleanIban, counterpartyAddress)}</Cdtr>
+                            <CdtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></CdtrAcct>`;
 
-    const txCode = isCredit ? '<Cd>RCDT</Cd><SubFmlyCd>XBCT</SubFmlyCd>' : '<Cd>ICDT</Cd><SubFmlyCd>DMCT</SubFmlyCd>';
+  const txCode = isCredit
+    ? '<Cd>RCDT</Cd><SubFmlyCd>XBCT</SubFmlyCd>'
+    : '<Cd>ICDT</Cd><SubFmlyCd>DMCT</SubFmlyCd>';
 
-    const amount = parseFloat(data.amount);
-
-    return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Document xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04 camt.053.001.04.xsd" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <BkToCstmrStmt>
         <GrpHdr>
@@ -182,8 +201,8 @@ export default function SepaManualScreen(): JSX.Element {
                             </Domn>
                         </BkTxCd>
                         <RltdPties>
-                            ${debtor}
-                            ${creditor}
+                            ${debtorXml}
+                            ${creditorXml}
                         </RltdPties>
                         <RmtInf>
                             <Ustrd>${escapeXml(data.remittanceInfo)}</Ustrd>
@@ -195,16 +214,31 @@ export default function SepaManualScreen(): JSX.Element {
         </Stmt>
     </BkToCstmrStmt>
 </Document>`;
-  }
+}
 
-  function escapeXml(str: string): string {
-    return str
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&apos;');
-  }
+export default function SepaManualScreen(): JSX.Element {
+  const { translate, translateError } = useSettingsContext();
+  const { call } = useApi();
+
+  const [isUploading, setIsUploading] = useState(false);
+  const [showNotification, setShowNotification] = useState(false);
+  const [error, setError] = useState<string>();
+
+  useAdminGuard();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isValid, errors },
+  } = useForm<ManualBankTxForm>({
+    mode: 'onChange',
+    defaultValues: {
+      currency: 'EUR',
+      direction: CreditDebitIndicator.CRDT,
+      country: 'DE',
+    },
+  });
 
   async function onSubmit(data: ManualBankTxForm) {
     const xml = buildCamt053Xml(data);

--- a/src/screens/sepa.screen.tsx
+++ b/src/screens/sepa.screen.tsx
@@ -5,12 +5,14 @@ import {
   IconSize,
   IconVariant,
   StyledButton,
+  StyledButtonColor,
   StyledButtonWidth,
   StyledFileUpload,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
 import { ErrorHint } from 'src/components/error-hint';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useSettingsContext } from '../contexts/settings.context';
@@ -23,6 +25,7 @@ interface FormDataFile {
 export default function SepaScreen(): JSX.Element {
   const { translate, translateError } = useSettingsContext();
   const { call } = useApi();
+  const navigate = useNavigate();
 
   const [isUploading, setIsUploading] = useState(false);
   const [showNotification, setShowNotification] = useState(false);
@@ -113,6 +116,13 @@ export default function SepaScreen(): JSX.Element {
           width={StyledButtonWidth.FULL}
           disabled={!isValid}
           isLoading={isUploading}
+        />
+
+        <StyledButton
+          label={translate('screens/kyc', 'Manual entry')}
+          onClick={() => navigate('/sepa/manuell')}
+          width={StyledButtonWidth.FULL}
+          color={StyledButtonColor.STURDY_WHITE}
         />
       </StyledVerticalStack>
     </Form>

--- a/src/screens/sepa.screen.tsx
+++ b/src/screens/sepa.screen.tsx
@@ -120,7 +120,7 @@ export default function SepaScreen(): JSX.Element {
 
         <StyledButton
           label={translate('screens/kyc', 'Manual entry')}
-          onClick={() => navigate('/sepa/manuell')}
+          onClick={() => navigate('/sepa/manual')}
           width={StyledButtonWidth.FULL}
           color={StyledButtonColor.STURDY_WHITE}
         />

--- a/src/util/camt053-builder.ts
+++ b/src/util/camt053-builder.ts
@@ -1,0 +1,207 @@
+interface PartyAddress {
+  street?: string;
+  houseNumber?: string;
+  zip?: string;
+  city?: string;
+  country?: string;
+}
+
+export interface Camt053Data {
+  bookingDate: string;
+  valueDate: string;
+  amount: string;
+  currency: string;
+  direction: 'CRDT' | 'DBIT';
+  accountIban: string;
+  accountOwner: string;
+  accountBank: string;
+  name: string;
+  street?: string;
+  houseNumber?: string;
+  zip?: string;
+  city?: string;
+  country?: string;
+  iban: string;
+  remittanceInfo: string;
+}
+
+function escapeXml(str?: string): string {
+  if (!str) return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildPartyXml(name: string, address?: PartyAddress): string {
+  const hasAddress = address?.street || address?.houseNumber || address?.zip || address?.city || address?.country;
+
+  const addressXml = hasAddress
+    ? [
+        '<PstlAdr>',
+        address?.street ? `<StrtNm>${escapeXml(address.street)}</StrtNm>` : '',
+        address?.houseNumber ? `<BldgNb>${escapeXml(address.houseNumber)}</BldgNb>` : '',
+        address?.zip ? `<PstCd>${escapeXml(address.zip)}</PstCd>` : '',
+        address?.city ? `<TwnNm>${escapeXml(address.city)}</TwnNm>` : '',
+        address?.country ? `<Ctry>${escapeXml(address.country)}</Ctry>` : '',
+        '</PstlAdr>',
+      ]
+        .filter(Boolean)
+        .join('')
+    : '';
+
+  return `<Nm>${escapeXml(name)}</Nm>${addressXml}`;
+}
+
+export function buildCamt053Xml(data: Camt053Data): string {
+  const now = new Date();
+  const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
+  const isoTimestamp = now.toISOString().replace('Z', '+00:00');
+  const ref = crypto.randomUUID();
+  const parsed = parseFloat(data.amount);
+  const amount = isNaN(parsed) ? '0.00' : parsed.toFixed(2);
+  const isCredit = data.direction === 'CRDT';
+
+  const accountIban = data.accountIban.replace(/\s/g, '');
+  const accountOwner = data.accountOwner;
+  const accountBank = data.accountBank;
+
+  const counterpartyAddress: PartyAddress = {
+    street: data.street,
+    houseNumber: data.houseNumber,
+    zip: data.zip,
+    city: data.city,
+    country: data.country,
+  };
+  const cleanIban = data.iban.replace(/\s/g, '');
+
+  const bookingDate = escapeXml(data.bookingDate);
+  const valueDate = escapeXml(data.valueDate);
+  const currency = escapeXml(data.currency);
+
+  const debtorXml = isCredit
+    ? `<Dbtr>${buildPartyXml(data.name, counterpartyAddress)}</Dbtr>
+                            <DbtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></DbtrAcct>`
+    : `<Dbtr><Nm>${escapeXml(accountOwner)}</Nm></Dbtr>
+                            <DbtrAcct><Id><IBAN>${escapeXml(accountIban)}</IBAN></Id></DbtrAcct>`;
+
+  const creditorXml = isCredit
+    ? `<Cdtr><Nm>${escapeXml(accountOwner)}</Nm></Cdtr>
+                            <CdtrAcct><Id><IBAN>${escapeXml(accountIban)}</IBAN></Id></CdtrAcct>`
+    : `<Cdtr>${buildPartyXml(data.name, counterpartyAddress)}</Cdtr>
+                            <CdtrAcct><Id><IBAN>${escapeXml(cleanIban)}</IBAN></Id></CdtrAcct>`;
+
+  const txCode = isCredit
+    ? '<Cd>RCDT</Cd><SubFmlyCd>XBCT</SubFmlyCd>'
+    : '<Cd>ICDT</Cd><SubFmlyCd>DMCT</SubFmlyCd>';
+
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Document xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04 camt.053.001.04.xsd" xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.04" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <BkToCstmrStmt>
+        <GrpHdr>
+            <MsgId>MSG-C053-${timestamp}-01</MsgId>
+            <CreDtTm>${isoTimestamp}</CreDtTm>
+            <AddtlInf>PRODUCTIVE</AddtlInf>
+        </GrpHdr>
+        <Stmt>
+            <Id>STM-C053-${timestamp}-01</Id>
+            <ElctrncSeqNb>1</ElctrncSeqNb>
+            <CreDtTm>${isoTimestamp}</CreDtTm>
+            <FrToDt>
+                <FrDtTm>${bookingDate}T00:00:00.000+00:00</FrDtTm>
+                <ToDtTm>${bookingDate}T23:59:59.999+00:00</ToDtTm>
+            </FrToDt>
+            <Acct>
+                <Id>
+                    <IBAN>${escapeXml(accountIban)}</IBAN>
+                </Id>
+                <Ownr>
+                    <Nm>${escapeXml(accountOwner)}</Nm>
+                </Ownr>
+                <Svcr>
+                    <FinInstnId>
+                        <Nm>${escapeXml(accountBank)}</Nm>
+                    </FinInstnId>
+                </Svcr>
+            </Acct>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>OPBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="${currency}">0</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>${bookingDate}</Dt>
+                </Dt>
+            </Bal>
+            <Bal>
+                <Tp>
+                    <CdOrPrtry>
+                        <Cd>CLBD</Cd>
+                    </CdOrPrtry>
+                </Tp>
+                <Amt Ccy="${currency}">0</Amt>
+                <CdtDbtInd>CRDT</CdtDbtInd>
+                <Dt>
+                    <Dt>${bookingDate}</Dt>
+                </Dt>
+            </Bal>
+            <Ntry>
+                <Amt Ccy="${currency}">${amount}</Amt>
+                <CdtDbtInd>${data.direction}</CdtDbtInd>
+                <RvslInd>false</RvslInd>
+                <Sts>BOOK</Sts>
+                <BookgDt>
+                    <Dt>${bookingDate}</Dt>
+                </BookgDt>
+                <ValDt>
+                    <Dt>${valueDate}</Dt>
+                </ValDt>
+                <AcctSvcrRef>${ref}</AcctSvcrRef>
+                <BkTxCd>
+                    <Domn>
+                        <Cd>PMNT</Cd>
+                        <Fmly>
+                            ${txCode}
+                        </Fmly>
+                    </Domn>
+                    <Prtry>
+                        <Cd>1000</Cd>
+                    </Prtry>
+                </BkTxCd>
+                <AmtDtls>
+                    <TxAmt>
+                        <Amt Ccy="${currency}">${amount}</Amt>
+                    </TxAmt>
+                </AmtDtls>
+                <NtryDtls>
+                    <TxDtls>
+                        <Amt Ccy="${currency}">${amount}</Amt>
+                        <CdtDbtInd>${data.direction}</CdtDbtInd>
+                        <BkTxCd>
+                            <Domn>
+                                <Cd>PMNT</Cd>
+                                <Fmly>
+                                    ${txCode}
+                                </Fmly>
+                            </Domn>
+                        </BkTxCd>
+                        <RltdPties>
+                            ${debtorXml}
+                            ${creditorXml}
+                        </RltdPties>
+                        <RmtInf>
+                            <Ustrd>${escapeXml(data.remittanceInfo)}</Ustrd>
+                        </RmtInf>
+                    </TxDtls>
+                </NtryDtls>
+                <AddtlNtryInf>${isCredit ? 'Gutschrift' : 'Zahlung'} ${escapeXml(data.name)}</AddtlNtryInf>
+            </Ntry>
+        </Stmt>
+    </BkToCstmrStmt>
+</Document>`;
+}


### PR DESCRIPTION
## Summary
- Add "Manual entry" button on `/sepa` page linking to `/sepa/manuell`
- New form at `/sepa/manuell` for manual bank transaction entry with fields: booking date, value date, amount, currency, direction (CRDT/DBIT), counterparty details (name, address, IBAN), and remittance info
- Generates CAMT.053 XML client-side and submits via existing `POST /bankTx` endpoint
- Admin-only access: `useAdminGuard()` on frontend, `RoleGuard(BANKING_BOT)` on API (ADMIN role inherits BANKING_BOT access)

## Test plan
- [ ] Navigate to `/sepa` and verify "Manual entry" button appears
- [ ] Click button and verify redirect to `/sepa/manuell`
- [ ] Fill out form and submit — verify bank transaction is created
- [ ] Verify non-admin users cannot access `/sepa/manuell`