### PR TITLE
feat: support dashboard state refactor, configurable clerks, layout fixes

### DIFF
--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -102,7 +102,7 @@ export function useSupportDashboard() {
 
   async function getIssueList(params?: {
     department?: string;
-    state?: string;
+    states?: string;
     type?: string;
     take?: number;
     skip?: number;
@@ -115,6 +115,20 @@ export function useSupportDashboard() {
 
     return call<{ data: SupportIssueListItem[]; total: number }>({
       url: `support/issue/list${queryString}`,
+      method: 'GET',
+    });
+  }
+
+  async function getIssueCounts(): Promise<Record<string, number>> {
+    return call<Record<string, number>>({
+      url: 'support/issue/counts',
+      method: 'GET',
+    });
+  }
+
+  async function getClerks(): Promise<string[]> {
+    return call<string[]>({
+      url: 'support/issue/clerks',
       method: 'GET',
     });
   }
@@ -198,6 +212,8 @@ export function useSupportDashboard() {
   return useMemo(
     () => ({
       getIssueList,
+      getIssueCounts,
+      getClerks,
       getIssueData,
       updateIssue,
       sendMessage,

--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -126,6 +126,14 @@ export function useSupportDashboard() {
     });
   }
 
+  async function getIssueActivity(since?: Date): Promise<{ count: number; latestAt?: string }> {
+    const query = since ? `?since=${encodeURIComponent(since.toISOString())}` : '';
+    return call<{ count: number; latestAt?: string }>({
+      url: `support/issue/activity${query}`,
+      method: 'GET',
+    });
+  }
+
   async function getClerks(): Promise<string[]> {
     return call<string[]>({
       url: 'support/issue/clerks',
@@ -213,6 +221,7 @@ export function useSupportDashboard() {
     () => ({
       getIssueList,
       getIssueCounts,
+      getIssueActivity,
       getClerks,
       getIssueData,
       updateIssue,

--- a/src/index.css
+++ b/src/index.css
@@ -72,16 +72,20 @@ input[type='number'] {
 @tailwind components;
 @tailwind utilities;
 
-/* Scroll shadow — bottom only, visible when content overflows */
+/* Scroll shadow — top + bottom, each visible only when content overflows in that direction */
 .scroll-shadow {
   background:
+    linear-gradient(white 30%, transparent) center top,
     linear-gradient(transparent, white 70%) center bottom,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.12), transparent) center top,
     radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.12), transparent) center bottom;
   background-repeat: no-repeat;
   background-size:
     100% 40px,
+    100% 40px,
+    100% 10px,
     100% 10px;
-  background-attachment: local, scroll;
+  background-attachment: local, local, scroll, scroll;
 }
 
 /* Shadow DOM Animation */

--- a/src/screens/support-dashboard-create.screen.tsx
+++ b/src/screens/support-dashboard-create.screen.tsx
@@ -1,13 +1,14 @@
-import { SupportIssueReason, SupportIssueType, useAuthContext, useUserContext } from '@dfx.swiss/react';
+import { SupportIssueReason, SupportIssueType } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { toBase64 } from 'src/util/utils';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { ASSIGNABLE_DEPARTMENTS, UserSearchResult, useSupportDashboard } from 'src/hooks/support-dashboard.hook';
+import { reasonLabel, typeLabel } from 'src/util/support-helpers';
+import { toBase64 } from 'src/util/utils';
 
 const ISSUE_TYPES = Object.values(SupportIssueType);
 const ISSUE_REASONS = Object.values(SupportIssueReason);
@@ -16,10 +17,10 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
   useSupportDashboardGuard();
 
   const { translate } = useSettingsContext();
-  const { session } = useAuthContext();
-  const { user } = useUserContext();
-  const { createIssue, searchUsers } = useSupportDashboard();
+  const { createIssue, searchUsers, getClerks } = useSupportDashboard();
   const { navigate } = useNavigation();
+
+  const [clerks, setClerks] = useState<string[]>([]);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string>();
@@ -38,6 +39,16 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
   const [reason, setReason] = useState<string>(ISSUE_REASONS[0]);
   const [name, setName] = useState('');
   const [department, setDepartment] = useState<string>(ASSIGNABLE_DEPARTMENTS[0]);
+  const [clerk, setClerk] = useState<string>('');
+
+  useEffect(() => {
+    getClerks()
+      .then((list) => {
+        setClerks(list);
+        setClerk((prev) => prev || list[0] || '');
+      })
+      .catch(() => undefined);
+  }, [getClerks]);
   const [message, setMessage] = useState('');
   const [selectedFile, setSelectedFile] = useState<File>();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -106,14 +117,13 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
     setError(undefined);
 
     try {
-      const author = user?.mail ?? session?.address ?? 'Support';
       const fileData = selectedFile ? await toBase64(selectedFile) : undefined;
       await createIssue(selectedUser.id, {
         type,
         reason,
         name: name.trim(),
         department,
-        author,
+        author: clerk,
         message: message.trim(),
         file: fileData ?? undefined,
         fileName: selectedFile?.name,
@@ -209,7 +219,7 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
           >
             {ISSUE_TYPES.map((t) => (
               <option key={t} value={t}>
-                {t}
+                {translate('screens/support', typeLabel(t))}
               </option>
             ))}
           </select>
@@ -223,7 +233,7 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
           >
             {ISSUE_REASONS.map((r) => (
               <option key={r} value={r}>
-                {r}
+                {translate('screens/support', reasonLabel(r))}
               </option>
             ))}
           </select>
@@ -249,6 +259,20 @@ export default function SupportDashboardCreateScreen(): JSX.Element {
             {ASSIGNABLE_DEPARTMENTS.map((d) => (
               <option key={d} value={d}>
                 {d}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <FormField label="Clerk">
+          <select
+            className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={clerk}
+            onChange={(e) => setClerk(e.target.value)}
+          >
+            {clerks.map((c) => (
+              <option key={c} value={c}>
+                {c}
               </option>
             ))}
           </select>

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -1,7 +1,6 @@
-import { Department, SupportIssueInternalState, useAuthContext, useUserContext } from '@dfx.swiss/react';
+import { Department, SupportIssueInternalState, useAuthContext, UserRole } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { toBase64 } from 'src/util/utils';
 import { useParams } from 'react-router-dom';
 import { FilePreviewPanel } from 'src/components/compliance/file-preview-panel';
 import { ErrorHint } from 'src/components/error-hint';
@@ -17,6 +16,8 @@ import {
   useSupportDashboard,
 } from 'src/hooks/support-dashboard.hook';
 import { formatDateTime, statusBadge } from 'src/util/compliance-helpers';
+import { reasonLabel, typeLabel } from 'src/util/support-helpers';
+import { toBase64 } from 'src/util/utils';
 
 export default function SupportDashboardIssueScreen(): JSX.Element {
   useSupportDashboardGuard();
@@ -24,8 +25,8 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
   const { id } = useParams();
   const { translate } = useSettingsContext();
   const { session } = useAuthContext();
-  const { user } = useUserContext();
-  const { getIssueData, updateIssue, sendMessage, getIssueMessages, getMessageFile } = useSupportDashboard();
+  const canAccessCompliance = session?.role === UserRole.ADMIN || session?.role === UserRole.COMPLIANCE;
+  const { getIssueData, updateIssue, sendMessage, getIssueMessages, getMessageFile, getClerks } = useSupportDashboard();
   const { navigate } = useNavigation();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -33,6 +34,9 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
   const [actionError, setActionError] = useState<string>();
   const [issueData, setIssueData] = useState<SupportIssueInternalData>();
   const [messages, setMessages] = useState<SupportMessageInfo[]>([]);
+  const [pendingCount, setPendingCount] = useState(0);
+  const visibleIdsRef = useRef<Set<number>>(new Set());
+  const [clerks, setClerks] = useState<string[]>([]);
 
   // Update form state
   const [updateState, setUpdateState] = useState('');
@@ -42,9 +46,10 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
 
   // Message form state
   const [messageText, setMessageText] = useState('');
+  const [messageAuthor, setMessageAuthor] = useState<string>('');
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [isSending, setIsSending] = useState(false);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // File preview state
@@ -56,6 +61,15 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
 
   useLayoutOptions({ title: translate('screens/support', 'Support Issue'), backButton: true, noMaxWidth: true });
 
+  useEffect(() => {
+    getClerks()
+      .then((list) => {
+        setClerks(list);
+        setMessageAuthor((prev) => prev || list[0] || '');
+      })
+      .catch(() => undefined);
+  }, [getClerks]);
+
   const loadIssue = useCallback((): void => {
     if (!id) return;
     setIsLoading(true);
@@ -65,15 +79,29 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
         setUpdateState(data.state);
         setUpdateDepartment(data.department ?? '');
         setUpdateClerk(data.clerk ?? '');
+        setMessageAuthor((prev) => (data.clerk && clerks.includes(data.clerk) ? data.clerk : prev || clerks[0] || ''));
       })
       .catch((e: Error) => setLoadError(e.message ?? 'Unknown error'))
       .finally(() => setIsLoading(false));
-  }, [id, getIssueData]);
+  }, [id, getIssueData, clerks]);
 
   const loadMessages = useCallback((): void => {
     if (!issueData?.uid) return;
     getIssueMessages(issueData.uid)
-      .then(setMessages)
+      .then((fetched) => {
+        setMessages(fetched);
+        setPendingCount(0);
+      })
+      .catch((e: Error) => setActionError(e.message ?? 'Failed to load messages'));
+  }, [issueData?.uid, getIssueMessages]);
+
+  const pollForNewMessages = useCallback((): void => {
+    if (!issueData?.uid) return;
+    getIssueMessages(issueData.uid)
+      .then((fetched) => {
+        const newCount = fetched.filter((m) => !visibleIdsRef.current.has(m.id)).length;
+        if (newCount > 0) setPendingCount(newCount);
+      })
       .catch((e: Error) => setActionError(e.message ?? 'Failed to load messages'));
   }, [issueData?.uid, getIssueMessages]);
 
@@ -85,15 +113,21 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
     loadMessages();
   }, [loadMessages]);
 
-  // Polling for new messages
+  // Track visible message IDs for polling delta
   useEffect(() => {
-    const interval = setInterval(loadMessages, 15000);
-    return () => clearInterval(interval);
-  }, [loadMessages]);
+    visibleIdsRef.current = new Set(messages.map((m) => m.id));
+  }, [messages]);
 
-  // Scroll to bottom when new messages arrive
+  // Polling for new messages (non-intrusive, sets pendingCount)
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const interval = setInterval(() => pollForNewMessages(), 15000);
+    return () => clearInterval(interval);
+  }, [pollForNewMessages]);
+
+  // Scroll messages container to bottom when messages change (initial load, send, manual reload)
+  useEffect(() => {
+    const el = messagesContainerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
   }, [messages]);
 
   async function handleUpdate(): Promise<void> {
@@ -119,7 +153,7 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
     setIsSending(true);
     setActionError(undefined);
     try {
-      const author = user?.mail ?? session?.address ?? 'Support';
+      const author = messageAuthor;
       const text = messageText.trim() || undefined;
 
       if (selectedFiles.length > 0) {
@@ -207,15 +241,29 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
           <InfoPanel title="Issue Details">
             <InfoRow label="UID" value={issueData.uid} mono />
             <InfoRow label="Name" value={issueData.name} />
-            <InfoRow label="Type" value={issueData.type} />
-            <InfoRow label="Reason" value={issueData.reason} />
+            <InfoRow label="Type" value={translate('screens/support', typeLabel(issueData.type))} />
+            <InfoRow label="Reason" value={translate('screens/support', reasonLabel(issueData.reason))} />
             <InfoRow label="State" value={statusBadge(issueData.state)} />
             <InfoRow label="Department" value={issueData.department ?? '-'} />
             <InfoRow label="Created" value={formatDateTime(issueData.created)} />
           </InfoPanel>
 
           <InfoPanel title="Account Data">
-            <InfoRow label="UserData ID" value={String(issueData.account.id)} />
+            <InfoRow
+              label="UserData ID"
+              value={
+                canAccessCompliance ? (
+                  <button
+                    className="text-dfxBlue-400 underline hover:text-dfxBlue-800"
+                    onClick={() => navigate(`/compliance/user/${issueData.account.id}`)}
+                  >
+                    {issueData.account.id}
+                  </button>
+                ) : (
+                  String(issueData.account.id)
+                )
+              }
+            />
             <InfoRow label="Status" value={statusBadge(issueData.account.status)} />
             <InfoRow label="Verified Name" value={issueData.account.verifiedName ?? '-'} />
             <InfoRow label="DFX Name" value={issueData.account.completeName ?? '-'} />
@@ -335,7 +383,7 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
                 value={updateDepartment}
                 onChange={(e) => setUpdateDepartment(e.target.value)}
               >
-                <option value="">-</option>
+                {!issueData?.department && <option value="">-</option>}
                 {ASSIGNABLE_DEPARTMENTS.map((d) => (
                   <option key={d} value={d}>
                     {d}
@@ -345,12 +393,18 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
             </div>
             <div className="flex flex-col gap-1">
               <label className="text-xs text-dfxGray-700">Clerk</label>
-              <input
+              <select
                 className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
                 value={updateClerk}
                 onChange={(e) => setUpdateClerk(e.target.value)}
-                placeholder="Clerk name"
-              />
+              >
+                {!issueData?.clerk && <option value="">-</option>}
+                {clerks.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
             </div>
             <button
               className="px-4 py-1.5 bg-dfxBlue-400 text-white rounded text-xs hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
@@ -364,8 +418,21 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
 
         {/* Messages / Chat */}
         <div className="bg-white rounded-lg shadow-sm p-4">
-          <h2 className="text-dfxGray-700 mb-3">Messages ({messages.length})</h2>
-          <div className="flex flex-col gap-2 max-h-[40vh] overflow-auto mb-4 p-2">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-dfxGray-700">Messages ({messages.length})</h2>
+            {pendingCount > 0 && (
+              <button
+                className="px-3 py-1 text-xs text-white bg-dfxRed-100 rounded-full hover:bg-dfxRed-150 transition-colors"
+                onClick={() => loadMessages()}
+              >
+                {pendingCount} new {pendingCount === 1 ? 'message' : 'messages'} — load
+              </button>
+            )}
+          </div>
+          <div
+            ref={messagesContainerRef}
+            className="flex flex-col gap-2 max-h-[40vh] overflow-auto mb-4 p-2 scroll-shadow"
+          >
             {[...messages]
               .sort((a, b) => a.id - b.id)
               .map((msg) => {
@@ -399,7 +466,6 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
                   </div>
                 );
               })}
-            <div ref={messagesEndRef} />
           </div>
 
           {/* Message Input */}
@@ -451,6 +517,18 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
                 }
               }}
             />
+            <select
+              className="px-2 py-2 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+              value={messageAuthor}
+              onChange={(e) => setMessageAuthor(e.target.value)}
+              title="Author"
+            >
+              {clerks.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
             <button
               className="px-4 py-2 bg-dfxBlue-400 text-white rounded text-sm hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
               onClick={handleSendMessage}

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -8,129 +8,132 @@ import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { CustomerAuthor, SupportIssueListItem, useSupportDashboard } from 'src/hooks/support-dashboard.hook';
 import { formatDateTime, statusBadge } from 'src/util/compliance-helpers';
+import { reasonLabel, typeLabel } from 'src/util/support-helpers';
 
-type Tab = 'open' | 'canceled' | 'completed';
+type PagedTab = 'OnHold' | 'Canceled' | 'Completed';
+type Tab = 'open' | PagedTab;
 
-const OPEN_STATES = [
-  SupportIssueInternalState.CREATED,
-  SupportIssueInternalState.PENDING,
-  SupportIssueInternalState.ON_HOLD,
-];
+const OPEN_STATES = [SupportIssueInternalState.CREATED, SupportIssueInternalState.PENDING];
+const PAGED_TABS: PagedTab[] = ['OnHold', 'Canceled', 'Completed'];
 const PAGE_SIZE = 20;
+
+interface TabData {
+  issues: SupportIssueListItem[];
+  total: number;
+  loaded: boolean;
+  loading: boolean;
+}
+
+const emptyTabData: TabData = { issues: [], total: 0, loaded: false, loading: false };
 
 export default function SupportDashboardScreen(): JSX.Element {
   useSupportDashboardGuard();
 
   const { translate } = useSettingsContext();
   const { session } = useAuthContext();
-  const { getIssueList } = useSupportDashboard();
+  const { getIssueList, getIssueCounts } = useSupportDashboard();
   const { navigate } = useNavigation();
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const [openIssuesRaw, setOpenIssuesRaw] = useState<SupportIssueListItem[]>([]);
+  const [openIssues, setOpenIssues] = useState<SupportIssueListItem[]>([]);
   const [activeTab, setActiveTab] = useState<Tab>('open');
 
-  // Filters (only apply to Open tab)
   const [typeFilter, setTypeFilter] = useState<string>('');
   const [stateFilter, setStateFilter] = useState<string>('');
   const [departmentFilter, setDepartmentFilter] = useState<string>('');
 
-  // Canceled/Completed paging state
-  const [canceledIssues, setCanceledIssues] = useState<SupportIssueListItem[]>([]);
-  const [canceledTotal, setCanceledTotal] = useState(0);
-  const [canceledLoaded, setCanceledLoaded] = useState(false);
-  const [canceledLoading, setCanceledLoading] = useState(false);
+  const [tabs, setTabs] = useState<Record<PagedTab, TabData>>({
+    OnHold: { ...emptyTabData },
+    Canceled: { ...emptyTabData },
+    Completed: { ...emptyTabData },
+  });
 
-  const [completedIssues, setCompletedIssues] = useState<SupportIssueListItem[]>([]);
-  const [completedTotal, setCompletedTotal] = useState(0);
-  const [completedLoaded, setCompletedLoaded] = useState(false);
-  const [completedLoading, setCompletedLoading] = useState(false);
-
-  // Search (server-side for canceled/completed)
   const [searchQuery, setSearchQuery] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
 
   const isAdmin = session?.role === UserRole.ADMIN;
 
-  // Load open issues (all, no paging)
-  const loadOpenIssues = useCallback((): void => {
-    setIsLoading(true);
-    setError(undefined);
-
-    const params: Record<string, string> = {};
-    if (typeFilter) params.type = typeFilter;
-    if (departmentFilter) params.department = departmentFilter;
-
-    getIssueList(params)
-      .then((res) => setOpenIssuesRaw(res.data))
-      .catch((e: Error) => setError(e.message ?? 'Unknown error'))
-      .finally(() => setIsLoading(false));
-  }, [typeFilter, departmentFilter, getIssueList]);
-
-  useEffect(() => {
-    loadOpenIssues();
-  }, [loadOpenIssues]);
-
-  // Load counts for canceled/completed tabs on mount
-  useEffect(() => {
-    getIssueList({ state: 'Canceled', take: 1, skip: 0 }).then((res) => setCanceledTotal(res.total));
-    getIssueList({ state: 'Completed', take: 1, skip: 0 }).then((res) => setCompletedTotal(res.total));
-  }, [getIssueList]);
-
-  // Load canceled/completed (paged, server-side search)
-  const loadPaged = useCallback(
-    (state: 'Canceled' | 'Completed', skip: number, query: string, append: boolean): void => {
-      const setLoading = state === 'Canceled' ? setCanceledLoading : setCompletedLoading;
-      const setIssues = state === 'Canceled' ? setCanceledIssues : setCompletedIssues;
-      const setTotal = state === 'Canceled' ? setCanceledTotal : setCompletedTotal;
-      const setLoaded = state === 'Canceled' ? setCanceledLoaded : setCompletedLoaded;
-
-      setLoading(true);
+  const loadOpenIssues = useCallback(
+    (query: string): void => {
+      setIsLoading(true);
       setError(undefined);
 
-      getIssueList({ state, take: PAGE_SIZE, skip, query: query || undefined })
-        .then((res) => {
-          setIssues((prev) => (append ? [...prev, ...res.data] : res.data));
-          setTotal(res.total);
-          setLoaded(true);
-        })
+      const params: Record<string, string> = { states: OPEN_STATES.join(',') };
+      if (typeFilter) params.type = typeFilter;
+      if (departmentFilter) params.department = departmentFilter;
+      if (query) params.query = query;
+
+      getIssueList(params)
+        .then((res) => setOpenIssues(res.data))
         .catch((e: Error) => setError(e.message ?? 'Unknown error'))
-        .finally(() => setLoading(false));
+        .finally(() => setIsLoading(false));
+    },
+    [typeFilter, departmentFilter, getIssueList],
+  );
+
+  useEffect(() => {
+    getIssueCounts()
+      .then((counts) =>
+        setTabs((prev) => ({
+          OnHold: { ...prev.OnHold, total: counts[SupportIssueInternalState.ON_HOLD] ?? 0 },
+          Canceled: { ...prev.Canceled, total: counts[SupportIssueInternalState.CANCELED] ?? 0 },
+          Completed: { ...prev.Completed, total: counts[SupportIssueInternalState.COMPLETED] ?? 0 },
+        })),
+      )
+      .catch(() => undefined);
+  }, [getIssueCounts]);
+
+  const loadPaged = useCallback(
+    (state: PagedTab, skip: number, query: string, append: boolean): void => {
+      setTabs((prev) => ({ ...prev, [state]: { ...prev[state], loading: true } }));
+      setError(undefined);
+
+      getIssueList({ states: state, take: PAGE_SIZE, skip, query: query || undefined })
+        .then((res) => {
+          setTabs((prev) => ({
+            ...prev,
+            [state]: {
+              issues: append ? [...prev[state].issues, ...res.data] : res.data,
+              total: res.total,
+              loaded: true,
+              loading: false,
+            },
+          }));
+        })
+        .catch((e: Error) => {
+          setError(e.message ?? 'Unknown error');
+          setTabs((prev) => ({ ...prev, [state]: { ...prev[state], loading: false } }));
+        });
     },
     [getIssueList],
   );
 
-  // Lazy load on tab switch
   useEffect(() => {
-    if (activeTab === 'canceled' && !canceledLoaded) {
-      loadPaged('Canceled', 0, '', false);
-    }
-    if (activeTab === 'completed' && !completedLoaded) {
-      loadPaged('Completed', 0, '', false);
-    }
-  }, [activeTab, loadPaged, canceledLoaded, completedLoaded]);
+    if (activeTab !== 'open' && !tabs[activeTab].loaded) loadPaged(activeTab, 0, '', false);
+  }, [activeTab, loadPaged, tabs]);
 
-  // Debounced search for canceled/completed
   useEffect(() => {
-    if (activeTab === 'open') return;
-
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      const state = activeTab === 'canceled' ? 'Canceled' : 'Completed';
-      loadPaged(state, 0, searchQuery, false);
+      if (activeTab === 'open') loadOpenIssues(searchQuery);
+      else loadPaged(activeTab, 0, searchQuery, false);
     }, 300);
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [searchQuery, activeTab, loadPaged]);
+  }, [searchQuery, activeTab, loadPaged, loadOpenIssues]);
 
-  useLayoutOptions({ title: translate('screens/support', 'Support Dashboard'), backButton: true, noMaxWidth: true });
+  useLayoutOptions({
+    title: translate('screens/support', 'Support Dashboard'),
+    backButton: true,
+    noMaxWidth: true,
+    noPadding: true,
+  });
 
   const openIssueGroups = useMemo(() => {
-    let filtered = openIssuesRaw.filter((i) => (OPEN_STATES as string[]).includes(i.state));
-    if (stateFilter) filtered = filtered.filter((i) => i.state === stateFilter);
+    const filtered = stateFilter ? openIssues.filter((i) => i.state === stateFilter) : openIssues;
 
     const customerWaiting = filtered
       .filter((i) => i.lastMessageAuthor === CustomerAuthor)
@@ -144,33 +147,25 @@ export default function SupportDashboardScreen(): JSX.Element {
       customerWaiting,
       created: rest.filter((i) => i.state === SupportIssueInternalState.CREATED).sort(byCreated),
       pending: rest.filter((i) => i.state === SupportIssueInternalState.PENDING).sort(byCreated),
-      onHold: rest.filter((i) => i.state === SupportIssueInternalState.ON_HOLD).sort(byCreated),
     };
-  }, [openIssuesRaw, stateFilter]);
+  }, [openIssues, stateFilter]);
 
   const openIssueCount =
-    openIssueGroups.customerWaiting.length +
-    openIssueGroups.created.length +
-    openIssueGroups.pending.length +
-    openIssueGroups.onHold.length;
+    openIssueGroups.customerWaiting.length + openIssueGroups.created.length + openIssueGroups.pending.length;
 
-  const displayedIssues = activeTab === 'canceled' ? canceledIssues : completedIssues;
-  const displayedTotal = activeTab === 'canceled' ? canceledTotal : completedTotal;
-  const isTabLoading = activeTab === 'open' ? isLoading : activeTab === 'canceled' ? canceledLoading : completedLoading;
-  const hasMore = activeTab !== 'open' && displayedIssues.length < displayedTotal;
+  const currentTab = activeTab === 'open' ? null : tabs[activeTab];
+  const displayedIssues = currentTab?.issues ?? [];
+  const displayedTotal = currentTab?.total ?? 0;
+  const isTabLoading = activeTab === 'open' ? isLoading : (currentTab?.loading ?? false);
+  const hasMore = currentTab != null && displayedIssues.length < displayedTotal;
 
   function handleLoadMore(): void {
-    const state = activeTab === 'canceled' ? 'Canceled' : 'Completed';
-    loadPaged(state, displayedIssues.length, searchQuery, true);
-  }
-
-  function handleTabChange(tab: Tab): void {
-    setActiveTab(tab);
-    if (tab === 'open') setSearchQuery('');
+    if (activeTab === 'open') return;
+    loadPaged(activeTab, displayedIssues.length, searchQuery, true);
   }
 
   return (
-    <div className="w-full flex flex-col gap-4 max-w-6xl text-left">
+    <div className="w-full flex flex-col gap-3 flex-1 min-h-0 p-3 text-left">
       {/* Stats & Actions */}
       <div className="flex items-center gap-4 flex-wrap">
         <div className="bg-white rounded-lg shadow-sm p-3 flex-1 min-w-[150px]">
@@ -192,18 +187,16 @@ export default function SupportDashboardScreen(): JSX.Element {
         <TabButton
           label={`Open (${openIssueCount})`}
           active={activeTab === 'open'}
-          onClick={() => handleTabChange('open')}
+          onClick={() => setActiveTab('open')}
         />
-        <TabButton
-          label={`Canceled (${canceledTotal})`}
-          active={activeTab === 'canceled'}
-          onClick={() => handleTabChange('canceled')}
-        />
-        <TabButton
-          label={`Completed (${completedTotal})`}
-          active={activeTab === 'completed'}
-          onClick={() => handleTabChange('completed')}
-        />
+        {PAGED_TABS.map((tab) => (
+          <TabButton
+            key={tab}
+            label={`${tab} (${tabs[tab].total})`}
+            active={activeTab === tab}
+            onClick={() => setActiveTab(tab)}
+          />
+        ))}
       </div>
 
       {/* Filters - only for Open tab */}
@@ -213,15 +206,23 @@ export default function SupportDashboardScreen(): JSX.Element {
             label="Type"
             value={typeFilter}
             onChange={setTypeFilter}
-            options={Object.values(SupportIssueType)}
+            options={Object.values(SupportIssueType).map((t) => ({
+              value: t,
+              label: translate('screens/support', typeLabel(t)),
+            }))}
           />
-          <FilterSelect label="State" value={stateFilter} onChange={setStateFilter} options={OPEN_STATES} />
+          <FilterSelect
+            label="State"
+            value={stateFilter}
+            onChange={setStateFilter}
+            options={OPEN_STATES.map((s) => ({ value: s, label: s }))}
+          />
           {isAdmin && (
             <FilterSelect
               label="Department"
               value={departmentFilter}
               onChange={setDepartmentFilter}
-              options={Object.values(Department)}
+              options={Object.values(Department).map((d) => ({ value: d, label: d }))}
             />
           )}
           <button
@@ -237,21 +238,19 @@ export default function SupportDashboardScreen(): JSX.Element {
         </div>
       )}
 
-      {/* Search - for Canceled and Completed tabs */}
-      {(activeTab === 'canceled' || activeTab === 'completed') && (
-        <div className="flex flex-col gap-1">
-          <input
-            className="px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search by UID, name, clerk, message..."
-          />
-        </div>
-      )}
+      {/* Search - all tabs (server-side) */}
+      <div className="flex flex-col gap-1">
+        <input
+          className="px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search by UID, name, clerk, message..."
+        />
+      </div>
 
       {/* Content */}
       {error && <ErrorHint message={error} />}
-      {isTabLoading && (activeTab !== 'open' ? displayedIssues.length === 0 : openIssueCount === 0) ? (
+      {isTabLoading && (activeTab === 'open' ? openIssueCount === 0 : displayedIssues.length === 0) ? (
         <StyledLoadingSpinner size={SpinnerSize.LG} />
       ) : activeTab === 'open' ? (
         <GroupedIssueTable
@@ -305,7 +304,7 @@ function FilterSelect({
   label: string;
   value: string;
   onChange: (v: string) => void;
-  options: string[];
+  options: { value: string; label: string }[];
 }): JSX.Element {
   return (
     <div className="flex flex-col gap-1">
@@ -317,8 +316,8 @@ function FilterSelect({
       >
         <option value="">All</option>
         {options.map((opt) => (
-          <option key={opt} value={opt}>
-            {opt}
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
           </option>
         ))}
       </select>
@@ -330,7 +329,6 @@ interface IssueGroups {
   customerWaiting: SupportIssueListItem[];
   created: SupportIssueListItem[];
   pending: SupportIssueListItem[];
-  onHold: SupportIssueListItem[];
 }
 
 const COLUMN_COUNT = 9;
@@ -362,13 +360,18 @@ function IssueRow({
   showDepartment: boolean;
   onRowClick: (issue: SupportIssueListItem) => void;
 }): JSX.Element {
+  const { translate } = useSettingsContext();
   return (
     <tr
       className="border-b border-dfxGray-300 transition-colors hover:bg-dfxBlue-400 cursor-pointer group"
       onClick={() => onRowClick(issue)}
     >
-      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">{issue.type}</td>
-      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">{issue.reason}</td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">
+        {translate('screens/support', typeLabel(issue.type))}
+      </td>
+      <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white">
+        {translate('screens/support', reasonLabel(issue.reason))}
+      </td>
       <td className="px-2 py-1.5 text-xs text-dfxBlue-800 text-left group-hover:text-white max-w-[200px] truncate">
         {issue.name}
       </td>
@@ -416,18 +419,17 @@ function GroupedIssueTable({
   showDepartment: boolean;
   onRowClick: (issue: SupportIssueListItem) => void;
 }): JSX.Element {
-  const total = groups.customerWaiting.length + groups.created.length + groups.pending.length + groups.onHold.length;
+  const total = groups.customerWaiting.length + groups.created.length + groups.pending.length;
   if (total === 0) return <div className="p-4 text-dfxGray-700 text-sm">No issues found</div>;
 
   const colSpan = showDepartment ? COLUMN_COUNT + 1 : COLUMN_COUNT;
   const sections: { label: string; issues: SupportIssueListItem[] }[] = [
     { label: 'Created', issues: groups.created },
     { label: 'Pending', issues: groups.pending },
-    { label: 'OnHold', issues: groups.onHold },
   ];
 
   return (
-    <div className="bg-white rounded-lg shadow-sm max-h-[60vh] overflow-auto scroll-shadow">
+    <div className="bg-white shadow-sm flex-1 min-h-0 overflow-auto scroll-shadow">
       <table className="w-full border-collapse">
         <IssueTableHeader showDepartment={showDepartment} />
         <tbody>
@@ -469,7 +471,7 @@ function IssueTable({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-sm max-h-[60vh] overflow-auto scroll-shadow">
+    <div className="bg-white shadow-sm flex-1 min-h-0 overflow-auto scroll-shadow">
       <table className="w-full border-collapse">
         <IssueTableHeader showDepartment={showDepartment} />
         <tbody>

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -31,7 +31,7 @@ export default function SupportDashboardScreen(): JSX.Element {
 
   const { translate } = useSettingsContext();
   const { session } = useAuthContext();
-  const { getIssueList, getIssueCounts } = useSupportDashboard();
+  const { getIssueList, getIssueCounts, getIssueActivity } = useSupportDashboard();
   const { navigate } = useNavigation();
 
   const [isLoading, setIsLoading] = useState(true);
@@ -51,6 +51,9 @@ export default function SupportDashboardScreen(): JSX.Element {
 
   const [searchQuery, setSearchQuery] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const [newMessageCount, setNewMessageCount] = useState(0);
+  const baselineRef = useRef<Date>(new Date());
 
   const isAdmin = session?.role === UserRole.ADMIN;
 
@@ -111,7 +114,7 @@ export default function SupportDashboardScreen(): JSX.Element {
 
   useEffect(() => {
     if (activeTab !== 'open' && !tabs[activeTab].loaded) loadPaged(activeTab, 0, '', false);
-  }, [activeTab, loadPaged, tabs]);
+  }, [activeTab, loadPaged]);
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -124,6 +127,27 @@ export default function SupportDashboardScreen(): JSX.Element {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
   }, [searchQuery, activeTab, loadPaged, loadOpenIssues]);
+
+  useEffect(() => {
+    const tick = (): void => {
+      getIssueActivity(baselineRef.current)
+        .then((res) => setNewMessageCount(res.count))
+        .catch(() => undefined);
+    };
+    const id = setInterval(tick, 30_000);
+    return () => clearInterval(id);
+  }, [getIssueActivity]);
+
+  const reloadAfterActivity = useCallback((): void => {
+    baselineRef.current = new Date();
+    setNewMessageCount(0);
+    if (activeTab === 'open') {
+      loadOpenIssues(searchQuery);
+    } else {
+      setTabs((prev) => ({ ...prev, [activeTab]: { ...prev[activeTab], loaded: false } }));
+      loadPaged(activeTab, 0, searchQuery, false);
+    }
+  }, [activeTab, searchQuery, loadOpenIssues, loadPaged]);
 
   useLayoutOptions({
     title: translate('screens/support', 'Support Dashboard'),
@@ -235,6 +259,14 @@ export default function SupportDashboardScreen(): JSX.Element {
           >
             Reset
           </button>
+          {newMessageCount > 0 && (
+            <button
+              className="ml-auto px-3 py-1 text-xs text-white bg-dfxRed-100 rounded-full hover:bg-dfxRed-150 transition-colors"
+              onClick={reloadAfterActivity}
+            >
+              {newMessageCount} new {newMessageCount === 1 ? 'message' : 'messages'} — load
+            </button>
+          )}
         </div>
       )}
 

--- a/src/util/support-helpers.ts
+++ b/src/util/support-helpers.ts
@@ -1,0 +1,10 @@
+import { SupportIssueType } from '@dfx.swiss/react';
+import { IssueReasonLabels, IssueTypeLabels } from 'src/config/labels';
+
+export function typeLabel(type: string): string {
+  return IssueTypeLabels[type as SupportIssueType] ?? type;
+}
+
+export function reasonLabel(reason: string): string {
+  return IssueReasonLabels[reason as keyof typeof IssueReasonLabels] ?? reason;
+}


### PR DESCRIPTION
## Summary
- **Configurable clerks**: hardcoded `Clerk` enum removed; names now loaded via `GET /support/issue/clerks` and validated against the loaded list with first-entry fallback.
- **State refactor**: 12 `useState`s + 5 ternary chains replaced by a single `Record<Tab, TabData>`.
- **Performance**: 3× count requests on mount replaced by a single `getIssueCounts()` call.
- **Helpers**: new `support-helpers.ts` with `typeLabel()` / `reasonLabel()` reused across 3 screens.
- **Cleanup**: dropped dead client-side filter, unreachable message-author fallback, and redundant `handleTabChange` wrapper; split `loadMessages(boolean)` into `loadMessages()` + `pollForNewMessages()`.
- **Layout**: replaced magic `h-[calc(100vh-4rem)]` with `flex-1 min-h-0` + layout `noPadding` so the table fills the remaining space; added top scroll shadow on the message list.

## Related
Companion API PR: DFXswiss/api#3593

## Test plan
- [ ] Dashboard mount triggers exactly one network call for counts (was 3)
- [ ] Clerk dropdowns on dashboard/issue/create screens show values from API (`['Support']` when setting unset)
- [ ] Tab switch OnHold/Canceled/Completed loads lazily, pagination + search works
- [ ] Issue detail polling surfaces pending-messages button without disrupting scroll; manual load clears it
- [ ] Sending a message keeps the clerk/author selection sensible when `data.clerk` isn't in the list
- [ ] Table fills vertical space without the previous large bottom gap
- [ ] `npm test` + `npm run lint` pass