### PR TITLE
Fix critical protobufjs vulnerability via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28626,9 +28626,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
       "form-data": "^2.5.5"
     },
     "@coinbase/wallet-sdk": "3.9.3",
-    "axios": "^1.15.0"
+    "axios": "^1.15.0",
+    "protobufjs": "^7.5.5"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- Add `protobufjs: ^7.5.5` to npm overrides to resolve 7 critical vulnerabilities
- Root cause: `@trezor/protobuf` depends on `protobufjs@7.4.0` which is vulnerable to [arbitrary code execution (GHSA-xq3m-2v4x-88gg)](https://github.com/advisories/GHSA-xq3m-2v4x-88gg)
- The vulnerable version propagates through the entire `@trezor/*` dependency chain (`@trezor/protobuf` → `@trezor/transport` → `@trezor/connect` → `@trezor/connect-web`)
- An npm override is the least invasive fix since `@trezor/connect-web` hasn't released a patched version yet

## Test plan
- [ ] Verify `npm audit` reports 0 critical vulnerabilities
- [ ] Verify Trezor wallet connection still works