### PR TITLE
Run PR review bot on PRs targeting main

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -2,6 +2,9 @@ name: PR Review Bot
 
 on:
   pull_request:
+    branches:
+      - main
+      - develop
     types: [opened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Summary
- Add explicit `branches: [main, develop]` filter to `pr-review-bot.yml`
- The review bot (security audit, ESLint, TypeScript check, commit verification) was not running on release PRs (`develop → main`), e.g. #1054
- This ensures the security audit also catches vulnerabilities before production releases

## Test plan
- [ ] Verify review bot runs on next release PR (`develop → main`)