### PR TITLE
fix: display verifiedName in company onboarding review

### DIFF
--- a/src/components/compliance/onboarding-check-configs.ts
+++ b/src/components/compliance/onboarding-check-configs.ts
@@ -19,6 +19,7 @@ export interface CheckItemConfig {
   fileType?: string;
   href?: string;
   condition?: (checks: Record<string, string>) => boolean;
+  visibleCondition?: (userData: Record<string, unknown>) => boolean;
 }
 
 export interface OnboardingTabConfig {
@@ -47,6 +48,15 @@ export const onboardingTabs: OnboardingTabConfig[] = [
     ],
     checkItems: [
       { id: 'nameMatch', label: 'Das Dokument lautet auf den Namen "{organizationName}"' },
+      {
+        id: 'verifiedNameMatch',
+        label:
+          'Der verifizierte Name des Kunden "{verifiedName}" stimmt mit dem Unternehmensnamen "{organizationName}" überein',
+        visibleCondition: (userData) => {
+          const v = userData['verifiedName'];
+          return typeof v === 'string' && v.trim().length > 0;
+        },
+      },
       {
         id: 'legalEntityMatch',
         label: 'Das Unternehmen ist gemäss Onboarding eine "{legalEntity}"',
@@ -191,7 +201,12 @@ export const onboardingTabs: OnboardingTabConfig[] = [
     decisionLabel: 'Entscheid:',
     rejectionReasons: [],
     checkItems: [
-      { id: 'aktennotiz', label: 'Aktennotiz erstellen', type: 'link', href: '/kyc/log?userDataId={id}&eventDate={today}' },
+      {
+        id: 'aktennotiz',
+        label: 'Aktennotiz erstellen',
+        type: 'link',
+        href: '/kyc/log?userDataId={id}&eventDate={today}',
+      },
     ],
   },
   {

--- a/src/components/compliance/onboarding-check-panel.tsx
+++ b/src/components/compliance/onboarding-check-panel.tsx
@@ -228,100 +228,101 @@ export function OnboardingCheckPanel({
       )}
 
       {/* Checklist */}
-      {checkItems.length > 0 && <div>
-        <h3 className="text-dfxGray-700 mb-2 font-semibold text-sm">Checks</h3>
-        <div className="bg-white rounded-lg shadow-sm">
-          {checkItems.map((item) => {
-            if (item.type === 'conditional' && item.condition && !item.condition(checks)) return null;
+      {checkItems.length > 0 && (
+        <div>
+          <h3 className="text-dfxGray-700 mb-2 font-semibold text-sm">Checks</h3>
+          <div className="bg-white rounded-lg shadow-sm">
+            {checkItems.map((item) => {
+              if (item.visibleCondition && !item.visibleCondition(userData)) return null;
+              if (item.type === 'conditional' && item.condition && !item.condition(checks)) return null;
 
-            if (item.type === 'link' && item.href) {
-              const resolvedHref = resolveLabel(item.href, { ...userData, today: todayAsString() });
-              return (
-                <div
-                  key={item.id}
-                  className="flex items-center justify-between px-3 py-2 border-b border-dfxGray-300 last:border-0"
-                >
-                  <a
-                    href={resolvedHref}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-dfxBlue-300 underline hover:text-dfxBlue-800 transition-colors"
+              if (item.type === 'link' && item.href) {
+                const resolvedHref = resolveLabel(item.href, { ...userData, today: todayAsString() });
+                return (
+                  <div
+                    key={item.id}
+                    className="flex items-center justify-between px-3 py-2 border-b border-dfxGray-300 last:border-0"
                   >
-                    {item.label}
-                  </a>
-                </div>
-              );
-            }
-
-            if (item.type === 'fileLink') {
-              const linkedFile = allFiles.find((f) => f.type === item.fileType);
-              return (
-                <div
-                  key={item.id}
-                  className="flex items-center justify-between px-3 py-2 border-b border-dfxGray-300 last:border-0"
-                >
-                  {linkedFile ? (
-                    <button
+                    <a
+                      href={resolvedHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
                       className="text-sm text-dfxBlue-300 underline hover:text-dfxBlue-800 transition-colors"
-                      onClick={() => onOpenFile(linkedFile)}
                     >
                       {item.label}
-                    </button>
-                  ) : (
-                    <span className="text-sm text-dfxGray-700">{item.label} (nicht vorhanden)</span>
-                  )}
-                </div>
-              );
-            }
+                    </a>
+                  </div>
+                );
+              }
 
-            if (item.type === 'select' && item.options) {
+              if (item.type === 'fileLink') {
+                const linkedFile = allFiles.find((f) => f.type === item.fileType);
+                return (
+                  <div
+                    key={item.id}
+                    className="flex items-center justify-between px-3 py-2 border-b border-dfxGray-300 last:border-0"
+                  >
+                    {linkedFile ? (
+                      <button
+                        className="text-sm text-dfxBlue-300 underline hover:text-dfxBlue-800 transition-colors"
+                        onClick={() => onOpenFile(linkedFile)}
+                      >
+                        {item.label}
+                      </button>
+                    ) : (
+                      <span className="text-sm text-dfxGray-700">{item.label} (nicht vorhanden)</span>
+                    )}
+                  </div>
+                );
+              }
+
+              if (item.type === 'select' && item.options) {
+                return (
+                  <div
+                    key={item.id}
+                    className="flex items-center justify-between px-3 py-2 border-b border-dfxGray-300 last:border-0"
+                  >
+                    <span className="text-sm text-dfxBlue-800">{resolveLabel(item.label, userData)}</span>
+                    <select
+                      className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                      value={checks[item.id] ?? ''}
+                      onChange={(e) => setChecks((prev) => ({ ...prev, [item.id]: e.target.value }))}
+                    >
+                      <option value="">—</option>
+                      {item.options.map((opt) => (
+                        <option key={opt} value={opt}>
+                          {opt}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                );
+              }
+
+              const displayLabel =
+                item.altLabel && item.altCondition?.(userData) ? item.altLabel : resolveLabel(item.label, userData);
+
               return (
                 <div
                   key={item.id}
                   className="flex items-center justify-between px-3 py-2 border-b border-dfxGray-300 last:border-0"
                 >
-                  <span className="text-sm text-dfxBlue-800">{resolveLabel(item.label, userData)}</span>
+                  <span className="text-sm text-dfxBlue-800">{displayLabel}</span>
                   <select
                     className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
                     value={checks[item.id] ?? ''}
                     onChange={(e) => setChecks((prev) => ({ ...prev, [item.id]: e.target.value }))}
                   >
                     <option value="">—</option>
-                    {item.options.map((opt) => (
-                      <option key={opt} value={opt}>
-                        {opt}
-                      </option>
-                    ))}
+                    <option value="Yes">Ja</option>
+                    <option value="No">Nein</option>
                   </select>
                 </div>
               );
-            }
-
-            const displayLabel =
-              item.altLabel && item.altCondition?.(userData)
-                ? item.altLabel
-                : resolveLabel(item.label, userData);
-
-            return (
-              <div
-                key={item.id}
-                className="flex items-center justify-between px-3 py-2 border-b border-dfxGray-300 last:border-0"
-              >
-                <span className="text-sm text-dfxBlue-800">{displayLabel}</span>
-                <select
-                  className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
-                  value={checks[item.id] ?? ''}
-                  onChange={(e) => setChecks((prev) => ({ ...prev, [item.id]: e.target.value }))}
-                >
-                  <option value="">—</option>
-                  <option value="Yes">Ja</option>
-                  <option value="No">Nein</option>
-                </select>
-              </div>
-            );
-          })}
+            })}
+          </div>
         </div>
-      </div>}
+      )}
 
       {/* Decision */}
       <div className="bg-white rounded-lg shadow-sm px-3 py-3">

--- a/src/components/compliance/onboarding-company-header.tsx
+++ b/src/components/compliance/onboarding-company-header.tsx
@@ -59,9 +59,7 @@ function extractLegalEntityFromStep(kycSteps: KycStepInfo[], accountType: string
 }
 
 function extractStepCreatedDate(kycSteps: KycStepInfo[]): string {
-  const step = kycSteps
-    .filter((s) => s.name === 'LegalEntity')
-    .sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
+  const step = kycSteps.filter((s) => s.name === 'LegalEntity').sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
 
   if (!step) return '-';
   return new Date(step.created).toLocaleDateString('de-CH');
@@ -78,6 +76,7 @@ export function OnboardingCompanyHeader({ userData, kycSteps }: OnboardingCompan
     { label: 'UserDataId', value: extractField(userData, 'id') },
     { label: 'Organization', value: extractField(userData, 'organizationName') },
     { label: 'Account Type', value: accountType },
+    { label: 'Verified Name', value: extractField(userData, 'verifiedName') },
     { label: 'Legal Entity', value: extractLegalEntityFromStep(kycSteps, accountType) },
     { label: 'Adresse', value: buildAddress(userData) },
     { label: 'Ansprechsperson', value: contactName },


### PR DESCRIPTION
## Summary
- Add `Verified Name` field to the company onboarding review header (shown directly below `Account Type`)
- Add a new check in the Handelsregisterauszug tab that verifies the customer's verified name matches the organization name
- The new check is only shown when `userData.verifiedName` is already set; when unset, the check is hidden

## Test plan
- [ ] Open Compliance → Company Onboarding Review for a userData with `verifiedName` set → "Verified Name" row appears below "Account Type"
- [ ] Open the Handelsregisterauszug tab → the check "Der verifizierte Name des Kunden ... stimmt mit dem Unternehmensnamen ... überein" is shown
- [ ] Open Compliance → Company Onboarding Review for a userData without `verifiedName` → check is hidden, header still renders "-"