### PR TITLE
feat: pending reviews section on compliance screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ const ComplianceSupportIssueScreen = lazy(() => import('./screens/compliance-sup
 const ComplianceRecommendationGraphScreen = lazy(() => import('./screens/compliance-recommendation-graph.screen'));
 const ComplianceCustodyOrdersScreen = lazy(() => import('./screens/compliance-custody-orders.screen'));
 const ComplianceReviewScreen = lazy(() => import('./screens/compliance-review.screen'));
+const CompliancePendingReviewsScreen = lazy(() => import('./screens/compliance-pending-reviews.screen'));
 const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
 const SupportDashboardIssueScreen = lazy(() => import('./screens/support-dashboard-issue.screen'));
 const SupportDashboardCreateScreen = lazy(() => import('./screens/support-dashboard-create.screen'));
@@ -391,6 +392,10 @@ export const Routes = [
       {
         path: 'compliance/user/:id/kyc',
         element: withSuspense(<ComplianceReviewScreen />),
+      },
+      {
+        path: 'compliance/pending-reviews/:type/:name',
+        element: withSuspense(<CompliancePendingReviewsScreen />),
       },
       {
         path: 'support/dashboard',

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -90,6 +90,33 @@ export interface PendingOnboardingInfo {
   date: string;
 }
 
+export enum PendingReviewType {
+  KYC_STEP = 'KycStep',
+  BANK_DATA = 'BankData',
+}
+
+export enum PendingReviewStatus {
+  MANUAL_REVIEW = 'ManualReview',
+  INTERNAL_REVIEW = 'InternalReview',
+}
+
+export interface PendingReviewSummaryEntry {
+  type: PendingReviewType;
+  name: string;
+  manualReview: number;
+  internalReview: number;
+}
+
+export interface PendingReviewItem {
+  id: number;
+  userDataId: number;
+  userName?: string;
+  accountType?: string;
+  kycLevel?: number;
+  status: PendingReviewStatus;
+  date: string;
+}
+
 export interface BankTxSearchResult {
   id: number;
   transactionId?: number;
@@ -509,6 +536,26 @@ export function useCompliance() {
     });
   }
 
+  async function getPendingReviews(): Promise<PendingReviewSummaryEntry[]> {
+    return call<PendingReviewSummaryEntry[]>({
+      url: 'support/pending-reviews',
+      method: 'GET',
+    });
+  }
+
+  async function getPendingReviewItems(
+    type: PendingReviewType,
+    status: PendingReviewStatus,
+    name?: string,
+  ): Promise<PendingReviewItem[]> {
+    const query = new URLSearchParams({ type, status });
+    if (name) query.set('name', name);
+    return call<PendingReviewItem[]>({
+      url: `support/pending-reviews/items?${query.toString()}`,
+      method: 'GET',
+    });
+  }
+
   async function getRecommendationGraph(userDataId: number): Promise<RecommendationGraph> {
     return call<RecommendationGraph>({
       url: `support/recommendation-graph/${userDataId}`,
@@ -634,6 +681,8 @@ export function useCompliance() {
       search,
       getUserData,
       getPendingOnboardings,
+      getPendingReviews,
+      getPendingReviewItems,
       downloadUserFiles,
       checkUserFiles,
       getTransactionRefundData,

--- a/src/screens/compliance-pending-reviews.screen.tsx
+++ b/src/screens/compliance-pending-reviews.screen.tsx
@@ -1,0 +1,115 @@
+import { useSessionContext } from '@dfx.swiss/react';
+import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { useEffect, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { PendingReviewItem, PendingReviewStatus, PendingReviewType, useCompliance } from 'src/hooks/compliance.hook';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+
+export default function CompliancePendingReviewsScreen(): JSX.Element {
+  useComplianceGuard();
+
+  const { translate } = useSettingsContext();
+  const { getPendingReviewItems } = useCompliance();
+  const { navigate } = useNavigation();
+  const { isLoggedIn } = useSessionContext();
+  const { type, name } = useParams<{ type: PendingReviewType; name: string }>();
+  const { search } = useLocation();
+
+  const status =
+    (new URLSearchParams(search).get('status') as PendingReviewStatus) ?? PendingReviewStatus.MANUAL_REVIEW;
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [items, setItems] = useState<PendingReviewItem[]>([]);
+
+  useEffect(() => {
+    if (!isLoggedIn || !type) return;
+
+    const queryName = type === PendingReviewType.KYC_STEP ? name : undefined;
+    getPendingReviewItems(type, status, queryName)
+      .then(setItems)
+      .catch((e) => setError(e.message))
+      .finally(() => setIsLoading(false));
+  }, [isLoggedIn, type, name, status]);
+
+  const title =
+    type === PendingReviewType.BANK_DATA
+      ? `${translate('screens/compliance', 'BankData')} – ${status}`
+      : `${name} – ${status}`;
+
+  useLayoutOptions({ title });
+
+  if (isLoading) {
+    return <StyledLoadingSpinner size={SpinnerSize.LG} />;
+  }
+
+  if (error) {
+    return <ErrorHint message={error} />;
+  }
+
+  return (
+    <StyledVerticalStack gap={6} full>
+      <div className="w-full overflow-x-auto">
+        <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
+          <thead>
+            <tr className="bg-dfxGray-300">
+              <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                {translate('screens/compliance', 'ID')}
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                {translate('screens/kyc', 'Account Type')}
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                {translate('screens/kyc', 'Name')}
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                {translate('screens/compliance', 'Kyc Level')}
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                {translate('screens/compliance', 'Date')}
+              </th>
+              <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800" />
+            </tr>
+          </thead>
+          <tbody>
+            {items.length > 0 ? (
+              items.map((item) => (
+                <tr
+                  key={item.id}
+                  className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300 cursor-pointer"
+                  onClick={() => navigate(`compliance/user/${item.userDataId}/kyc`)}
+                >
+                  <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{item.userDataId}</td>
+                  <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{item.accountType ?? '-'}</td>
+                  <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{item.userName ?? '-'}</td>
+                  <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{item.kycLevel ?? '-'}</td>
+                  <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">
+                    {new Date(item.date).toLocaleDateString('de-CH')}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      className="px-2 py-1 text-xs font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors"
+                      onClick={() => navigate(`compliance/user/${item.userDataId}/kyc`)}
+                    >
+                      {translate('screens/compliance', 'Open')}
+                    </button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={6} className="px-4 py-3 text-center text-dfxGray-700">
+                  {translate('screens/compliance', 'No entries found')}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </StyledVerticalStack>
+  );
+}

--- a/src/screens/compliance.screen.tsx
+++ b/src/screens/compliance.screen.tsx
@@ -11,7 +11,7 @@ import {
   StyledInput,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
 import { ErrorHint } from 'src/components/error-hint';
@@ -20,6 +20,8 @@ import {
   BankTxSearchResult,
   ComplianceSearchResult,
   PendingOnboardingInfo,
+  PendingReviewStatus,
+  PendingReviewSummaryEntry,
   UserSearchResult,
   useCompliance,
 } from 'src/hooks/compliance.hook';
@@ -35,7 +37,7 @@ export default function ComplianceScreen(): JSX.Element {
   useComplianceGuard();
 
   const { translate, translateError } = useSettingsContext();
-  const { search, downloadUserFiles, getPendingOnboardings } = useCompliance();
+  const { search, downloadUserFiles, getPendingOnboardings, getPendingReviews } = useCompliance();
   const { navigate } = useNavigation();
   const { search: query } = useLocation();
 
@@ -45,6 +47,7 @@ export default function ComplianceScreen(): JSX.Element {
   const [showInfo, setShowInfo] = useState(false);
   const [downloadingUserId, setDownloadingUserId] = useState<number>();
   const [pendingOnboardings, setPendingOnboardings] = useState<PendingOnboardingInfo[]>([]);
+  const [pendingReviews, setPendingReviews] = useState<PendingReviewSummaryEntry[]>([]);
 
   const paramSearch = new URLSearchParams(query).get('search') || undefined;
 
@@ -52,6 +55,9 @@ export default function ComplianceScreen(): JSX.Element {
     getPendingOnboardings()
       .then(setPendingOnboardings)
       .catch(() => setPendingOnboardings([]));
+    getPendingReviews()
+      .then(setPendingReviews)
+      .catch(() => setPendingReviews([]));
   }, []);
 
   useEffect(() => {
@@ -395,6 +401,60 @@ export default function ComplianceScreen(): JSX.Element {
                         </button>
                       </td>
                     </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {pendingReviews.length > 0 && (
+          <div className="w-full">
+            <h2 className="text-dfxGray-700">
+              {translate('screens/compliance', 'Pending Reviews')} (
+              {pendingReviews.reduce((sum, r) => sum + r.manualReview + r.internalReview, 0)})
+            </h2>
+            <div className="w-full overflow-x-auto">
+              <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
+                <thead>
+                  <tr className="bg-dfxGray-300">
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                      {translate('screens/compliance', 'Type')}
+                    </th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">
+                      {translate('screens/kyc', 'Name')}
+                    </th>
+                    <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">
+                      {translate('screens/compliance', 'Manual Review')}
+                    </th>
+                    <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">
+                      {translate('screens/compliance', 'Internal Review')}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pendingReviews.map((r) => (
+                    <Fragment key={`${r.type}-${r.name}`}>
+                      {[PendingReviewStatus.MANUAL_REVIEW, PendingReviewStatus.INTERNAL_REVIEW].map((s) => {
+                        const isManual = s === PendingReviewStatus.MANUAL_REVIEW;
+                        const count = isManual ? r.manualReview : r.internalReview;
+                        if (count === 0) return null;
+                        const valueCell = 'px-4 py-3 text-right text-sm text-dfxBlue-800 font-semibold';
+                        const emptyCell = 'px-4 py-3 text-right text-sm text-dfxGray-600';
+                        return (
+                          <tr
+                            key={s}
+                            className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300 cursor-pointer"
+                            onClick={() => navigate(`compliance/pending-reviews/${r.type}/${r.name}?status=${s}`)}
+                          >
+                            <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{r.type}</td>
+                            <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{r.name}</td>
+                            <td className={isManual ? valueCell : emptyCell}>{isManual ? count : '-'}</td>
+                            <td className={isManual ? emptyCell : valueCell}>{isManual ? '-' : count}</td>
+                          </tr>
+                        );
+                      })}
+                    </Fragment>
                   ))}
                 </tbody>
               </table>


### PR DESCRIPTION
## Summary
- Adds a new **Pending Reviews** section on the Compliance landing page (`/compliance`) below _Pending Onboardings_.
- Shows one row per `(type, name)` combination with counts for Manual Review and Internal Review; clicking a row opens a drilldown listing the affected users.
- New drilldown screen at `/compliance/pending-reviews/:type/:name?status=…` reuses the existing user details navigation.
- Header count reflects the total number of pending items (not just the number of grouped rows).

## Context
Replaces the external Google Sheet (`NutzerMonitoring`) that the compliance team used to track manual checks. Depends on the new backend endpoints added in the companion API PR (`feat: compliance pending reviews endpoint`).

Covers every `KycStepName` and `bank_data` entry in `ManualReview` or `InternalReview` — including `NameChange` / `AddressChange` which the old Google Sheet did not explicitly track.

## Test plan
- [ ] Compliance landing page shows _Pending Reviews_ section with correct total count in the header.
- [ ] Each `(type, name)` combination renders at most two rows (one per active status), with gray `-` in the empty status column.
- [ ] Clicking an MR row navigates to `/compliance/pending-reviews/:type/:name?status=ManualReview` and shows matching users.
- [ ] Clicking an IR row shows the corresponding Internal Review users.
- [ ] Clicking a user row in the drilldown opens the existing user details screen.
- [ ] Non-compliance users cannot reach the drilldown route.
- [ ] Pending Onboardings section continues to work unchanged.