### PR TITLE
fix: replace hardcoded IBAN and bank details in placeholders

### DIFF
--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -134,9 +134,22 @@ export default function SepaManualScreen(): JSX.Element {
             </span>
           </p>
 
-          <StyledInput name="bookingDate" type="date" label={translate('screens/kyc', 'Booking date')} full smallLabel />
+          <StyledInput
+            name="bookingDate"
+            type="date"
+            label={translate('screens/kyc', 'Booking date')}
+            full
+            smallLabel
+          />
           <StyledInput name="valueDate" type="date" label={translate('screens/kyc', 'Value date')} full smallLabel />
-          <StyledInput name="amount" type="number" label={translate('screens/kyc', 'Amount')} placeholder="0.00" full smallLabel />
+          <StyledInput
+            name="amount"
+            type="number"
+            label={translate('screens/kyc', 'Amount')}
+            placeholder="0.00"
+            full
+            smallLabel
+          />
           <StyledDropdown
             name="currency"
             label={translate('screens/kyc', 'Currency')}
@@ -160,9 +173,27 @@ export default function SepaManualScreen(): JSX.Element {
             {translate('screens/kyc', 'Account')}
           </p>
 
-          <StyledInput name="accountOwner" label={translate('screens/kyc', 'Account owner')} placeholder="DFX AG" full smallLabel />
-          <StyledInput name="accountIban" label={translate('screens/kyc', 'Account IBAN')} placeholder="CH78 8080 8002 6086 1409 2" full smallLabel />
-          <StyledInput name="accountBank" label={translate('screens/kyc', 'Bank name')} placeholder="Raiffeisenbank" full smallLabel />
+          <StyledInput
+            name="accountOwner"
+            label={translate('screens/kyc', 'Account owner')}
+            placeholder="Acme AG"
+            full
+            smallLabel
+          />
+          <StyledInput
+            name="accountIban"
+            label={translate('screens/kyc', 'Account IBAN')}
+            placeholder="CH00 0000 0000 0000 0000 0"
+            full
+            smallLabel
+          />
+          <StyledInput
+            name="accountBank"
+            label={translate('screens/kyc', 'Bank name')}
+            placeholder="Bank"
+            full
+            smallLabel
+          />
         </StyledVerticalStack>
 
         <StyledVerticalStack gap={2} full>
@@ -170,7 +201,14 @@ export default function SepaManualScreen(): JSX.Element {
             {translate('screens/kyc', 'Counterparty')}
           </p>
 
-          <StyledInput name="name" autocomplete="name" label={translate('screens/kyc', 'Name')} placeholder={translate('screens/kyc', 'John Doe')} full smallLabel />
+          <StyledInput
+            name="name"
+            autocomplete="name"
+            label={translate('screens/kyc', 'Name')}
+            placeholder={translate('screens/kyc', 'John Doe')}
+            full
+            smallLabel
+          />
           <StyledHorizontalStack gap={2}>
             <StyledInput
               name="street"
@@ -220,7 +258,13 @@ export default function SepaManualScreen(): JSX.Element {
             full
             smallLabel
           />
-          <StyledInput name="iban" label={translate('screens/kyc', 'IBAN')} placeholder="DE89 3704 0044 0532 0130 00" full smallLabel />
+          <StyledInput
+            name="iban"
+            label={translate('screens/kyc', 'IBAN')}
+            placeholder="DE89 3704 0044 0532 0130 00"
+            full
+            smallLabel
+          />
         </StyledVerticalStack>
 
         <StyledVerticalStack gap={2} full>

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -261,7 +261,7 @@ export default function SepaManualScreen(): JSX.Element {
           <StyledInput
             name="iban"
             label={translate('screens/kyc', 'IBAN')}
-            placeholder="DE89 3704 0044 0532 0130 00"
+            placeholder="DE00 0000 0000 0000 0000 00"
             full
             smallLabel
           />


### PR DESCRIPTION
## Summary
- Replace real account IBAN (`CH78 8080 8002 6086 1409 2`) with generic placeholder (`CH00 0000 0000 0000 0000 0`)
- Replace counterparty IBAN (`DE89 3704 0044 0532 0130 00`) with generic placeholder (`DE00 0000 0000 0000 0000 00`)
- Replace `DFX AG` and `Raiffeisenbank` with generic values (`Acme AG`, `Bank`)
- Fixes security bot finding from #1043

## Test plan
- [ ] Verify placeholder text in manual bank transaction form at `/sepa/manual`
- [ ] Confirm form still validates and submits correctly