### PR TITLE
feat: compliance improvements (limit request, stop transaction, chargeback)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.3.0-beta.267",
-        "@dfx.swiss/react-components": "^1.3.0-beta.267",
+        "@dfx.swiss/react": "^1.3.0-beta.268",
+        "@dfx.swiss/react-components": "^1.3.0-beta.268",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
         "@ledgerhq/hw-transport-webhid": "^6.27.19",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.3.0-beta.267",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.0-beta.267.tgz",
-      "integrity": "sha512-ly5OfDkxCiBLv7jFT5Q/VoKSoyfM7Yb4HhKwMHti9RfrYkCK1zZtdBWf5H8oSmo2gS/uBeh98WaF5Ns1fA5G4A==",
+      "version": "1.3.0-beta.268",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.0-beta.268.tgz",
+      "integrity": "sha512-bEZADH+VS7HtJLgDXFWvScs0Y//5wssMXdYcPEKoeX04vosyhQ+oO6tooqZ40jEEp0uF55AddbnfsRYRGRgZew==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2645,9 +2645,9 @@
       }
     },
     "node_modules/@dfx.swiss/react-components": {
-      "version": "1.3.0-beta.267",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react-components/-/react-components-1.3.0-beta.267.tgz",
-      "integrity": "sha512-FRXOvxPzFpFsleRSq/RGNFRBqKM6+6DKjbTzh7k9yvDEWufoCwzfsGMIfSo40ljAMVuSWyMPTprctXsjFGqUpw==",
+      "version": "1.3.0-beta.268",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react-components/-/react-components-1.3.0-beta.268.tgz",
+      "integrity": "sha512-0eaUTfxsJazmQtzl25+tVlZ1A5QYJ4AGCXt+RYR53+mFs9dKIQzbZ1FShExhQBS7W+vbKZqkiTW3fEf79ly8ZQ==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.3.0-beta.267",
-    "@dfx.swiss/react-components": "^1.3.0-beta.267",
+    "@dfx.swiss/react": "^1.3.0-beta.268",
+    "@dfx.swiss/react-components": "^1.3.0-beta.268",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",
     "@ledgerhq/hw-transport-webhid": "^6.27.19",

--- a/src/components/compliance/chargeback-modal.tsx
+++ b/src/components/compliance/chargeback-modal.tsx
@@ -1,0 +1,343 @@
+import { Country, Utils, Validations } from '@dfx.swiss/react';
+import {
+  Form,
+  SpinnerSize,
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledInput,
+  StyledLoadingSpinner,
+  StyledSearchDropdown,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorHint } from 'src/components/error-hint';
+import { Modal } from 'src/components/modal';
+import { RefundDataTable } from 'src/components/refund/refund-data-table';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { TransactionRefundData, useCompliance } from 'src/hooks/compliance.hook';
+
+interface ChargebackModalProps {
+  readonly isOpen: boolean;
+  readonly transactionId: number | undefined;
+  readonly transactionType?: string;
+  readonly sourceType?: string;
+  readonly onClose: () => void;
+  readonly onSuccess: () => void;
+}
+
+interface ChargebackFormData {
+  iban: string;
+  refundAddress: string;
+  creditorName: string;
+  creditorAddress: string;
+  creditorZipCity: string;
+  creditorCountry: Country;
+}
+
+type RefundMode = 'bank' | 'crypto' | 'card';
+
+function getRefundMode(transactionType?: string, sourceType?: string): RefundMode {
+  if (transactionType === 'BuyFiat') return 'crypto';
+  if (sourceType === 'CryptoInput') return 'crypto';
+  if (sourceType === 'CheckoutTx') return 'card';
+  return 'bank';
+}
+
+export function ChargebackModal({
+  isOpen,
+  transactionId,
+  transactionType,
+  sourceType,
+  onClose,
+  onSuccess,
+}: ChargebackModalProps): JSX.Element {
+  const { translate, translateError, allowedCountries } = useSettingsContext();
+  const { getTransactionRefundData, chargebackTransaction } = useCompliance();
+  const { rootRef } = useLayoutContext();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+  const [refundData, setRefundData] = useState<TransactionRefundData>();
+  const [manualAmount, setManualAmount] = useState<string>('');
+
+  const refundMode = useMemo(() => getRefundMode(transactionType, sourceType), [transactionType, sourceType]);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid, errors },
+    setValue,
+    reset,
+  } = useForm<ChargebackFormData>({ mode: 'onTouched' });
+
+  useEffect(() => {
+    if (isOpen && transactionId) {
+      loadRefundData(transactionId);
+    }
+    if (!isOpen) {
+      setRefundData(undefined);
+      setError(undefined);
+      setManualAmount('');
+      reset();
+    }
+  }, [isOpen, transactionId]);
+
+  async function loadRefundData(txId: number): Promise<void> {
+    setIsLoading(true);
+    setError(undefined);
+
+    try {
+      const data = await getTransactionRefundData(txId);
+      setRefundData(data);
+
+      if (refundMode === 'bank') {
+        if (data.refundTarget) setValue('iban', data.refundTarget);
+        if (data.bankDetails) {
+          if (data.bankDetails.name) setValue('creditorName', data.bankDetails.name);
+          const address = [data.bankDetails.address, data.bankDetails.houseNumber].filter(Boolean).join(' ');
+          if (address) setValue('creditorAddress', address);
+          const zipCity = [data.bankDetails.zip, data.bankDetails.city].filter(Boolean).join(' ');
+          if (zipCity) setValue('creditorZipCity', zipCity);
+          if (data.bankDetails.country) {
+            const country = allowedCountries.find((c) => c.symbol === data.bankDetails?.country);
+            if (country) setValue('creditorCountry', country);
+          }
+        }
+      } else if (refundMode === 'crypto') {
+        if (data.refundTarget) setValue('refundAddress', data.refundTarget);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load refund data');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function onSubmit(formData: ChargebackFormData): Promise<void> {
+    if (!transactionId || !refundData) return;
+
+    setIsSubmitting(true);
+    setError(undefined);
+
+    const parsedAmount = manualAmount ? parseFloat(manualAmount) : undefined;
+    if (parsedAmount != null && (parsedAmount <= 0 || parsedAmount > refundData.inputAmount)) return;
+
+    try {
+      await chargebackTransaction(transactionId, {
+        refundTarget:
+          refundMode === 'bank' ? formData.iban : refundMode === 'crypto' ? formData.refundAddress : undefined,
+        creditorData:
+          refundMode === 'bank'
+            ? {
+                name: formData.creditorName,
+                address: formData.creditorAddress,
+                zip: formData.creditorZipCity,
+                city: formData.creditorZipCity,
+                country: formData.creditorCountry.symbol,
+              }
+            : undefined,
+        chargebackAmount: parsedAmount,
+      });
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Chargeback failed');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleClose(): void {
+    reset();
+    setError(undefined);
+    setManualAmount('');
+    onClose();
+  }
+
+  const bankRules = Utils.createRules({
+    iban: Validations.Required,
+    creditorName: Validations.Required,
+    creditorAddress: Validations.Required,
+    creditorZipCity: Validations.Required,
+    creditorCountry: Validations.Required,
+  });
+
+  const cryptoRules = Utils.createRules({
+    refundAddress: Validations.Required,
+  });
+
+  const rules = refundMode === 'bank' ? bankRules : refundMode === 'crypto' ? cryptoRules : {};
+
+  if (!isOpen) return <></>;
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <div className="bg-white rounded-lg shadow-sm p-6 max-w-lg mx-auto w-full">
+        <h2 className="text-lg font-semibold text-dfxBlue-800 mb-4 text-left">
+          {translate('screens/payment', 'Transaction refund')}
+        </h2>
+
+        {isLoading ? (
+          <div className="flex justify-center py-8">
+            <StyledLoadingSpinner size={SpinnerSize.LG} />
+          </div>
+        ) : !refundData ? (
+          <StyledVerticalStack gap={4} full>
+            {error && <ErrorHint message={error} />}
+            <StyledButton
+              label={translate('general/actions', 'Close')}
+              onClick={handleClose}
+              width={StyledButtonWidth.FULL}
+              color={StyledButtonColor.STURDY_WHITE}
+            />
+          </StyledVerticalStack>
+        ) : (
+          <StyledVerticalStack gap={4} full>
+            <RefundDataTable refundData={refundData} />
+
+            <Form
+              control={control}
+              rules={rules}
+              errors={errors}
+              onSubmit={handleSubmit(onSubmit)}
+              translate={translateError}
+            >
+              <StyledVerticalStack gap={4} full>
+                {refundMode === 'bank' && (
+                  <>
+                    <StyledInput
+                      control={control}
+                      rules={bankRules?.iban}
+                      name="iban"
+                      label={translate('screens/payment', 'Chargeback IBAN')}
+                      placeholder="CH..."
+                      full
+                      smallLabel
+                    />
+                    <StyledInput
+                      control={control}
+                      rules={bankRules?.creditorName}
+                      name="creditorName"
+                      label={translate('screens/kyc', 'Name')}
+                      placeholder={translate('screens/kyc', 'John Doe')}
+                      full
+                      smallLabel
+                    />
+                    <StyledInput
+                      control={control}
+                      rules={bankRules?.creditorAddress}
+                      name="creditorAddress"
+                      label={translate('screens/kyc', 'Street') + ' / ' + translate('screens/kyc', 'House nr.')}
+                      placeholder="Musterstrasse 1"
+                      full
+                      smallLabel
+                    />
+                    <StyledInput
+                      control={control}
+                      rules={bankRules?.creditorZipCity}
+                      name="creditorZipCity"
+                      label={translate('screens/kyc', 'ZIP code') + ' / ' + translate('screens/kyc', 'City')}
+                      placeholder="10115 Berlin"
+                      full
+                      smallLabel
+                    />
+                    <StyledSearchDropdown<Country>
+                      control={control}
+                      rules={bankRules?.creditorCountry}
+                      rootRef={rootRef}
+                      name="creditorCountry"
+                      label={translate('screens/kyc', 'Country')}
+                      placeholder={translate('general/actions', 'Select') + '...'}
+                      items={allowedCountries ?? []}
+                      labelFunc={(item) => item.name}
+                      filterFunc={(i, s) =>
+                        !s || [i.name, i.symbol].some((w) => w.toLowerCase().includes(s.toLowerCase()))
+                      }
+                      matchFunc={(i, s) => i.name.toLowerCase() === s?.toLowerCase()}
+                      full
+                      smallLabel
+                    />
+                  </>
+                )}
+
+                {refundMode === 'crypto' && (
+                  <StyledInput
+                    control={control}
+                    rules={cryptoRules?.refundAddress}
+                    name="refundAddress"
+                    label="Refund address"
+                    placeholder="0x..."
+                    full
+                    smallLabel
+                  />
+                )}
+
+                {refundMode === 'card' && (
+                  <p className="text-sm text-dfxBlue-800">Refund will be processed back to the original card.</p>
+                )}
+
+                <div>
+                  <label className="block text-sm text-dfxBlue-800 mb-1">Manual refund amount (optional)</label>
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    value={manualAmount}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      if (val === '' || /^\d*\.?\d*$/.test(val)) setManualAmount(val);
+                    }}
+                    placeholder={`${refundData.refundAmount ?? ''} ${refundData.refundAsset?.name ?? ''}`}
+                    className={`w-full px-3 py-2 text-sm text-dfxBlue-800 border rounded focus:outline-none ${
+                      manualAmount !== '' &&
+                      (parseFloat(manualAmount) <= 0 || parseFloat(manualAmount) > refundData.inputAmount)
+                        ? 'border-primary-red focus:border-primary-red'
+                        : 'border-dfxGray-400 focus:border-dfxBlue-800'
+                    }`}
+                  />
+                  {manualAmount !== '' && parseFloat(manualAmount) <= 0 && (
+                    <p className="text-xs text-primary-red mt-1">Amount must be greater than 0</p>
+                  )}
+                  {manualAmount !== '' &&
+                    parseFloat(manualAmount) > 0 &&
+                    parseFloat(manualAmount) > refundData.inputAmount && (
+                      <p className="text-xs text-primary-red mt-1">
+                        Amount must not exceed the transaction amount ({refundData.inputAmount}{' '}
+                        {refundData.inputAsset?.name})
+                      </p>
+                    )}
+                </div>
+
+                {error && <ErrorHint message={error} />}
+
+                <div className="flex gap-2 w-full">
+                  <StyledButton
+                    label={translate('general/actions', 'Cancel')}
+                    onClick={handleClose}
+                    width={StyledButtonWidth.FULL}
+                    color={StyledButtonColor.STURDY_WHITE}
+                    disabled={isSubmitting}
+                  />
+                  <StyledButton
+                    type="submit"
+                    label={translate('general/actions', 'Confirm refund')}
+                    onClick={handleSubmit(onSubmit)}
+                    width={StyledButtonWidth.FULL}
+                    disabled={
+                      !isValid ||
+                      (manualAmount !== '' &&
+                        (parseFloat(manualAmount) <= 0 || parseFloat(manualAmount) > refundData.inputAmount))
+                    }
+                    isLoading={isSubmitting}
+                  />
+                </div>
+              </StyledVerticalStack>
+            </Form>
+          </StyledVerticalStack>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/compliance/limit-request-modal.tsx
+++ b/src/components/compliance/limit-request-modal.tsx
@@ -1,0 +1,151 @@
+import { ApiError, FundOrigin, InvestmentDate, Limit, Utils, Validations } from '@dfx.swiss/react';
+import {
+  Form,
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useState } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
+import { ErrorHint } from 'src/components/error-hint';
+import { Modal } from 'src/components/modal';
+import { LimitRequestFields } from 'src/components/support-issue/limit-request-fields';
+import { DefaultFileTypes } from 'src/config/file-types';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useCompliance } from 'src/hooks/compliance.hook';
+import { toBase64 } from 'src/util/utils';
+
+interface LimitRequestModalProps {
+  isOpen: boolean;
+  userDataId: number;
+  defaultName?: string;
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+interface LimitRequestFormData {
+  name: string;
+  limit: Limit;
+  investmentDate: InvestmentDate;
+  fundOrigin: FundOrigin;
+  message: string;
+  file?: File;
+}
+
+export function LimitRequestModal({
+  isOpen,
+  userDataId,
+  defaultName,
+  onClose,
+  onCreated,
+}: LimitRequestModalProps): JSX.Element {
+  const { translate, translateError } = useSettingsContext();
+  const { rootRef } = useLayoutContext();
+  const { createLimitRequest } = useCompliance();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors, isValid },
+  } = useForm<LimitRequestFormData>({
+    mode: 'all',
+    defaultValues: { name: defaultName },
+  });
+  const investmentDate = useWatch({ control, name: 'investmentDate' });
+
+  const rules = Utils.createRules({
+    name: Validations.Required,
+    limit: Validations.Required,
+    investmentDate: Validations.Required,
+    fundOrigin: Validations.Required,
+    message: [Validations.Required, Validations.Custom((message) => message.length <= 4000 || 'message_length')],
+    file: [Validations.Custom((file) => (!file || DefaultFileTypes.includes(file.type) ? true : 'file_type'))],
+  });
+
+  function handleClose(): void {
+    reset({ name: defaultName });
+    setError(undefined);
+    onClose();
+  }
+
+  async function onSubmit(data: LimitRequestFormData): Promise<void> {
+    setIsLoading(true);
+    setError(undefined);
+
+    try {
+      await createLimitRequest(userDataId, {
+        name: data.name,
+        message: data.message,
+        limit: data.limit,
+        investmentDate: data.investmentDate,
+        fundOrigin: data.fundOrigin,
+        file: data.file && (await toBase64(data.file)),
+        fileName: data.file?.name,
+      });
+      onCreated?.();
+      handleClose();
+    } catch (e) {
+      setError((e as ApiError).message ?? 'Unknown error');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <div className="bg-white rounded-lg shadow-sm p-6">
+        <h2 className="text-lg font-semibold text-dfxBlue-800 mb-4 text-left">
+          {translate('screens/support', 'Limit increase request')}
+        </h2>
+
+        <Form
+          control={control}
+          rules={rules}
+          errors={errors}
+          onSubmit={handleSubmit(onSubmit)}
+          translate={translateError}
+        >
+          <StyledVerticalStack gap={6} full center>
+            <LimitRequestFields
+              rootRef={rootRef}
+              control={control}
+              rules={rules}
+              errors={errors}
+              investmentDate={investmentDate}
+            />
+
+            {error && (
+              <div>
+                <ErrorHint message={error} />
+              </div>
+            )}
+
+            <div className="flex gap-2 w-full">
+              <StyledButton
+                label={translate('general/actions', 'Cancel')}
+                onClick={handleClose}
+                width={StyledButtonWidth.FULL}
+                color={StyledButtonColor.STURDY_WHITE}
+                disabled={isLoading}
+              />
+              <StyledButton
+                type="submit"
+                label={translate('general/actions', 'Save')}
+                onClick={handleSubmit(onSubmit)}
+                width={StyledButtonWidth.FULL}
+                disabled={!isValid}
+                isLoading={isLoading}
+              />
+            </div>
+          </StyledVerticalStack>
+        </Form>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/compliance/onboarding-company-header.tsx
+++ b/src/components/compliance/onboarding-company-header.tsx
@@ -59,9 +59,7 @@ function extractLegalEntityFromStep(kycSteps: KycStepInfo[], accountType: string
 }
 
 function extractStepCreatedDate(kycSteps: KycStepInfo[]): string {
-  const step = kycSteps
-    .filter((s) => s.name === 'LegalEntity')
-    .sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
+  const step = kycSteps.filter((s) => s.name === 'LegalEntity').sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
 
   if (!step) return '-';
   return new Date(step.created).toLocaleDateString('de-CH');
@@ -72,7 +70,6 @@ export function OnboardingCompanyHeader({ userData, kycSteps }: OnboardingCompan
     [extractField(userData, 'firstname'), extractField(userData, 'surname')].filter((v) => v !== '-').join(' ') || '-';
 
   const accountType = extractField(userData, 'accountType');
-  const kycHash = extractField(userData, 'kycHash');
 
   const fields: HeaderField[] = [
     { label: 'UserDataId', value: extractField(userData, 'id') },
@@ -84,12 +81,6 @@ export function OnboardingCompanyHeader({ userData, kycSteps }: OnboardingCompan
     { label: 'Mail', value: extractField(userData, 'mail') },
     { label: 'Sprache', value: extractField(userData, 'language') },
     { label: 'Datum Dokument eingereicht', value: extractStepCreatedDate(kycSteps) },
-    {
-      label: 'Login Kundenkonto',
-      value: kycHash !== '-' ? 'Login Kundenkonto' : '-',
-      isLink: kycHash !== '-',
-      href: kycHash !== '-' ? `/kyc?code=${kycHash}` : undefined,
-    },
   ];
 
   return (

--- a/src/components/compliance/onboarding-freigabe-panel.tsx
+++ b/src/components/compliance/onboarding-freigabe-panel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { LimitRequestModal } from 'src/components/compliance/limit-request-modal';
 import { KycFile, KycStepInfo } from 'src/hooks/compliance.hook';
 import { formatDate, formatDateTime, formatValue, statusBadge } from 'src/util/compliance-helpers';
 
@@ -31,6 +32,7 @@ interface OnboardingOnboardingFreigabePanelProps {
   onOpenFile: (file: KycFile) => void;
   onSave: (params: OnboardingFreigabeSaveParams) => Promise<void>;
   isSaving: boolean;
+  onLimitRequestCreated?: () => void;
 }
 
 interface SavedComment {
@@ -275,6 +277,7 @@ export function OnboardingFreigabePanel({
   onOpenFile,
   onSave,
   isSaving,
+  onLimitRequestCreated,
 }: OnboardingOnboardingFreigabePanelProps): JSX.Element {
   // Derived from predecessor step status (read-only, like in GS)
   const ownerDirectoryStep = findStep(kycSteps, 'OwnerDirectory');
@@ -301,6 +304,7 @@ export function OnboardingFreigabePanel({
   const [businessActivities, setBusinessActivities] = useState('');
   const [finalDecision, setFinalDecision] = useState<DecisionValue>('');
   const [processedBy, setProcessedBy] = useState('');
+  const [showLimitRequestModal, setShowLimitRequestModal] = useState(false);
 
   // Load saved state from result.complianceReview and result text fields
   useEffect(() => {
@@ -476,226 +480,256 @@ export function OnboardingFreigabePanel({
   const signatoryPowerResult = parseResult(signatoryPowerStep);
 
   return (
-    <div className="flex flex-col gap-2">
-      {/* Title */}
-      <h2 className="text-xl font-bold text-dfxBlue-800 mb-2">GwG Kunden Onboarding</h2>
+    <>
+      <div className="flex flex-col gap-2">
+        {/* Title */}
+        <h2 className="text-xl font-bold text-dfxBlue-800 mb-2">GwG Kunden Onboarding</h2>
 
-      {/* Status */}
-      <div className="flex items-center gap-3 mb-2">
-        <span className="text-sm text-dfxGray-700 font-medium">Status:</span>
-        {statusBadge(step.status)}
-      </div>
+        {/* Status */}
+        <div className="flex items-center gap-3 mb-2">
+          <span className="text-sm text-dfxGray-700 font-medium">Status:</span>
+          {statusBadge(step.status)}
+        </div>
 
-      {/* Section 1: User Data */}
-      <SectionTitle title="User Daten:" />
-      <InfoTable rows={userInfoRows} />
+        {/* Section 1: User Data */}
+        <SectionTitle title="User Daten:" />
+        <InfoTable rows={userInfoRows} />
 
-      {/* Section 3: FinancialData */}
-      {financialDataStep?.result && (
-        <>
-          <SectionTitle title="FinancialData:" />
-          {renderStepResult(financialDataStep.result)}
-        </>
-      )}
+        {/* Section 3: FinancialData */}
+        {financialDataStep?.result && (
+          <>
+            <SectionTitle title="FinancialData:" />
+            {renderStepResult(financialDataStep.result)}
+          </>
+        )}
 
-      {/* Section 4: BeneficialOwners */}
-      {beneficialOwnerStep?.result && (
-        <>
-          <SectionTitle title="BeneficialOwners:" />
-          {renderStepResult(beneficialOwnerStep.result)}
-        </>
-      )}
+        {/* Section 4: BeneficialOwners */}
+        {beneficialOwnerStep?.result && (
+          <>
+            <SectionTitle title="BeneficialOwners:" />
+            {renderStepResult(beneficialOwnerStep.result)}
+          </>
+        )}
 
-      {/* Section 5: Step Results (only Organization) */}
-      {isOrganization && (
-        <>
-          <InfoTable
-            rows={[
-              { label: 'Legal Entity', value: legalEntity || '-' },
-              {
-                label: 'SignatoryPower',
-                value: signatoryPowerResult?.signatoryPower ? String(signatoryPowerResult.signatoryPower) : '-',
-              },
-              {
-                label: 'OperationalActivity',
-                value:
-                  operationalActivityResult?.isOperational != null
-                    ? String(operationalActivityResult.isOperational)
-                    : '-',
-              },
-              {
-                label: 'WebsiteUrl',
-                value: operationalActivityResult?.websiteUrl ? String(operationalActivityResult.websiteUrl) : '-',
-                isLink: !!operationalActivityResult?.websiteUrl,
-                href: operationalActivityResult?.websiteUrl ? String(operationalActivityResult.websiteUrl) : undefined,
-              },
-            ]}
-          />
-        </>
-      )}
-
-      {/* Documents + Decisions + Footer — one table for consistent column alignment */}
-      <table className="w-full mt-4">
-        <colgroup>
-          <col style={{ width: '220px' }} />
-          <col />
-          <col style={{ width: '180px' }} />
-        </colgroup>
-        <tbody>
-          {/* Section 6: Documents */}
-          <DocLink label="Deckblatt" file={deckblatt} onOpenFile={onOpenFile} />
-          <DocLink label="Identifikationsdokument" file={identDoc} onOpenFile={onOpenFile} />
-          <DocLink label="Identifizierungsformular" file={identForm} onOpenFile={onOpenFile} />
-          <DocLink label="Risikoprofil" file={riskProfile} onOpenFile={onOpenFile} />
-          <DocLink label="Formular A oder K" file={formAK} onOpenFile={onOpenFile} />
-          <DocLink label="Name Check DFX" file={nameCheckDfx} onOpenFile={onOpenFile} />
-          <DocLink label="Name Check Dilisense Personal" file={nameCheckPersonal} onOpenFile={onOpenFile} />
-          {isOrganization && (
-            <DocLink label="Name Check Dilisense Business" file={nameCheckBusiness} onOpenFile={onOpenFile} />
-          )}
-          {isOrganization && (
-            <DocLink
-              label="Entscheid zum Handelsregisterauszug:"
-              file={commercialRegisterFile}
-              onOpenFile={onOpenFile}
-              decision={commercialRegisterDecision}
+        {/* Section 5: Step Results (only Organization) */}
+        {isOrganization && (
+          <>
+            <InfoTable
+              rows={[
+                { label: 'Legal Entity', value: legalEntity || '-' },
+                {
+                  label: 'SignatoryPower',
+                  value: signatoryPowerResult?.signatoryPower ? String(signatoryPowerResult.signatoryPower) : '-',
+                },
+                {
+                  label: 'OperationalActivity',
+                  value:
+                    operationalActivityResult?.isOperational != null
+                      ? String(operationalActivityResult.isOperational)
+                      : '-',
+                },
+                {
+                  label: 'WebsiteUrl',
+                  value: operationalActivityResult?.websiteUrl ? String(operationalActivityResult.websiteUrl) : '-',
+                  isLink: !!operationalActivityResult?.websiteUrl,
+                  href: operationalActivityResult?.websiteUrl
+                    ? String(operationalActivityResult.websiteUrl)
+                    : undefined,
+                },
+              ]}
             />
-          )}
-          {isOrganization && (
-            <DocLink
-              label="Entscheid zur Vollmacht:"
-              file={authorityFile}
-              onOpenFile={onOpenFile}
-              decision={authorityDecision}
+          </>
+        )}
+
+        {/* Documents + Decisions + Footer — one table for consistent column alignment */}
+        <table className="w-full mt-4">
+          <colgroup>
+            <col style={{ width: '220px' }} />
+            <col />
+            <col style={{ width: '180px' }} />
+          </colgroup>
+          <tbody>
+            {/* Section 6: Documents */}
+            <DocLink label="Deckblatt" file={deckblatt} onOpenFile={onOpenFile} />
+            <DocLink label="Identifikationsdokument" file={identDoc} onOpenFile={onOpenFile} />
+            <DocLink label="Identifizierungsformular" file={identForm} onOpenFile={onOpenFile} />
+            <DocLink label="Risikoprofil" file={riskProfile} onOpenFile={onOpenFile} />
+            <DocLink label="Formular A oder K" file={formAK} onOpenFile={onOpenFile} />
+            <DocLink label="Name Check DFX" file={nameCheckDfx} onOpenFile={onOpenFile} />
+            <DocLink label="Name Check Dilisense Personal" file={nameCheckPersonal} onOpenFile={onOpenFile} />
+            {isOrganization && (
+              <DocLink label="Name Check Dilisense Business" file={nameCheckBusiness} onOpenFile={onOpenFile} />
+            )}
+            {isOrganization && (
+              <DocLink
+                label="Entscheid zum Handelsregisterauszug:"
+                file={commercialRegisterFile}
+                onOpenFile={onOpenFile}
+                decision={commercialRegisterDecision}
+              />
+            )}
+            {isOrganization && (
+              <DocLink
+                label="Entscheid zur Vollmacht:"
+                file={authorityFile}
+                onOpenFile={onOpenFile}
+                decision={authorityDecision}
+              />
+            )}
+            {isOrganization && !isGmbH && (
+              <DocLink
+                label="Entscheid zum Aktienbuch:"
+                file={stockRegisterFile}
+                onOpenFile={onOpenFile}
+                decision={stockRegisterDecision}
+              />
+            )}
+
+            {/* Onboarding Report PDF */}
+            <DocLink label="Onboarding Report PDF:" file={onboardingReportFile} onOpenFile={onOpenFile} />
+
+            {/* Spacer */}
+            <tr>
+              <td className="py-3" colSpan={3} />
+            </tr>
+
+            {/* Section 7: Decision Fields */}
+            <DropdownField
+              label="Complex organization structure:"
+              value={complexOrgStructure}
+              options={[
+                { value: 'Ja', label: 'Ja' },
+                { value: 'Nein', label: 'Nein' },
+              ]}
+              onChange={setComplexOrgStructure}
             />
-          )}
-          {isOrganization && !isGmbH && (
-            <DocLink
-              label="Entscheid zum Aktienbuch:"
-              file={stockRegisterFile}
-              onOpenFile={onOpenFile}
-              decision={stockRegisterDecision}
+            <DropdownField
+              label='Risiko Einstufung als "Geschäftsbeziehung mit erhöhtem Risiko":'
+              value={highRisk}
+              options={[
+                { value: 'Ja', label: 'Ja' },
+                { value: 'Nein', label: 'Nein' },
+              ]}
+              onChange={setHighRisk}
             />
-          )}
-
-          {/* Onboarding Report PDF */}
-          <DocLink label="Onboarding Report PDF:" file={onboardingReportFile} onOpenFile={onOpenFile} />
-
-          {/* Spacer */}
-          <tr>
-            <td className="py-3" colSpan={3} />
-          </tr>
-
-          {/* Section 7: Decision Fields */}
-          <DropdownField
-            label="Complex organization structure:"
-            value={complexOrgStructure}
-            options={[
-              { value: 'Ja', label: 'Ja' },
-              { value: 'Nein', label: 'Nein' },
-            ]}
-            onChange={setComplexOrgStructure}
-          />
-          <DropdownField
-            label='Risiko Einstufung als "Geschäftsbeziehung mit erhöhtem Risiko":'
-            value={highRisk}
-            options={[
-              { value: 'Ja', label: 'Ja' },
-              { value: 'Nein', label: 'Nein' },
-            ]}
-            onChange={setHighRisk}
-          />
-          <DropdownField
-            label="depositLimit in CHF:"
-            value={depositLimit}
-            options={[
-              { value: '100000', label: "100'000" },
-              { value: '500000', label: '500000' },
-            ]}
-            onChange={setDepositLimit}
-          />
-          <DropdownField
-            label="amlAccountType:"
-            value={amlAccountType}
-            options={[
-              { value: 'operativ tätige Gesellschaft', label: 'operativ tätige Gesellschaft' },
-              { value: 'Sitzgesellschaft', label: 'Sitzgesellschaft' },
-              { value: 'Einzelunternehmen', label: 'Einzelunternehmen' },
-              { value: 'Stiftung', label: 'Stiftung' },
-              { value: 'Verein', label: 'Verein' },
-              { value: 'natural person', label: 'natural person' },
-            ]}
-            onChange={setAmlAccountType}
-          />
-          <TextareaField
-            label="Wenn GmeR:
+            <tr>
+              <td className="py-1 pr-4 text-left text-sm text-dfxBlue-800 w-56 align-top">depositLimit in CHF:</td>
+              <td className="py-1 text-right">
+                {userData.id != null && (
+                  <button
+                    className="px-3 py-1 text-xs text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded transition-colors whitespace-nowrap"
+                    onClick={() => setShowLimitRequestModal(true)}
+                  >
+                    Limit Request
+                  </button>
+                )}
+              </td>
+              <td className="py-1 text-right">
+                <select
+                  className="px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                  value={depositLimit}
+                  onChange={(e) => setDepositLimit(e.target.value)}
+                >
+                  <option value="">—</option>
+                  <option value="100000">100&apos;000</option>
+                  <option value="500000">500000</option>
+                </select>
+              </td>
+            </tr>
+            <DropdownField
+              label="amlAccountType:"
+              value={amlAccountType}
+              options={[
+                { value: 'operativ tätige Gesellschaft', label: 'operativ tätige Gesellschaft' },
+                { value: 'Sitzgesellschaft', label: 'Sitzgesellschaft' },
+                { value: 'Einzelunternehmen', label: 'Einzelunternehmen' },
+                { value: 'Stiftung', label: 'Stiftung' },
+                { value: 'Verein', label: 'Verein' },
+                { value: 'natural person', label: 'natural person' },
+              ]}
+              onChange={setAmlAccountType}
+            />
+            <TextareaField
+              label="Wenn GmeR:
 Kommentar für die Aufnahme"
-            value={commentGmeR}
-            onChange={setCommentGmeR}
-          />
-          <TextareaField
-            label="Wenn Sitzgesellschaft:
+              value={commentGmeR}
+              onChange={setCommentGmeR}
+            />
+            <TextareaField
+              label="Wenn Sitzgesellschaft:
 Gründe für die Verwendung einer Sitzgesellschaften"
-            value={reasonSeatingCompany}
-            onChange={setReasonSeatingCompany}
-          />
-          <TextareaField
-            label="Bei Einzelunternehmen und Organisationen:
+              value={reasonSeatingCompany}
+              onChange={setReasonSeatingCompany}
+            />
+            <TextareaField
+              label="Bei Einzelunternehmen und Organisationen:
 Beschreibung der Geschäftlichen Aktivitäten"
-            value={businessActivities}
-            onChange={setBusinessActivities}
-          />
+              value={businessActivities}
+              onChange={setBusinessActivities}
+            />
 
-          {/* Spacer */}
-          <tr>
-            <td className="py-3" colSpan={3} />
-          </tr>
+            {/* Spacer */}
+            <tr>
+              <td className="py-3" colSpan={3} />
+            </tr>
 
-          {/* Final Decision */}
-          <DropdownField
-            label="Finaler Entscheid:"
-            value={finalDecision}
-            options={[
-              { value: 'Akzeptiert', label: 'Akzeptiert' },
-              { value: 'Abgelehnt', label: 'Abgelehnt' },
-            ]}
-            onChange={(v) => setFinalDecision(v as DecisionValue)}
-          />
+            {/* Final Decision */}
+            <DropdownField
+              label="Finaler Entscheid:"
+              value={finalDecision}
+              options={[
+                { value: 'Akzeptiert', label: 'Akzeptiert' },
+                { value: 'Abgelehnt', label: 'Abgelehnt' },
+              ]}
+              onChange={(v) => setFinalDecision(v as DecisionValue)}
+            />
 
-          {/* Spacer */}
-          <tr>
-            <td className="py-3" colSpan={3} />
-          </tr>
+            {/* Spacer */}
+            <tr>
+              <td className="py-3" colSpan={3} />
+            </tr>
 
-          {/* UTC Date + Processed by */}
-          <tr>
-            <td className="py-1 pr-4 text-left text-sm text-dfxBlue-800">Datum:</td>
-            <td className="py-1 text-left text-sm text-dfxBlue-800" colSpan={2}>
-              {formatDateTime(new Date().toISOString())}
-            </td>
-          </tr>
-          <DropdownField
-            label="Bearbeitet von:"
-            value={processedBy}
-            options={[
-              { value: 'Vesa Rasaj', label: 'Vesa Rasaj' },
-              { value: 'Cyrill Thommen', label: 'Cyrill Thommen' },
-            ]}
-            onChange={setProcessedBy}
-          />
-        </tbody>
-      </table>
+            {/* UTC Date + Processed by */}
+            <tr>
+              <td className="py-1 pr-4 text-left text-sm text-dfxBlue-800">Datum:</td>
+              <td className="py-1 text-left text-sm text-dfxBlue-800" colSpan={2}>
+                {formatDateTime(new Date().toISOString())}
+              </td>
+            </tr>
+            <DropdownField
+              label="Bearbeitet von:"
+              value={processedBy}
+              options={[
+                { value: 'Vesa Rasaj', label: 'Vesa Rasaj' },
+                { value: 'Cyrill Thommen', label: 'Cyrill Thommen' },
+              ]}
+              onChange={setProcessedBy}
+            />
+          </tbody>
+        </table>
 
-      {/* Save */}
-      <div className="mt-4">
-        <button
-          className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
-          onClick={handleSave}
-          disabled={isSaving || !finalDecision || !processedBy}
-        >
-          {isSaving ? 'Speichern...' : 'Speichern'}
-        </button>
+        {/* Save */}
+        <div className="mt-4">
+          <button
+            className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
+            onClick={handleSave}
+            disabled={isSaving || !finalDecision || !processedBy}
+          >
+            {isSaving ? 'Speichern...' : 'Speichern'}
+          </button>
+        </div>
       </div>
-    </div>
+      {userData.id != null && (
+        <LimitRequestModal
+          isOpen={showLimitRequestModal}
+          userDataId={Number(userData.id)}
+          defaultName={[extractField(userData, 'firstname'), extractField(userData, 'surname')]
+            .filter((v) => v !== '-')
+            .join(' ')}
+          onClose={() => setShowLimitRequestModal(false)}
+          onCreated={onLimitRequestCreated}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -1,6 +1,7 @@
-import { Transaction, useTransaction } from '@dfx.swiss/react';
+import { Transaction, TransactionState, useTransaction } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { Fragment, useState } from 'react';
+import { ChargebackModal } from 'src/components/compliance/chargeback-modal';
 import { ConfirmDialog } from 'src/components/confirm-dialog';
 import { BankTxInfo, CryptoInputInfo, TransactionInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { DetailRow, TransactionDetailRows, formatDate, statusBadge } from 'src/util/compliance-helpers';
@@ -42,6 +43,7 @@ export function TransactionsTable({
   const [stoppingTxId, setStoppingTxId] = useState<number>();
   const [stopConfirmTxId, setStopConfirmTxId] = useState<number>();
   const [stopError, setStopError] = useState<string>();
+  const [chargebackTxId, setChargebackTxId] = useState<number>();
 
   async function confirmStop(): Promise<void> {
     const txId = stopConfirmTxId;
@@ -286,15 +288,40 @@ export function TransactionsTable({
                             return (
                               <>
                                 <TransactionDetailRows tx={detail} />
-                                {!tx.isCompleted && tx.type === 'BuyCrypto' && (
+                                {((tx.type === 'BuyCrypto' && !tx.isCompleted) ||
+                                  ([
+                                    TransactionState.FAILED,
+                                    TransactionState.CHECK_PENDING,
+                                    TransactionState.KYC_REQUIRED,
+                                    TransactionState.LIMIT_EXCEEDED,
+                                    TransactionState.UNASSIGNED,
+                                  ].includes(detail.state) &&
+                                    !detail.chargebackAmount)) && (
                                   <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2">
-                                    <button
-                                      className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                                      onClick={() => setStopConfirmTxId(tx.id)}
-                                      disabled={stoppingTxId === tx.id || isStopped}
-                                    >
-                                      {stoppingTxId === tx.id ? 'Stopping...' : isStopped ? 'Stopped' : 'Stop'}
-                                    </button>
+                                    {tx.type === 'BuyCrypto' && !tx.isCompleted && (
+                                      <button
+                                        className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                        onClick={() => setStopConfirmTxId(tx.id)}
+                                        disabled={stoppingTxId === tx.id || isStopped}
+                                      >
+                                        {stoppingTxId === tx.id ? 'Stopping...' : isStopped ? 'Stopped' : 'Stop'}
+                                      </button>
+                                    )}
+                                    {[
+                                      TransactionState.FAILED,
+                                      TransactionState.CHECK_PENDING,
+                                      TransactionState.KYC_REQUIRED,
+                                      TransactionState.LIMIT_EXCEEDED,
+                                      TransactionState.UNASSIGNED,
+                                    ].includes(detail.state) &&
+                                      !detail.chargebackAmount && (
+                                        <button
+                                          className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                          onClick={() => setChargebackTxId(tx.id)}
+                                        >
+                                          Chargeback
+                                        </button>
+                                      )}
                                   </div>
                                 )}
                               </>
@@ -325,6 +352,25 @@ export function TransactionsTable({
         isLoading={stoppingTxId != null}
         onConfirm={confirmStop}
         onCancel={() => setStopConfirmTxId(undefined)}
+      />
+      <ChargebackModal
+        isOpen={chargebackTxId != null}
+        transactionId={chargebackTxId}
+        transactionType={transactions.find((t) => t.id === chargebackTxId)?.type}
+        sourceType={transactions.find((t) => t.id === chargebackTxId)?.sourceType}
+        onClose={() => setChargebackTxId(undefined)}
+        onSuccess={() => {
+          if (chargebackTxId) {
+            const tx = transactions.find((t) => t.id === chargebackTxId);
+            if (tx) {
+              getTransactionByUid(tx.uid).then((detail) => {
+                setTxDetailCache((prev) => new Map(prev).set(tx.uid, detail));
+              });
+            }
+          }
+          setChargebackTxId(undefined);
+          onStopped?.();
+        }}
       />
     </div>
   );

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -1,6 +1,7 @@
 import { Transaction, useTransaction } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { Fragment, useState } from 'react';
+import { ConfirmDialog } from 'src/components/confirm-dialog';
 import { BankTxInfo, CryptoInputInfo, TransactionInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { DetailRow, TransactionDetailRows, formatDate, statusBadge } from 'src/util/compliance-helpers';
 
@@ -15,6 +16,7 @@ interface TransactionsTableProps {
   onExpandBankTx: (id: number | undefined) => void;
   onExpandCryptoInput: (id: number | undefined) => void;
   onExpandTxUid: (uid: string | undefined) => void;
+  onStopped?: () => void;
 }
 
 export function TransactionsTable({
@@ -28,14 +30,39 @@ export function TransactionsTable({
   onExpandBankTx,
   onExpandCryptoInput,
   onExpandTxUid,
+  onStopped,
 }: TransactionsTableProps): JSX.Element {
   const { getTransactionByUid } = useTransaction();
-  const { downloadTransactionPdf } = useCompliance();
+  const { downloadTransactionPdf, stopTransaction } = useCompliance();
   const [txDetailCache, setTxDetailCache] = useState<Map<string, Transaction>>(new Map());
   const [txDetailLoading, setTxDetailLoading] = useState<string>();
   const [txDetailError, setTxDetailError] = useState<string>();
   const [isPdfDownloading, setIsPdfDownloading] = useState(false);
   const [pdfError, setPdfError] = useState<string>();
+  const [stoppingTxId, setStoppingTxId] = useState<number>();
+  const [stopConfirmTxId, setStopConfirmTxId] = useState<number>();
+  const [stopError, setStopError] = useState<string>();
+
+  async function confirmStop(): Promise<void> {
+    const txId = stopConfirmTxId;
+    if (!txId) return;
+    const tx = transactions.find((t) => t.id === txId);
+    setStoppingTxId(txId);
+    setStopError(undefined);
+    try {
+      await stopTransaction(txId);
+      if (tx) {
+        const updatedDetail = await getTransactionByUid(tx.uid);
+        setTxDetailCache((prev) => new Map(prev).set(tx.uid, updatedDetail));
+      }
+      onStopped?.();
+      setStopConfirmTxId(undefined);
+    } catch (e) {
+      setStopError(e instanceof Error ? e.message : 'Stop failed');
+    } finally {
+      setStoppingTxId(undefined);
+    }
+  }
 
   async function handleDownloadPdf(): Promise<void> {
     setIsPdfDownloading(true);
@@ -95,6 +122,7 @@ export function TransactionsTable({
         )}
       </div>
       {pdfError && <p className="text-xs text-primary-red mb-1">{pdfError}</p>}
+      {stopError && <p className="text-xs text-primary-red mb-1">{stopError}</p>}
       <table className="w-full border-collapse">
         <thead className="sticky top-0 bg-dfxGray-300">
           <tr>
@@ -252,7 +280,26 @@ export function TransactionsTable({
                         ) : txDetailError && !txDetailCache.has(tx.uid) ? (
                           <p className="text-primary-red text-sm">{txDetailError}</p>
                         ) : txDetailCache.has(tx.uid) ? (
-                          <TransactionDetailRows tx={txDetailCache.get(tx.uid) as Transaction} />
+                          (() => {
+                            const detail = txDetailCache.get(tx.uid) as Transaction;
+                            const isStopped = (detail.state as string) === 'Stopped';
+                            return (
+                              <>
+                                <TransactionDetailRows tx={detail} />
+                                {!tx.isCompleted && tx.type === 'BuyCrypto' && (
+                                  <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2">
+                                    <button
+                                      className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                      onClick={() => setStopConfirmTxId(tx.id)}
+                                      disabled={stoppingTxId === tx.id || isStopped}
+                                    >
+                                      {stoppingTxId === tx.id ? 'Stopping...' : isStopped ? 'Stopped' : 'Stop'}
+                                    </button>
+                                  </div>
+                                )}
+                              </>
+                            );
+                          })()
                         ) : null}
                       </td>
                     </tr>
@@ -269,6 +316,16 @@ export function TransactionsTable({
           )}
         </tbody>
       </table>
+      <ConfirmDialog
+        isOpen={stopConfirmTxId != null}
+        title="Transaktion stoppen"
+        message="Möchtest du diese Transaktion wirklich stoppen? Nach dem Stopp muss sie manuell weiterbearbeitet werden."
+        confirmLabel="Stop"
+        destructive
+        isLoading={stoppingTxId != null}
+        onConfirm={confirmStop}
+        onCancel={() => setStopConfirmTxId(undefined)}
+      />
     </div>
   );
 }

--- a/src/components/compliance/user-data-panel.tsx
+++ b/src/components/compliance/user-data-panel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { LimitRequestModal } from 'src/components/compliance/limit-request-modal';
 import { formatDate, formatDateTime } from 'src/util/compliance-helpers';
 
 interface UserDataPanelProps {
@@ -6,6 +7,8 @@ interface UserDataPanelProps {
   keyLabel: string;
   valueLabel: string;
   titleLabel: string;
+  userDataId?: number;
+  onLimitRequestCreated?: () => void;
 }
 
 const fieldOrder = [
@@ -87,8 +90,16 @@ function formatValue(key: string, value: unknown): string {
   return value?.toString() || '-';
 }
 
-export function UserDataPanel({ userData, keyLabel, valueLabel, titleLabel }: UserDataPanelProps): JSX.Element {
+export function UserDataPanel({
+  userData,
+  keyLabel,
+  valueLabel,
+  titleLabel,
+  userDataId,
+  onLimitRequestCreated,
+}: UserDataPanelProps): JSX.Element {
   const [showAll, setShowAll] = useState(false);
+  const [showLimitRequestModal, setShowLimitRequestModal] = useState(false);
 
   const allEntries = Object.entries(userData)
     .filter(([key]) => !hiddenFields.includes(key))
@@ -109,71 +120,92 @@ export function UserDataPanel({ userData, keyLabel, valueLabel, titleLabel }: Us
     allEntries.length - allEntries.filter(([key]) => fieldOrder.includes(key) || combinedFields[key]).length;
 
   return (
-    <div>
-      <h2 className="text-dfxGray-700 mb-2">
-        {titleLabel} ({Object.keys(userData).length})
-      </h2>
-      <div className="bg-white rounded-lg shadow-sm">
-        <table className="w-full border-collapse">
-          <thead className="sticky top-0 bg-dfxGray-300">
-            <tr>
-              <th className="px-3 py-2 text-left text-sm font-semibold text-dfxBlue-800">{keyLabel}</th>
-              <th className="px-3 py-2 text-left text-sm font-semibold text-dfxBlue-800">{valueLabel}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {visibleEntries.map(([key, value]) => {
-              const valueString = formatValue(key, value);
-              const secondaryField = combinedFields[key];
+    <>
+      <div>
+        <h2 className="text-dfxGray-700 mb-2">
+          {titleLabel} ({Object.keys(userData).length})
+        </h2>
+        <div className="bg-white rounded-lg shadow-sm">
+          <table className="w-full border-collapse">
+            <thead className="sticky top-0 bg-dfxGray-300">
+              <tr>
+                <th className="px-3 py-2 text-left text-sm font-semibold text-dfxBlue-800">{keyLabel}</th>
+                <th className="px-3 py-2 text-left text-sm font-semibold text-dfxBlue-800">{valueLabel}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleEntries.map(([key, value]) => {
+                const valueString = formatValue(key, value);
+                const secondaryField = combinedFields[key];
 
-              if (secondaryField) {
-                const secondaryValue = userData[secondaryField] || '';
-                const combinedValue = [valueString, secondaryValue].filter(Boolean).join(' ') || '-';
+                if (secondaryField) {
+                  const secondaryValue = userData[secondaryField] || '';
+                  const combinedValue = [valueString, secondaryValue].filter(Boolean).join(' ') || '-';
+                  return (
+                    <tr key={key} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
+                      <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium">
+                        {key} / {secondaryField}
+                      </td>
+                      <td className="px-3 py-2 text-left text-sm text-dfxBlue-800">{combinedValue}</td>
+                    </tr>
+                  );
+                }
+
                 return (
                   <tr key={key} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
-                    <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium">
-                      {key} / {secondaryField}
+                    <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium">{key}</td>
+                    <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 break-all">
+                      {key === 'kycHash' && valueString !== '-' ? (
+                        <a
+                          href={`/kyc?code=${valueString}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
+                        >
+                          {valueString}
+                        </a>
+                      ) : key === 'depositLimit' && userDataId ? (
+                        <div className="flex items-center justify-between gap-2">
+                          <span>{valueString}</span>
+                          <button
+                            className="px-3 py-1 text-xs text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded transition-colors whitespace-nowrap"
+                            onClick={() => setShowLimitRequestModal(true)}
+                          >
+                            Limit Request
+                          </button>
+                        </div>
+                      ) : (
+                        valueString
+                      )}
                     </td>
-                    <td className="px-3 py-2 text-left text-sm text-dfxBlue-800">{combinedValue}</td>
                   </tr>
                 );
-              }
-
-              return (
-                <tr key={key} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
-                  <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium">{key}</td>
-                  <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 break-all">
-                    {key === 'kycHash' && valueString !== '-' ? (
-                      <a
-                        href={`/kyc?code=${valueString}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
-                      >
-                        {valueString}
-                      </a>
-                    ) : (
-                      valueString
-                    )}
+              })}
+              {hiddenCount > 0 && (
+                <tr>
+                  <td colSpan={2} className="px-3 py-2 text-center">
+                    <button
+                      className="text-sm text-dfxBlue-300 hover:text-dfxBlue-800"
+                      onClick={() => setShowAll(!showAll)}
+                    >
+                      {showAll ? `Hide ${hiddenCount} fields` : `Show ${hiddenCount} more fields...`}
+                    </button>
                   </td>
                 </tr>
-              );
-            })}
-            {hiddenCount > 0 && (
-              <tr>
-                <td colSpan={2} className="px-3 py-2 text-center">
-                  <button
-                    className="text-sm text-dfxBlue-300 hover:text-dfxBlue-800"
-                    onClick={() => setShowAll(!showAll)}
-                  >
-                    {showAll ? `Hide ${hiddenCount} fields` : `Show ${hiddenCount} more fields...`}
-                  </button>
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+      {userDataId && (
+        <LimitRequestModal
+          isOpen={showLimitRequestModal}
+          userDataId={userDataId}
+          defaultName={[userData.firstname, userData.surname].filter(Boolean).join(' ') || undefined}
+          onClose={() => setShowLimitRequestModal(false)}
+          onCreated={onLimitRequestCreated}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -1,0 +1,54 @@
+import { StyledButton, StyledButtonColor, StyledButtonWidth } from '@dfx.swiss/react-components';
+import { Modal } from 'src/components/modal';
+import { useSettingsContext } from 'src/contexts/settings.context';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  isLoading?: boolean;
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  isOpen,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  isLoading,
+  destructive,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps): JSX.Element {
+  const { translate } = useSettingsContext();
+
+  return (
+    <Modal isOpen={isOpen} onClose={onCancel}>
+      <div className="bg-white rounded-lg shadow-xl p-6 max-w-md mx-auto w-full">
+        {title && <h2 className="text-lg font-semibold text-dfxBlue-800 mb-3 text-left">{title}</h2>}
+        <p className="text-sm text-dfxBlue-800 mb-6 text-left">{message}</p>
+        <div className="flex gap-2">
+          <StyledButton
+            label={cancelLabel ?? translate('general/actions', 'Cancel')}
+            onClick={onCancel}
+            width={StyledButtonWidth.FULL}
+            color={StyledButtonColor.STURDY_WHITE}
+            disabled={isLoading}
+          />
+          <StyledButton
+            label={confirmLabel ?? translate('general/actions', 'Confirm')}
+            onClick={onConfirm}
+            width={StyledButtonWidth.FULL}
+            color={destructive ? StyledButtonColor.RED : StyledButtonColor.BLUE}
+            isLoading={isLoading}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -35,8 +35,11 @@ export function Modal({ isOpen, onClose, children, className = '' }: ModalProps)
   }
 
   return createPortal(
-    <div className={`fixed inset-0 z-50 bg-white overflow-y-auto p-4 ${className}`}>
-      <div className="flex justify-center min-h-full">
+    <div
+      className={`fixed inset-0 z-50 bg-black/40 overflow-y-auto ${className}`}
+      onClick={(e) => e.target === e.currentTarget && onClose?.()}
+    >
+      <div className="flex min-h-full items-center justify-center p-4">
         <div className="w-full max-w-screen-md flex flex-col">{children}</div>
       </div>
     </div>,

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -35,8 +35,8 @@ export function Modal({ isOpen, onClose, children, className = '' }: ModalProps)
   }
 
   return createPortal(
-    <div className={`absolute inset-0 z-50 bg-white p-4 ${className}`}>
-      <div className="flex flex-grow justify-center bg-white min-h-full">
+    <div className={`fixed inset-0 z-50 bg-white overflow-y-auto p-4 ${className}`}>
+      <div className="flex justify-center min-h-full">
         <div className="w-full max-w-screen-md flex flex-col">{children}</div>
       </div>
     </div>,

--- a/src/components/refund/refund-creditor-fields.tsx
+++ b/src/components/refund/refund-creditor-fields.tsx
@@ -1,4 +1,3 @@
-import { Country } from '@dfx.swiss/react';
 import { StyledHorizontalStack, StyledInput, StyledSearchDropdown } from '@dfx.swiss/react-components';
 import { MutableRefObject } from 'react';
 import { Control, FieldError } from 'react-hook-form';
@@ -107,7 +106,7 @@ export function RefundCreditorFields({
           smallLabel
         />
       </StyledHorizontalStack>
-      <StyledSearchDropdown<Country>
+      <StyledSearchDropdown
         control={control}
         rules={rules?.creditorCountry}
         error={getError('creditorCountry')}

--- a/src/components/refund/refund-creditor-fields.tsx
+++ b/src/components/refund/refund-creditor-fields.tsx
@@ -1,0 +1,128 @@
+import { Country } from '@dfx.swiss/react';
+import { StyledHorizontalStack, StyledInput, StyledSearchDropdown } from '@dfx.swiss/react-components';
+import { MutableRefObject } from 'react';
+import { Control, FieldError } from 'react-hook-form';
+import { useSettingsContext } from 'src/contexts/settings.context';
+
+interface RefundCreditorFieldsProps {
+  readonly rootRef: MutableRefObject<HTMLDivElement | null>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly control: Control<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly rules?: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly errors?: Record<string, any>;
+  readonly showIban?: boolean;
+  readonly showName?: boolean;
+}
+
+export function RefundCreditorFields({
+  rootRef,
+  control,
+  rules,
+  errors,
+  showIban = true,
+  showName = true,
+}: RefundCreditorFieldsProps): JSX.Element {
+  const { translate, translateError, allowedCountries } = useSettingsContext();
+
+  function getError(name: string): FieldError | undefined {
+    const err = errors?.[name] as FieldError | undefined;
+    if (!err?.message) return err;
+    return { ...err, message: translateError(err.message) };
+  }
+
+  return (
+    <>
+      {showIban && (
+        <StyledInput
+          control={control}
+          rules={rules?.iban}
+          error={getError('iban')}
+          name="iban"
+          label={translate('screens/payment', 'Chargeback IBAN')}
+          placeholder="CH..."
+          full
+          smallLabel
+        />
+      )}
+      {showName && (
+        <StyledInput
+          control={control}
+          rules={rules?.creditorName}
+          error={getError('creditorName')}
+          name="creditorName"
+          autocomplete="name"
+          label={translate('screens/kyc', 'Name')}
+          placeholder={translate('screens/kyc', 'John Doe')}
+          full
+          smallLabel
+        />
+      )}
+      <StyledHorizontalStack gap={2}>
+        <StyledInput
+          control={control}
+          rules={rules?.creditorStreet}
+          error={getError('creditorStreet')}
+          name="creditorStreet"
+          autocomplete="street"
+          label={translate('screens/kyc', 'Street')}
+          placeholder={translate('screens/kyc', 'Street')}
+          full
+          smallLabel
+        />
+        <StyledInput
+          control={control}
+          rules={rules?.creditorHouseNumber}
+          error={getError('creditorHouseNumber')}
+          name="creditorHouseNumber"
+          autocomplete="house-number"
+          label={translate('screens/kyc', 'House nr.')}
+          placeholder="xx"
+          small
+          smallLabel
+        />
+      </StyledHorizontalStack>
+      <StyledHorizontalStack gap={2}>
+        <StyledInput
+          control={control}
+          rules={rules?.creditorZip}
+          error={getError('creditorZip')}
+          name="creditorZip"
+          autocomplete="zip"
+          label={translate('screens/kyc', 'ZIP code')}
+          placeholder="12345"
+          small
+          smallLabel
+        />
+        <StyledInput
+          control={control}
+          rules={rules?.creditorCity}
+          error={getError('creditorCity')}
+          name="creditorCity"
+          autocomplete="city"
+          label={translate('screens/kyc', 'City')}
+          placeholder={translate('screens/kyc', 'City')}
+          full
+          smallLabel
+        />
+      </StyledHorizontalStack>
+      <StyledSearchDropdown<Country>
+        control={control}
+        rules={rules?.creditorCountry}
+        error={getError('creditorCountry')}
+        rootRef={rootRef}
+        name="creditorCountry"
+        autocomplete="country"
+        label={translate('screens/kyc', 'Country')}
+        placeholder={translate('general/actions', 'Select') + '...'}
+        items={allowedCountries ?? []}
+        labelFunc={(item) => item.name}
+        filterFunc={(i, s) => !s || [i.name, i.symbol].some((w) => w.toLowerCase().includes(s.toLowerCase()))}
+        matchFunc={(i, s) => i.name.toLowerCase() === s?.toLowerCase()}
+        full
+        smallLabel
+      />
+    </>
+  );
+}

--- a/src/components/refund/refund-data-table.tsx
+++ b/src/components/refund/refund-data-table.tsx
@@ -1,0 +1,75 @@
+import { Utils } from '@dfx.swiss/react';
+import { AlignContent, StyledDataTable, StyledDataTableRow } from '@dfx.swiss/react-components';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { TransactionRefundData } from 'src/hooks/compliance.hook';
+
+interface RefundDataTableProps {
+  readonly refundData: TransactionRefundData;
+}
+
+export function RefundDataTable({ refundData }: RefundDataTableProps): JSX.Element {
+  const { translate } = useSettingsContext();
+
+  return (
+    <StyledDataTable alignContent={AlignContent.RIGHT} showBorder minWidth={false}>
+      <StyledDataTableRow label={translate('screens/payment', 'Transaction amount')}>
+        <p>
+          {refundData.inputAmount} {refundData.inputAsset?.name}
+        </p>
+      </StyledDataTableRow>
+      <StyledDataTableRow label={translate('screens/payment', 'DFX fee')}>
+        <p>
+          {refundData.fee.dfx} {refundData.refundAsset?.name}
+        </p>
+      </StyledDataTableRow>
+      <StyledDataTableRow label={translate('screens/payment', 'Bank fee')}>
+        <p>
+          {refundData.fee.bank} {refundData.refundAsset?.name}
+        </p>
+      </StyledDataTableRow>
+      <StyledDataTableRow label={translate('screens/payment', 'Network fee')}>
+        <p>
+          {refundData.fee.network} {refundData.refundAsset?.name}
+        </p>
+      </StyledDataTableRow>
+      <StyledDataTableRow
+        label={translate('screens/payment', 'Refund amount')}
+        infoText={translate('screens/payment', 'Refund amount is the transaction amount minus the fee.')}
+      >
+        <p>
+          {refundData.refundAmount} {refundData.refundAsset?.name}
+        </p>
+      </StyledDataTableRow>
+      {refundData.bankDetails?.name && (
+        <StyledDataTableRow label={translate('screens/payment', 'Name')}>
+          <p>{refundData.bankDetails.name}</p>
+        </StyledDataTableRow>
+      )}
+      {(refundData.bankDetails?.address || refundData.bankDetails?.houseNumber) && (
+        <StyledDataTableRow label={translate('screens/payment', 'Address')}>
+          <p>{[refundData.bankDetails.address, refundData.bankDetails.houseNumber].filter(Boolean).join(' ')}</p>
+        </StyledDataTableRow>
+      )}
+      {(refundData.bankDetails?.zip || refundData.bankDetails?.city) && (
+        <StyledDataTableRow label={translate('screens/payment', 'City')}>
+          <p>{[refundData.bankDetails.zip, refundData.bankDetails.city].filter(Boolean).join(' ')}</p>
+        </StyledDataTableRow>
+      )}
+      {refundData.bankDetails?.country && (
+        <StyledDataTableRow label={translate('screens/payment', 'Country')}>
+          <p>{refundData.bankDetails.country}</p>
+        </StyledDataTableRow>
+      )}
+      {refundData.bankDetails?.iban && (
+        <StyledDataTableRow label={translate('screens/payment', 'IBAN')}>
+          <p>{Utils.formatIban(refundData.bankDetails.iban) ?? refundData.bankDetails.iban}</p>
+        </StyledDataTableRow>
+      )}
+      {refundData.bankDetails?.bic && (
+        <StyledDataTableRow label={translate('screens/payment', 'BIC')}>
+          <p>{refundData.bankDetails.bic}</p>
+        </StyledDataTableRow>
+      )}
+    </StyledDataTable>
+  );
+}

--- a/src/components/support-issue/limit-request-fields.tsx
+++ b/src/components/support-issue/limit-request-fields.tsx
@@ -1,0 +1,113 @@
+import { FundOrigin, InvestmentDate, Limit } from '@dfx.swiss/react';
+import { StyledDropdown, StyledFileUpload, StyledInput } from '@dfx.swiss/react-components';
+import { MutableRefObject } from 'react';
+import { Control, FieldError } from 'react-hook-form';
+import { DateLabels, LimitLabels, OriginFutureLabels, OriginNowLabels } from 'src/config/labels';
+import { useSettingsContext } from 'src/contexts/settings.context';
+
+interface LimitRequestFieldsProps {
+  rootRef: MutableRefObject<HTMLDivElement | null>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control: Control<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rules?: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors?: Record<string, any>;
+  investmentDate?: InvestmentDate;
+}
+
+export function LimitRequestFields({
+  rootRef,
+  control,
+  rules,
+  errors,
+  investmentDate,
+}: LimitRequestFieldsProps): JSX.Element {
+  const { translate, translateError } = useSettingsContext();
+
+  function getError(name: string): FieldError | undefined {
+    const err = errors?.[name] as FieldError | undefined;
+    if (!err?.message) return err;
+    return { ...err, message: translateError(err.message) };
+  }
+
+  return (
+    <>
+      <StyledInput
+        control={control}
+        rules={rules?.name}
+        error={getError('name')}
+        name="name"
+        autocomplete="name"
+        label={translate('screens/support', 'Name')}
+        placeholder={`${translate('screens/kyc', 'John')} ${translate('screens/kyc', 'Doe')}`}
+        full
+      />
+
+      <StyledDropdown<Limit>
+        control={control}
+        rules={rules?.limit}
+        error={getError('limit')}
+        rootRef={rootRef}
+        label={translate('screens/limit', 'Investment volume')}
+        items={Object.values(Limit).filter((i) => typeof i !== 'string') as number[]}
+        labelFunc={(item) => LimitLabels[item]}
+        name="limit"
+        placeholder={translate('general/actions', 'Select') + '...'}
+        full
+      />
+
+      <StyledDropdown<InvestmentDate>
+        control={control}
+        rules={rules?.investmentDate}
+        error={getError('investmentDate')}
+        rootRef={rootRef}
+        label={translate('screens/limit', 'Investment date')}
+        items={Object.values(InvestmentDate)}
+        labelFunc={(item) => translate('screens/limit', DateLabels[item])}
+        name="investmentDate"
+        placeholder={translate('general/actions', 'Select') + '...'}
+        full
+      />
+
+      <StyledDropdown<FundOrigin>
+        control={control}
+        rules={rules?.fundOrigin}
+        error={getError('fundOrigin')}
+        rootRef={rootRef}
+        label={translate('screens/limit', 'Origin of funds')}
+        items={Object.values(FundOrigin)}
+        labelFunc={(item) =>
+          translate(
+            'screens/limit',
+            investmentDate === InvestmentDate.FUTURE ? OriginFutureLabels[item] : OriginNowLabels[item],
+          )
+        }
+        name="fundOrigin"
+        placeholder={translate('general/actions', 'Select') + '...'}
+        full
+      />
+
+      <StyledInput
+        control={control}
+        rules={rules?.message}
+        error={getError('message')}
+        name="message"
+        label={`${translate('screens/limit', 'Origin of funds')} (${translate('screens/limit', 'free text')})`}
+        multiLine
+        full
+      />
+
+      <StyledFileUpload
+        control={control}
+        rules={rules?.file}
+        error={getError('file')}
+        name="file"
+        label={translate('screens/support', 'File')}
+        placeholder={translate('general/actions', 'Drop files here')}
+        buttonLabel={translate('general/actions', 'Browse')}
+        full
+      />
+    </>
+  );
+}

--- a/src/config/labels.ts
+++ b/src/config/labels.ts
@@ -44,6 +44,7 @@ export const PaymentStateLabels = {
   [TransactionState.LIQUIDITY_PENDING]: 'Liquidity pending',
   [TransactionState.PAYOUT_IN_PROGRESS]: 'Payout in progress',
   [TransactionState.PRICE_UNDETERMINABLE]: 'Price undeterminable',
+  [TransactionState.STOPPED]: 'Stopped',
 };
 
 export function toPaymentStateLabel(state: TransactionState): string {
@@ -171,7 +172,7 @@ export function addressLabel(wallet: UserAddress | Session): string {
   const custodyLabel = 'DFX Safe';
   return ('role' in wallet && wallet.role === UserRole.CUSTODY) || ('isCustody' in wallet && wallet.isCustody)
     ? custodyLabel
-    : wallet.address ?? '';
+    : (wallet.address ?? '');
 }
 
 // --- VERIFICATION CALL --- //
@@ -185,4 +186,3 @@ export const PhoneCallTimeLabels = {
   [PhoneCallTime.H_15_TO_16]: '15:00 - 16:00',
   [PhoneCallTime.H_9_TO_16]: '09:00 - 16:00',
 };
-

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -41,22 +41,6 @@ export interface TransactionRefundData {
   bankDetails?: RefundBankDetails;
 }
 
-export interface BankRefundData {
-  refundTarget: string;
-  name: string;
-  address: string;
-  houseNumber?: string;
-  zip: string;
-  city: string;
-  country: string;
-}
-
-export interface SupportUserInfo {
-  id: number;
-  firstname: string;
-  surname: string;
-}
-
 export interface ChargebackRefundData {
   refundTarget?: string;
   creditorData?: {
@@ -399,13 +383,6 @@ export function useCompliance() {
     });
   }
 
-  async function getSupportUserInfo(): Promise<SupportUserInfo> {
-    return call<SupportUserInfo>({
-      url: 'support/me',
-      method: 'GET',
-    });
-  }
-
   async function getUserData(userDataId: number): Promise<ComplianceUserData> {
     return call<ComplianceUserData>({
       url: `support/${userDataId}`,
@@ -439,14 +416,6 @@ export function useCompliance() {
     return call<TransactionRefundData>({
       url: `support/transaction/${transactionId}/refund`,
       method: 'GET',
-    });
-  }
-
-  async function processTransactionRefund(transactionId: number, data: BankRefundData): Promise<void> {
-    return call<void>({
-      url: `support/transaction/${transactionId}/refund`,
-      method: 'PUT',
-      data,
     });
   }
 
@@ -599,7 +568,7 @@ export function useCompliance() {
 
   async function chargebackTransaction(transactionId: number, data: ChargebackRefundData): Promise<void> {
     return call<void>({
-      url: `support/transaction/${transactionId}/chargeback`,
+      url: `support/transaction/${transactionId}/refund`,
       method: 'PUT',
       data,
     });
@@ -615,13 +584,11 @@ export function useCompliance() {
   return useMemo(
     () => ({
       search,
-      getSupportUserInfo,
       getUserData,
       getPendingOnboardings,
       downloadUserFiles,
       checkUserFiles,
       getTransactionRefundData,
-      processTransactionRefund,
       getKycFileList,
       getKycFileStats,
       getTransactionList,

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -1,4 +1,13 @@
-import { AccountType, Asset, Fiat, KycStatus, ResponseType, useApi } from '@dfx.swiss/react';
+import {
+  AccountType,
+  Asset,
+  Fiat,
+  FundOrigin,
+  InvestmentDate,
+  KycStatus,
+  ResponseType,
+  useApi,
+} from '@dfx.swiss/react';
 import { CustodyOrderListEntry } from 'src/dto/order.dto';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
 import { useMemo } from 'react';
@@ -530,6 +539,38 @@ export function useCompliance() {
     });
   }
 
+  async function createLimitRequest(
+    userDataId: number,
+    data: {
+      name: string;
+      message: string;
+      limit: number;
+      investmentDate: InvestmentDate;
+      fundOrigin: FundOrigin;
+      file?: string;
+      fileName?: string;
+    },
+  ): Promise<void> {
+    return call<void>({
+      url: `support/issue/support?userDataId=${userDataId}`,
+      method: 'POST',
+      data: {
+        type: 'LimitRequest',
+        reason: 'Other',
+        name: data.name,
+        message: data.message,
+        file: data.file,
+        fileName: data.fileName,
+        limitRequest: {
+          limit: data.limit,
+          investmentDate: data.investmentDate,
+          fundOrigin: data.fundOrigin,
+          fundOriginText: data.message,
+        },
+      },
+    });
+  }
+
   return useMemo(
     () => ({
       search,
@@ -550,6 +591,7 @@ export function useCompliance() {
       approveCustodyOrder,
       updateKycStep,
       updateUserData,
+      createLimitRequest,
     }),
     [call],
   );

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -51,6 +51,25 @@ export interface BankRefundData {
   country: string;
 }
 
+export interface SupportUserInfo {
+  id: number;
+  firstname: string;
+  surname: string;
+}
+
+export interface ChargebackRefundData {
+  refundTarget?: string;
+  creditorData?: {
+    name: string;
+    address: string;
+    houseNumber?: string;
+    zip: string;
+    city: string;
+    country: string;
+  };
+  chargebackAmount?: number;
+}
+
 export enum ComplianceSearchType {
   REF = 'Ref',
   KYC_HASH = 'KycHash',
@@ -380,6 +399,13 @@ export function useCompliance() {
     });
   }
 
+  async function getSupportUserInfo(): Promise<SupportUserInfo> {
+    return call<SupportUserInfo>({
+      url: 'support/me',
+      method: 'GET',
+    });
+  }
+
   async function getUserData(userDataId: number): Promise<ComplianceUserData> {
     return call<ComplianceUserData>({
       url: `support/${userDataId}`,
@@ -571,6 +597,14 @@ export function useCompliance() {
     });
   }
 
+  async function chargebackTransaction(transactionId: number, data: ChargebackRefundData): Promise<void> {
+    return call<void>({
+      url: `support/transaction/${transactionId}/chargeback`,
+      method: 'PUT',
+      data,
+    });
+  }
+
   async function stopTransaction(transactionId: number): Promise<void> {
     return call<void>({
       url: `transaction/admin/${transactionId}/stop`,
@@ -581,6 +615,7 @@ export function useCompliance() {
   return useMemo(
     () => ({
       search,
+      getSupportUserInfo,
       getUserData,
       getPendingOnboardings,
       downloadUserFiles,
@@ -599,6 +634,7 @@ export function useCompliance() {
       updateKycStep,
       updateUserData,
       createLimitRequest,
+      chargebackTransaction,
       stopTransaction,
     }),
     [call],

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -571,6 +571,13 @@ export function useCompliance() {
     });
   }
 
+  async function stopTransaction(transactionId: number): Promise<void> {
+    return call<void>({
+      url: `transaction/admin/${transactionId}/stop`,
+      method: 'POST',
+    });
+  }
+
   return useMemo(
     () => ({
       search,
@@ -592,6 +599,7 @@ export function useCompliance() {
       updateKycStep,
       updateUserData,
       createLimitRequest,
+      stopTransaction,
     }),
     [call],
   );

--- a/src/screens/compliance-bank-tx-return.screen.tsx
+++ b/src/screens/compliance-bank-tx-return.screen.tsx
@@ -36,7 +36,7 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
 
   const { id } = useParams<{ id: string }>();
   const { translate, translateError, allowedCountries } = useSettingsContext();
-  const { getTransactionRefundData, processTransactionRefund } = useCompliance();
+  const { getTransactionRefundData, chargebackTransaction } = useCompliance();
   const { goBack } = useNavigation();
   const { rootRef } = useLayoutContext();
 
@@ -93,14 +93,16 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
     setError(undefined);
 
     try {
-      await processTransactionRefund(+id, {
+      await chargebackTransaction(+id, {
         refundTarget: formData.iban,
-        name: formData.creditorName,
-        address: formData.creditorStreet,
-        houseNumber: formData.creditorHouseNumber || undefined,
-        zip: formData.creditorZip,
-        city: formData.creditorCity,
-        country: formData.creditorCountry.symbol,
+        creditorData: {
+          name: formData.creditorName,
+          address: formData.creditorStreet,
+          houseNumber: formData.creditorHouseNumber || undefined,
+          zip: formData.creditorZip,
+          city: formData.creditorCity,
+          country: formData.creditorCountry.symbol,
+        },
       });
       setSuccess(true);
     } catch (e: unknown) {

--- a/src/screens/compliance-bank-tx-return.screen.tsx
+++ b/src/screens/compliance-bank-tx-return.screen.tsx
@@ -1,23 +1,19 @@
 import { Country, Utils, Validations } from '@dfx.swiss/react';
 import {
-  AlignContent,
   Form,
   SpinnerSize,
   StyledButton,
   StyledButtonColor,
   StyledButtonWidth,
-  StyledDataTable,
-  StyledDataTableRow,
-  StyledHorizontalStack,
-  StyledInput,
   StyledLoadingSpinner,
-  StyledSearchDropdown,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
 import { ErrorHint } from 'src/components/error-hint';
+import { RefundCreditorFields } from 'src/components/refund/refund-creditor-fields';
+import { RefundDataTable } from 'src/components/refund/refund-data-table';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { TransactionRefundData, useCompliance } from 'src/hooks/compliance.hook';
@@ -71,10 +67,7 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
       const data = await getTransactionRefundData(transactionId);
       setRefundData(data);
 
-      // Pre-fill form with bank details if available
-      if (data.refundTarget) {
-        setValue('iban', data.refundTarget);
-      }
+      if (data.refundTarget) setValue('iban', data.refundTarget);
       if (data.bankDetails) {
         if (data.bankDetails.name) setValue('creditorName', data.bankDetails.name);
         if (data.bankDetails.address) setValue('creditorStreet', data.bankDetails.address);
@@ -86,8 +79,8 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
           if (country) setValue('creditorCountry', country);
         }
       }
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
       setIsLoading(false);
     }
@@ -110,8 +103,8 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
         country: formData.creditorCountry.symbol,
       });
       setSuccess(true);
-    } catch (e: any) {
-      setError(e.message);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
     } finally {
       setIsSubmitting(false);
     }
@@ -159,66 +152,7 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
 
   return (
     <StyledVerticalStack gap={6} full>
-      <StyledDataTable alignContent={AlignContent.RIGHT} showBorder minWidth={false}>
-        <StyledDataTableRow label={translate('screens/payment', 'Transaction amount')}>
-          <p>
-            {refundData.inputAmount} {refundData.inputAsset?.name}
-          </p>
-        </StyledDataTableRow>
-        <StyledDataTableRow label={translate('screens/payment', 'DFX fee')}>
-          <p>
-            {refundData.fee.dfx} {refundData.refundAsset?.name}
-          </p>
-        </StyledDataTableRow>
-        <StyledDataTableRow label={translate('screens/payment', 'Bank fee')}>
-          <p>
-            {refundData.fee.bank} {refundData.refundAsset?.name}
-          </p>
-        </StyledDataTableRow>
-        <StyledDataTableRow label={translate('screens/payment', 'Network fee')}>
-          <p>
-            {refundData.fee.network} {refundData.refundAsset?.name}
-          </p>
-        </StyledDataTableRow>
-        <StyledDataTableRow
-          label={translate('screens/payment', 'Refund amount')}
-          infoText={translate('screens/payment', 'Refund amount is the transaction amount minus the fee.')}
-        >
-          <p>
-            {refundData.refundAmount} {refundData.refundAsset?.name}
-          </p>
-        </StyledDataTableRow>
-        {refundData.bankDetails?.name && (
-          <StyledDataTableRow label={translate('screens/payment', 'Name')}>
-            <p>{refundData.bankDetails.name}</p>
-          </StyledDataTableRow>
-        )}
-        {(refundData.bankDetails?.address || refundData.bankDetails?.houseNumber) && (
-          <StyledDataTableRow label={translate('screens/payment', 'Address')}>
-            <p>{[refundData.bankDetails.address, refundData.bankDetails.houseNumber].filter(Boolean).join(' ')}</p>
-          </StyledDataTableRow>
-        )}
-        {(refundData.bankDetails?.zip || refundData.bankDetails?.city) && (
-          <StyledDataTableRow label={translate('screens/payment', 'City')}>
-            <p>{[refundData.bankDetails.zip, refundData.bankDetails.city].filter(Boolean).join(' ')}</p>
-          </StyledDataTableRow>
-        )}
-        {refundData.bankDetails?.country && (
-          <StyledDataTableRow label={translate('screens/payment', 'Country')}>
-            <p>{refundData.bankDetails.country}</p>
-          </StyledDataTableRow>
-        )}
-        {refundData.bankDetails?.iban && (
-          <StyledDataTableRow label={translate('screens/payment', 'IBAN')}>
-            <p>{Utils.formatIban(refundData.bankDetails.iban) ?? refundData.bankDetails.iban}</p>
-          </StyledDataTableRow>
-        )}
-        {refundData.bankDetails?.bic && (
-          <StyledDataTableRow label={translate('screens/payment', 'BIC')}>
-            <p>{refundData.bankDetails.bic}</p>
-          </StyledDataTableRow>
-        )}
-      </StyledDataTable>
+      <RefundDataTable refundData={refundData} />
 
       <Form
         control={control}
@@ -228,70 +162,7 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
         translate={translateError}
       >
         <StyledVerticalStack gap={6} full>
-          <StyledInput
-            name="iban"
-            label={translate('screens/payment', 'Chargeback IBAN')}
-            placeholder="CH..."
-            full
-            smallLabel
-          />
-          <StyledInput
-            name="creditorName"
-            autocomplete="name"
-            label={translate('screens/kyc', 'Name')}
-            placeholder={translate('screens/kyc', 'John Doe')}
-            full
-            smallLabel
-          />
-          <StyledHorizontalStack gap={2}>
-            <StyledInput
-              name="creditorStreet"
-              autocomplete="street"
-              label={translate('screens/kyc', 'Street')}
-              placeholder={translate('screens/kyc', 'Street')}
-              full
-              smallLabel
-            />
-            <StyledInput
-              name="creditorHouseNumber"
-              autocomplete="house-number"
-              label={translate('screens/kyc', 'House nr.')}
-              placeholder="xx"
-              small
-              smallLabel
-            />
-          </StyledHorizontalStack>
-          <StyledHorizontalStack gap={2}>
-            <StyledInput
-              name="creditorZip"
-              autocomplete="zip"
-              label={translate('screens/kyc', 'ZIP code')}
-              placeholder="12345"
-              small
-              smallLabel
-            />
-            <StyledInput
-              name="creditorCity"
-              autocomplete="city"
-              label={translate('screens/kyc', 'City')}
-              placeholder={translate('screens/kyc', 'City')}
-              full
-              smallLabel
-            />
-          </StyledHorizontalStack>
-          <StyledSearchDropdown<Country>
-            rootRef={rootRef}
-            name="creditorCountry"
-            autocomplete="country"
-            label={translate('screens/kyc', 'Country')}
-            placeholder={translate('general/actions', 'Select') + '...'}
-            items={allowedCountries}
-            labelFunc={(item) => item.name}
-            filterFunc={(i, s) => !s || [i.name, i.symbol].some((w) => w.toLowerCase().includes(s.toLowerCase()))}
-            matchFunc={(i, s) => i.name.toLowerCase() === s?.toLowerCase()}
-            full
-            smallLabel
-          />
+          <RefundCreditorFields rootRef={rootRef} control={control} rules={rules} errors={errors} />
 
           {error && (
             <div>

--- a/src/screens/compliance-company-onboarding.screen.tsx
+++ b/src/screens/compliance-company-onboarding.screen.tsx
@@ -219,6 +219,7 @@ export default function ComplianceCompanyOnboardingScreen(): JSX.Element {
               onOpenFile={openFile}
               onSave={handleFreigabeSave}
               isSaving={isSaving}
+              onLimitRequestCreated={loadData}
             />
           ) : (
             <OnboardingCheckPanel

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -40,7 +40,6 @@ export default function ComplianceUserScreen(): JSX.Element {
   const { getFile } = useKyc();
   const navigate = useNavigate();
 
-  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [data, setData] = useState<ComplianceUserData>();
   const [preview, setPreview] = useState<{ url: string; contentType: string; name: string }>();
@@ -89,11 +88,9 @@ export default function ComplianceUserScreen(): JSX.Element {
       setError('No ID provided');
       return;
     }
-    setIsLoading(true);
     getUserData(+userDataId)
       .then(setData)
-      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Unknown error'))
-      .finally(() => setIsLoading(false));
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Unknown error'));
   }, [userDataId, getUserData]);
 
   useEffect(() => {
@@ -120,9 +117,9 @@ export default function ComplianceUserScreen(): JSX.Element {
 
   return (
     <>
-      {error ? (
+      {error && !data ? (
         <ErrorHint message={error} />
-      ) : isLoading || !data ? (
+      ) : !data ? (
         <StyledLoadingSpinner size={SpinnerSize.LG} />
       ) : (
         <div className="w-full flex flex-col gap-4">
@@ -192,6 +189,7 @@ export default function ComplianceUserScreen(): JSX.Element {
                   onExpandBankTx={handleExpandBankTx}
                   onExpandCryptoInput={handleExpandCryptoInput}
                   onExpandTxUid={handleExpandTxUid}
+                  onStopped={loadData}
                 />
               )}
 

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -1,6 +1,6 @@
 import { useKyc } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
   BankDatasTable,
@@ -84,21 +84,21 @@ export default function ComplianceUserScreen(): JSX.Element {
     }
   }
 
-  useEffect(() => {
-    let cancelled = false;
-    if (userDataId) {
-      setIsLoading(true);
-      getUserData(+userDataId)
-        .then((d) => !cancelled && setData(d))
-        .catch((e: unknown) => !cancelled && setError(e instanceof Error ? e.message : 'Unknown error'))
-        .finally(() => !cancelled && setIsLoading(false));
-    } else {
+  const loadData = useCallback(() => {
+    if (!userDataId) {
       setError('No ID provided');
+      return;
     }
-    return () => {
-      cancelled = true;
-    };
-  }, [userDataId]);
+    setIsLoading(true);
+    getUserData(+userDataId)
+      .then(setData)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Unknown error'))
+      .finally(() => setIsLoading(false));
+  }, [userDataId, getUserData]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   useEffect(() => {
     return () => preview && URL.revokeObjectURL(preview.url);
@@ -133,6 +133,8 @@ export default function ComplianceUserScreen(): JSX.Element {
               keyLabel={translate('screens/compliance', 'Key')}
               valueLabel={translate('screens/compliance', 'Value')}
               titleLabel={translate('screens/compliance', 'User Data')}
+              userDataId={userDataId ? +userDataId : undefined}
+              onLimitRequestCreated={loadData}
             />
 
             <div className="w-1/3 min-w-[300px] flex flex-col gap-4">

--- a/src/screens/support-issue.screen.tsx
+++ b/src/screens/support-issue.screen.tsx
@@ -34,17 +34,11 @@ import { useForm, useWatch } from 'react-hook-form';
 import { Trans } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 import { AddBankAccount } from 'src/components/payment/add-bank-account';
+import { LimitRequestFields } from 'src/components/support-issue/limit-request-fields';
 import { DefaultFileTypes } from 'src/config/file-types';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { ErrorHint } from '../components/error-hint';
-import {
-  DateLabels,
-  IssueReasonLabels,
-  IssueTypeLabels,
-  LimitLabels,
-  OriginFutureLabels,
-  OriginNowLabels,
-} from '../config/labels';
+import { IssueReasonLabels, IssueTypeLabels } from '../config/labels';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useKycLevelGuard, useUserGuard } from '../hooks/guard.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
@@ -183,7 +177,6 @@ export default function SupportIssueScreen(): JSX.Element {
     navigate({ pathname: `/support/chat/${issueUid}` });
   }
 
-
   useEffect(() => {
     const kycCompleted = user && user.kyc.level >= KycLevel.Completed;
 
@@ -230,7 +223,6 @@ export default function SupportIssueScreen(): JSX.Element {
     setSelectedTxState(undefined);
     setValue('transaction', undefined);
   }, [selectedReason]);
-
 
   useEffect(() => {
     getBanks()
@@ -295,8 +287,7 @@ export default function SupportIssueScreen(): JSX.Element {
     setSelectTransaction(false);
   }
 
-  const isFundsNotReceivedRequest =
-    selectedReason === SupportIssueReason.FUNDS_NOT_RECEIVED && isRequestOnly === true;
+  const isFundsNotReceivedRequest = selectedReason === SupportIssueReason.FUNDS_NOT_RECEIVED && isRequestOnly === true;
 
   const rules = Utils.createRules({
     type: Validations.Required,
@@ -469,71 +460,35 @@ export default function SupportIssueScreen(): JSX.Element {
               </>
             )}
 
-            <StyledInput
-              name="name"
-              autocomplete="name"
-              label={translate('screens/support', 'Name')}
-              placeholder={`${translate('screens/kyc', 'John')} ${translate('screens/kyc', 'Doe')}`}
-              full
-            />
-
-            {selectedType === SupportIssueType.LIMIT_REQUEST && (
+            {selectedType === SupportIssueType.LIMIT_REQUEST ? (
+              <LimitRequestFields
+                rootRef={rootRef}
+                control={control}
+                rules={rules}
+                errors={errors}
+                investmentDate={investmentDate}
+              />
+            ) : (
               <>
-                <StyledDropdown<Limit>
-                  rootRef={rootRef}
-                  label={translate('screens/limit', 'Investment volume')}
-                  items={Object.values(Limit).filter((i) => typeof i !== 'string') as number[]}
-                  labelFunc={(item) => LimitLabels[item]}
-                  name="limit"
-                  placeholder={translate('general/actions', 'Select') + '...'}
+                <StyledInput
+                  name="name"
+                  autocomplete="name"
+                  label={translate('screens/support', 'Name')}
+                  placeholder={`${translate('screens/kyc', 'John')} ${translate('screens/kyc', 'Doe')}`}
                   full
                 />
 
-                <StyledDropdown<InvestmentDate>
-                  rootRef={rootRef}
-                  label={translate('screens/limit', 'Investment date')}
-                  items={Object.values(InvestmentDate)}
-                  labelFunc={(item) => translate('screens/limit', DateLabels[item])}
-                  name="investmentDate"
-                  placeholder={translate('general/actions', 'Select') + '...'}
-                  full
-                />
+                <StyledInput name="message" label={translate('screens/support', 'Description')} multiLine full />
 
-                <StyledDropdown<FundOrigin>
-                  rootRef={rootRef}
-                  label={translate('screens/limit', 'Origin of funds')}
-                  items={Object.values(FundOrigin)}
-                  labelFunc={(item) =>
-                    translate(
-                      'screens/limit',
-                      investmentDate === InvestmentDate.FUTURE ? OriginFutureLabels[item] : OriginNowLabels[item],
-                    )
-                  }
-                  name="fundOrigin"
-                  placeholder={translate('general/actions', 'Select') + '...'}
+                <StyledFileUpload
+                  name="file"
+                  label={translate('screens/support', 'File')}
+                  placeholder={translate('general/actions', 'Drop files here')}
+                  buttonLabel={translate('general/actions', 'Browse')}
                   full
                 />
               </>
             )}
-
-            <StyledInput
-              name="message"
-              label={
-                selectedType === SupportIssueType.LIMIT_REQUEST
-                  ? `${translate('screens/limit', 'Origin of funds')} (${translate('screens/limit', 'free text')})`
-                  : translate('screens/support', 'Description')
-              }
-              multiLine
-              full
-            />
-
-            <StyledFileUpload
-              name="file"
-              label={translate('screens/support', 'File')}
-              placeholder={translate('general/actions', 'Drop files here')}
-              buttonLabel={translate('general/actions', 'Browse')}
-              full
-            />
 
             {error && (
               <div>


### PR DESCRIPTION
## Summary
- **Onboarding cleanup** (`9080619`, `06e78f1`): remove the "Login Kundenkonto" row from the onboarding header and use fixed positioning for the modal overlay.
- **Limit Request UI** (`5b6c089`, `19244f6`, `9a8f301`): add `createLimitRequest` to the compliance hook, extract `LimitRequestFields` for reuse, and add a "Limit Request" button in compliance onboarding.
- **Stop transaction button** (`a4d112d`): add a stop-transaction button with confirm dialog in the compliance transactions tab, calling the new `POST /transaction/admin/:id/stop` endpoint.
- **Chargeback flow** (`88950a0`): add a chargeback modal in the compliance transactions tab that calls `PUT /support/transaction/:id/chargeback` to release a refund. Extract reusable refund components (creditor fields, data table) and refactor `compliance-bank-tx-return` to use them. Add the new `STOPPED` payment state label and a `getSupportUserInfo` hook.
- **Package bump** (`4d8a711`): bump `@dfx.swiss/react` and `@dfx.swiss/react-components` to `1.3.0-beta.268` (includes the new `TransactionState.STOPPED`).

## Companion PRs
- api: linked separately
- packages: DFXswiss/packages#145

## Test plan
- [ ] `npm run lint` ✅
- [ ] `npm test` ✅ (26 suites, 276 tests passing)
- [ ] Manual: open compliance transactions tab → "Stop transaction" button shows confirm dialog and on confirm marks the transaction as Stopped.
- [ ] Manual: open compliance transactions tab → "Chargeback" modal allows entering creditor data and submits to the chargeback endpoint for BuyCrypto, BuyFiat and unassigned BankTx.
- [ ] Manual: compliance onboarding → "Limit Request" button creates a support issue routed to COMPLIANCE.
- [ ] Manual: bank-tx-return screen still works after refactor (uses extracted refund components).