### PR TITLE
feat: add compliance mros list screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ const ComplianceKycStepScreen = lazy(() => import('./screens/compliance-kyc-step
 const ComplianceSupportIssueScreen = lazy(() => import('./screens/compliance-support-issue.screen'));
 const ComplianceRecommendationGraphScreen = lazy(() => import('./screens/compliance-recommendation-graph.screen'));
 const ComplianceCustodyOrdersScreen = lazy(() => import('./screens/compliance-custody-orders.screen'));
+const ComplianceMrosListScreen = lazy(() => import('./screens/compliance-mros-list.screen'));
 const ComplianceReviewScreen = lazy(() => import('./screens/compliance-review.screen'));
 const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
 const SupportDashboardIssueScreen = lazy(() => import('./screens/support-dashboard-issue.screen'));
@@ -387,6 +388,10 @@ export const Routes = [
       {
         path: 'compliance/custody-orders',
         element: withSuspense(<ComplianceCustodyOrdersScreen />),
+      },
+      {
+        path: 'compliance/mros',
+        element: withSuspense(<ComplianceMrosListScreen />),
       },
       {
         path: 'compliance/user/:id/kyc',

--- a/src/dto/mros.dto.ts
+++ b/src/dto/mros.dto.ts
@@ -1,0 +1,17 @@
+export enum MrosStatus {
+  DRAFT = 'Draft',
+  SUBMITTED = 'Submitted',
+  CONFIRMED = 'Confirmed',
+  CLOSED = 'Closed',
+}
+
+export interface MrosListEntry {
+  id: number;
+  created: Date;
+  updated: Date;
+  status: MrosStatus;
+  submissionDate?: Date;
+  authorityReference?: string;
+  caseManager: string;
+  userData: { id: number };
+}

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -8,6 +8,7 @@ import {
   ResponseType,
   useApi,
 } from '@dfx.swiss/react';
+import { MrosListEntry } from 'src/dto/mros.dto';
 import { CustodyOrderListEntry } from 'src/dto/order.dto';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
 import { useMemo } from 'react';
@@ -509,6 +510,13 @@ export function useCompliance() {
     });
   }
 
+  async function getMrosList(): Promise<MrosListEntry[]> {
+    return call<MrosListEntry[]>({
+      url: 'mros',
+      method: 'GET',
+    });
+  }
+
   async function getRecommendationGraph(userDataId: number): Promise<RecommendationGraph> {
     return call<RecommendationGraph>({
       url: `support/recommendation-graph/${userDataId}`,
@@ -646,6 +654,7 @@ export function useCompliance() {
       generateOnboardingPdf,
       getCustodyOrders,
       approveCustodyOrder,
+      getMrosList,
       updateKycStep,
       updateUserData,
       createLimitRequest,

--- a/src/screens/compliance-mros-list.screen.tsx
+++ b/src/screens/compliance-mros-list.screen.tsx
@@ -1,0 +1,96 @@
+import { useSessionContext } from '@dfx.swiss/react';
+import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { useCallback, useEffect, useState } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
+import { MrosListEntry } from 'src/dto/mros.dto';
+import { useCompliance } from 'src/hooks/compliance.hook';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+export default function ComplianceMrosListScreen(): JSX.Element {
+  useComplianceGuard();
+  useLayoutOptions({ title: 'MROS Reports', backButton: true, noMaxWidth: true });
+
+  const { isLoggedIn } = useSessionContext();
+  const { getMrosList } = useCompliance();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [data, setData] = useState<MrosListEntry[]>([]);
+
+  const loadData = useCallback(() => {
+    if (!isLoggedIn) return;
+
+    setIsLoading(true);
+    setError(undefined);
+
+    getMrosList()
+      .then(setData)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setIsLoading(false));
+  }, [isLoggedIn, getMrosList]);
+
+  useEffect(() => {
+    loadData();
+  }, [isLoggedIn]);
+
+  function formatDate(date?: Date): string {
+    if (!date) return '-';
+    return new Date(date).toLocaleDateString('de-CH', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }
+
+  return (
+    <StyledVerticalStack gap={6} full>
+      {error && <ErrorHint message={error} />}
+
+      {isLoading && data.length === 0 ? (
+        <StyledLoadingSpinner size={SpinnerSize.LG} />
+      ) : (
+        <div className="w-full overflow-x-auto">
+          <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
+            <thead>
+              <tr className="bg-dfxGray-300">
+                <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">ID</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Created</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Updated</th>
+                <th className="px-4 py-3 text-right text-sm font-semibold text-dfxBlue-800">UserData ID</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Status</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Submission Date</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Authority Reference</th>
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800">Case Manager</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.length > 0 ? (
+                data.map((entry) => (
+                  <tr key={entry.id} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
+                    <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.id}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.created)}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.updated)}</td>
+                    <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.userData.id}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.status}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.submissionDate)}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.authorityReference ?? '-'}</td>
+                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.caseManager}</td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={8} className="px-4 py-3 text-center text-dfxGray-700">
+                    No MROS reports found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </StyledVerticalStack>
+  );
+}

--- a/src/screens/compliance-mros-list.screen.tsx
+++ b/src/screens/compliance-mros-list.screen.tsx
@@ -2,10 +2,23 @@ import { useSessionContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
-import { MrosListEntry } from 'src/dto/mros.dto';
+import { MrosListEntry, MrosStatus } from 'src/dto/mros.dto';
 import { useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+const statusClasses: Record<MrosStatus, string> = {
+  [MrosStatus.DRAFT]: 'bg-dfxGray-400 text-dfxBlue-800',
+  [MrosStatus.SUBMITTED]: 'bg-dfxBlue-300/20 text-dfxBlue-400',
+  [MrosStatus.CONFIRMED]: 'bg-dfxGreen-100/20 text-dfxGreen-300',
+  [MrosStatus.CLOSED]: 'bg-dfxGray-700/20 text-dfxGray-800',
+};
+
+function statusBadge(status: MrosStatus): JSX.Element {
+  const classes = statusClasses[status] ?? 'bg-dfxGray-400 text-dfxBlue-800';
+
+  return <span className={`px-2 py-1 rounded-full text-xs font-semibold ${classes}`}>{status}</span>;
+}
 
 export default function ComplianceMrosListScreen(): JSX.Element {
   useComplianceGuard();
@@ -74,7 +87,7 @@ export default function ComplianceMrosListScreen(): JSX.Element {
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.created)}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.updated)}</td>
                     <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.userData.id}</td>
-                    <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.status}</td>
+                    <td className="px-4 py-3 text-left text-sm">{statusBadge(entry.status)}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.submissionDate)}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.authorityReference ?? '-'}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.caseManager}</td>


### PR DESCRIPTION
## Summary
- New route `/compliance/mros` listing all MROS reports in a table with all columns (ID, Created, Updated, UserData ID, Status, Submission Date, Authority Reference, Case Manager)
- Guarded by `useComplianceGuard` — accessible for `COMPLIANCE` + `ADMIN` + `SUPER_ADMIN`
- DTOs in `src/dto/mros.dto.ts` (consistent with `src/dto/order.dto.ts` and `src/dto/recall.dto.ts`)
- `useCompliance` hook extended with `getMrosList()` calling `GET /mros`

## Dependency
- Backend release PR DFXswiss/api#3611 must be merged and deployed to `api.dfx.swiss` first — that release contains the MROS module with `GET /mros` endpoint on `UserRole.COMPLIANCE` guard. Until deployed, this screen will show a 404 error.

## Test plan
- [ ] Wait for DFXswiss/api#3611 to be merged and live on `api.dfx.swiss`
- [ ] Log in as COMPLIANCE user, navigate to `/compliance/mros`
- [ ] Verify all MROS entries are shown with all columns
- [ ] Non-compliance user → redirected away (guard)
- [ ] Empty state message when no MROS entries exist