### PR TITLE
feat: add sitemap page listing all app routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ const DashboardFinancialHistoryScreen = lazy(() => import('./screens/dashboard-f
 const DashboardFinancialLiveScreen = lazy(() => import('./screens/dashboard-financial-live.screen'));
 const DashboardFinancialExpensesScreen = lazy(() => import('./screens/dashboard-financial-expenses.screen'));
 const DashboardFinancialLiquidityScreen = lazy(() => import('./screens/dashboard-financial-liquidity.screen'));
+const SitemapScreen = lazy(() => import('./screens/sitemap.screen'));
 
 setupLanguages();
 
@@ -396,6 +397,10 @@ export const Routes = [
       {
         path: 'compliance/user/:id/kyc',
         element: withSuspense(<ComplianceReviewScreen />),
+      },
+      {
+        path: 'sitemap',
+        element: withSuspense(<SitemapScreen />),
       },
       {
         path: 'support/dashboard',

--- a/src/screens/sitemap.screen.tsx
+++ b/src/screens/sitemap.screen.tsx
@@ -1,0 +1,166 @@
+import { StyledVerticalStack } from '@dfx.swiss/react-components';
+import { Link } from 'react-router-dom';
+import { useAdminGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+interface PageEntry {
+  path: string;
+  label: string;
+}
+
+interface PageSection {
+  title: string;
+  pages: PageEntry[];
+}
+
+const sections: PageSection[] = [
+  {
+    title: 'Auth & Account',
+    pages: [
+      { path: '/', label: 'Home' },
+      { path: '/account', label: 'Account' },
+      { path: '/account/mail', label: 'Edit Mail' },
+      { path: '/settings', label: 'Settings' },
+      { path: '/login', label: 'Login' },
+      { path: '/login/mail', label: 'Login (Mail)' },
+      { path: '/login/wallet', label: 'Login (Wallet)' },
+      { path: '/connect', label: 'Connect' },
+      { path: '/mail-login', label: 'Mail Login' },
+      { path: '/account-merge', label: 'Account Merge' },
+      { path: '/profile', label: 'Profile' },
+      { path: '/contact', label: 'Contact' },
+      { path: '/link', label: 'Link' },
+      { path: '/2fa', label: '2FA' },
+    ],
+  },
+  {
+    title: 'Trading',
+    pages: [
+      { path: '/buy', label: 'Buy' },
+      { path: '/buy/info', label: 'Buy Info' },
+      { path: '/buy/success', label: 'Buy Success' },
+      { path: '/buy/failure', label: 'Buy Failure' },
+      { path: '/buy/personal-iban', label: 'Personal IBAN' },
+      { path: '/sell', label: 'Sell' },
+      { path: '/sell/info', label: 'Sell Info' },
+      { path: '/swap', label: 'Swap' },
+      { path: '/routes', label: 'Payment Routes' },
+      { path: '/buyCrypto/update', label: 'Buy Crypto Update' },
+    ],
+  },
+  {
+    title: 'Payment Links & Invoices',
+    pages: [
+      { path: '/pl', label: 'Payment Link' },
+      { path: '/pl/pos', label: 'Payment Link POS' },
+      { path: '/pl/result', label: 'Payment Link Result' },
+      { path: '/payment-link', label: 'Payment Link (Legacy)' },
+      { path: '/invoice', label: 'Invoice' },
+    ],
+  },
+  {
+    title: 'Transactions',
+    pages: [
+      { path: '/tx', label: 'Transactions' },
+      { path: '/blockchain/tx', label: 'Blockchain Tx' },
+    ],
+  },
+  {
+    title: 'KYC',
+    pages: [
+      { path: '/kyc', label: 'KYC' },
+      { path: '/kyc/redirect', label: 'KYC Redirect' },
+      { path: '/kyc/log', label: 'KYC Log' },
+      { path: '/file/download', label: 'File Download' },
+    ],
+  },
+  {
+    title: 'Support',
+    pages: [
+      { path: '/support', label: 'Support' },
+      { path: '/support/tickets', label: 'Support Tickets' },
+      { path: '/support/telegram', label: 'Telegram Support' },
+      { path: '/support/issue', label: 'Support Issue' },
+      { path: '/support/chat', label: 'Support Chat' },
+    ],
+  },
+  {
+    title: 'Compliance',
+    pages: [
+      { path: '/compliance', label: 'Compliance Dashboard' },
+      { path: '/compliance/kyc-files', label: 'KYC Files' },
+      { path: '/compliance/kyc-files/details', label: 'KYC Files Details' },
+      { path: '/compliance/kyc-stats', label: 'KYC Stats' },
+      { path: '/compliance/transactions', label: 'Transaction List' },
+      { path: '/compliance/custody-orders', label: 'Custody Orders' },
+      { path: '/compliance/recalls', label: 'Recalls' },
+      { path: '/compliance/mros', label: 'MROS Reports' },
+    ],
+  },
+  {
+    title: 'Support Dashboard',
+    pages: [
+      { path: '/support/dashboard', label: 'Support Dashboard' },
+      { path: '/support/dashboard/create', label: 'Create Issue' },
+    ],
+  },
+  {
+    title: 'RealUnit',
+    pages: [
+      { path: '/realunit', label: 'RealUnit' },
+      { path: '/realunit/holders', label: 'Holders' },
+      { path: '/realunit/quotes', label: 'Quotes' },
+      { path: '/realunit/transactions', label: 'Transactions' },
+    ],
+  },
+  {
+    title: 'Financial Dashboard',
+    pages: [
+      { path: '/dashboard', label: 'Dashboard' },
+      { path: '/dashboard/financial', label: 'Financial' },
+      { path: '/dashboard/financial/live', label: 'Financial Live' },
+      { path: '/dashboard/financial/history', label: 'Financial History' },
+      { path: '/dashboard/financial/history/expenses', label: 'Expenses' },
+      { path: '/dashboard/financial/liquidity', label: 'Liquidity' },
+    ],
+  },
+  {
+    title: 'Other',
+    pages: [
+      { path: '/sepa', label: 'SEPA' },
+      { path: '/sepa/manual', label: 'SEPA Manual' },
+      { path: '/stickers', label: 'Stickers' },
+      { path: '/safe', label: 'Safe' },
+      { path: '/recommendation', label: 'Recommendation' },
+    ],
+  },
+];
+
+export default function SitemapScreen(): JSX.Element {
+  useAdminGuard();
+  useLayoutOptions({ title: 'Sitemap', backButton: true, noMaxWidth: true });
+
+  return (
+    <StyledVerticalStack gap={6} full>
+      <div className="w-full grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {sections.map((section) => (
+          <div key={section.title} className="bg-white rounded-lg shadow-sm p-4">
+            <h2 className="text-dfxBlue-800 font-semibold text-base mb-3">{section.title}</h2>
+            <ul className="space-y-1">
+              {section.pages.map((page) => (
+                <li key={page.path}>
+                  <Link
+                    to={page.path}
+                    className="block text-sm text-dfxBlue-400 hover:text-dfxBlue-800 hover:underline"
+                  >
+                    {page.label} <span className="text-dfxGray-700">({page.path})</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </StyledVerticalStack>
+  );
+}

--- a/src/screens/sitemap.screen.tsx
+++ b/src/screens/sitemap.screen.tsx
@@ -134,6 +134,10 @@ const sections: PageSection[] = [
       { path: '/recommendation', label: 'Recommendation' },
     ],
   },
+  {
+    title: 'Admin',
+    pages: [{ path: '/sitemap', label: 'Sitemap' }],
+  },
 ];
 
 export default function SitemapScreen(): JSX.Element {


### PR DESCRIPTION
## Summary
- New route `/sitemap` — admin-only (`useAdminGuard`)
- Grouped overview of all routes in the app (Auth, Trading, Payment Links, Transactions, KYC, Support, Compliance, Support Dashboard, RealUnit, Financial Dashboard, Other)
- Each entry renders as a clickable link with label + path
- Responsive grid (1/2/3 columns based on viewport)

## Notes
- `/compliance/recalls` is already in develop (#1060 merged).
- `/compliance/mros` is listed too — becomes reachable once DFXswiss/services#1061 is merged.
- List is hand-curated (not auto-generated from the routes array) so we can provide readable labels and stable grouping.

## Test plan
- [ ] Log in as ADMIN, navigate to `/sitemap` → overview visible with all sections
- [ ] Non-admin user → redirected away by guard
- [ ] Click a link → navigates to the target page