### PR TITLE
feat: add compliance recall list screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ const ComplianceKycStepScreen = lazy(() => import('./screens/compliance-kyc-step
 const ComplianceSupportIssueScreen = lazy(() => import('./screens/compliance-support-issue.screen'));
 const ComplianceRecommendationGraphScreen = lazy(() => import('./screens/compliance-recommendation-graph.screen'));
 const ComplianceCustodyOrdersScreen = lazy(() => import('./screens/compliance-custody-orders.screen'));
+const ComplianceRecallListScreen = lazy(() => import('./screens/compliance-recall-list.screen'));
 const ComplianceReviewScreen = lazy(() => import('./screens/compliance-review.screen'));
 const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
 const SupportDashboardIssueScreen = lazy(() => import('./screens/support-dashboard-issue.screen'));
@@ -387,6 +388,10 @@ export const Routes = [
       {
         path: 'compliance/custody-orders',
         element: withSuspense(<ComplianceCustodyOrdersScreen />),
+      },
+      {
+        path: 'compliance/recalls',
+        element: withSuspense(<ComplianceRecallListScreen />),
       },
       {
         path: 'compliance/user/:id/kyc',

--- a/src/dto/recall.dto.ts
+++ b/src/dto/recall.dto.ts
@@ -10,8 +10,8 @@ export enum RecallReason {
 
 export interface RecallListEntry {
   id: number;
-  created: string;
-  updated: string;
+  created: Date;
+  updated: Date;
   sequence: number;
   comment: string;
   fee: number;

--- a/src/dto/recall.dto.ts
+++ b/src/dto/recall.dto.ts
@@ -1,0 +1,22 @@
+export enum RecallReason {
+  DUPL = 'DUPL',
+  TECH = 'TECH',
+  FRAD = 'FRAD',
+  CUST = 'CUST',
+  AM09 = 'AM09',
+  AC03 = 'AC03',
+  UNKNOWN = 'Unknown',
+}
+
+export interface RecallListEntry {
+  id: number;
+  created: string;
+  updated: string;
+  sequence: number;
+  comment: string;
+  fee: number;
+  reason?: RecallReason;
+  bankTx?: { id: number };
+  checkoutTx?: { id: number };
+  user?: { id: number };
+}

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -9,6 +9,7 @@ import {
   useApi,
 } from '@dfx.swiss/react';
 import { CustodyOrderListEntry } from 'src/dto/order.dto';
+import { RecallListEntry } from 'src/dto/recall.dto';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
 import { useMemo } from 'react';
 import { downloadFile, downloadPdfFromString, filenameDateFormat } from 'src/util/utils';
@@ -509,6 +510,13 @@ export function useCompliance() {
     });
   }
 
+  async function getRecalls(): Promise<RecallListEntry[]> {
+    return call<RecallListEntry[]>({
+      url: 'recall',
+      method: 'GET',
+    });
+  }
+
   async function getRecommendationGraph(userDataId: number): Promise<RecommendationGraph> {
     return call<RecommendationGraph>({
       url: `support/recommendation-graph/${userDataId}`,
@@ -646,6 +654,7 @@ export function useCompliance() {
       generateOnboardingPdf,
       getCustodyOrders,
       approveCustodyOrder,
+      getRecalls,
       updateKycStep,
       updateUserData,
       createLimitRequest,

--- a/src/screens/compliance-recall-list.screen.tsx
+++ b/src/screens/compliance-recall-list.screen.tsx
@@ -1,0 +1,105 @@
+import { useSessionContext } from '@dfx.swiss/react';
+import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { useCallback, useEffect, useState } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
+import { RecallListEntry } from 'src/dto/recall.dto';
+import { useCompliance } from 'src/hooks/compliance.hook';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+export default function ComplianceRecallListScreen(): JSX.Element {
+  useComplianceGuard();
+  useLayoutOptions({ title: 'Recalls', backButton: true, noMaxWidth: true });
+
+  const { isLoggedIn } = useSessionContext();
+  const { getRecalls } = useCompliance();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [data, setData] = useState<RecallListEntry[]>([]);
+
+  const loadData = useCallback(() => {
+    if (!isLoggedIn) return;
+
+    setIsLoading(true);
+    setError(undefined);
+
+    getRecalls()
+      .then(setData)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setIsLoading(false));
+  }, [isLoggedIn, getRecalls]);
+
+  useEffect(() => {
+    loadData();
+  }, [isLoggedIn]);
+
+  function formatDate(date: string): string {
+    return new Date(date).toLocaleDateString('de-CH', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  function txReference(entry: RecallListEntry): string {
+    if (entry.bankTx) return `BankTx #${entry.bankTx.id}`;
+    if (entry.checkoutTx) return `CheckoutTx #${entry.checkoutTx.id}`;
+    return '-';
+  }
+
+  return (
+    <StyledVerticalStack gap={6} full>
+      {error && <ErrorHint message={error} />}
+
+      {isLoading && data.length === 0 ? (
+        <StyledLoadingSpinner size={SpinnerSize.LG} />
+      ) : (
+        <div className="w-full overflow-x-auto">
+          <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
+            <thead>
+              <tr className="bg-dfxGray-300">
+                <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">ID</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Created</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Updated</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Transaction</th>
+                <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">Sequence</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Reason</th>
+                <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">Fee</th>
+                <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">User ID</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Comment</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.length > 0 ? (
+                data.map((entry) => (
+                  <tr key={entry.id} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
+                    <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.id}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.created)}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.updated)}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{txReference(entry)}</td>
+                    <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.sequence}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.reason ?? '-'}</td>
+                    <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.fee}</td>
+                    <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.user?.id ?? '-'}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800 max-w-xs truncate" title={entry.comment}>
+                      {entry.comment}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={9} className="px-4 py-3 text-center text-dfxGray-700">
+                    No recalls found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </StyledVerticalStack>
+  );
+}

--- a/src/screens/compliance-recall-list.screen.tsx
+++ b/src/screens/compliance-recall-list.screen.tsx
@@ -34,7 +34,7 @@ export default function ComplianceRecallListScreen(): JSX.Element {
     loadData();
   }, [isLoggedIn]);
 
-  function formatDate(date: string): string {
+  function formatDate(date: Date): string {
     return new Date(date).toLocaleDateString('de-CH', {
       day: '2-digit',
       month: '2-digit',


### PR DESCRIPTION
## Summary
- New route `/compliance/recalls` listing all recalls in a table with all columns (ID, Created, Updated, Transaction ref, Sequence, Reason, Fee, User ID, Comment)
- Guarded by `useComplianceGuard` — accessible for `COMPLIANCE` + `ADMIN` + `SUPER_ADMIN`
- DTOs in `src/dto/recall.dto.ts` (consistent with `src/dto/order.dto.ts` for custody orders)
- `useCompliance` hook extended with `getRecalls()` calling `GET /recall`

## Dependency
- Backend PR DFXswiss/api#3610 must be merged + deployed first — that PR adds `GET /recall` and switches guards to `UserRole.COMPLIANCE`. Until deployed, this screen will show a 404 error.

## Test plan
- [ ] Wait for DFXswiss/api#3610 to be merged and live on `api.dfx.swiss`
- [ ] Log in as COMPLIANCE user, navigate to `/compliance/recalls`
- [ ] Verify all recalls are shown with all columns
- [ ] Non-compliance user → redirected away (guard)
- [ ] Empty state message when no recalls exist