### PR TITLE
feat: bank transaction details screen in compliance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ const EditMailScreen = lazy(() => import('./screens/edit-mail.screen'));
 const SafeScreen = lazy(() => import('./screens/safe.screen'));
 const TelegramSupportScreen = lazy(() => import('./screens/telegram-support.screen'));
 const ComplianceScreen = lazy(() => import('./screens/compliance.screen'));
+const ComplianceBankTxScreen = lazy(() => import('./screens/compliance-bank-tx.screen'));
 const ComplianceBankTxReturnScreen = lazy(() => import('./screens/compliance-bank-tx-return.screen'));
 const ComplianceKycFilesScreen = lazy(() => import('./screens/compliance-kyc-files.screen'));
 const ComplianceKycFilesDetailsScreen = lazy(() => import('./screens/compliance-kyc-files-details.screen'));
@@ -366,6 +367,10 @@ export const Routes = [
       {
         path: 'compliance/recommendations/:id',
         element: withSuspense(<ComplianceRecommendationGraphScreen />),
+      },
+      {
+        path: 'compliance/bank-tx/:id',
+        element: withSuspense(<ComplianceBankTxScreen />),
       },
       {
         path: 'compliance/bank-tx/:id/return',

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -5,22 +5,12 @@ import { BankTxSearchResult } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
-
-// Row data is cached under this key on click in the compliance search list
-// and read back here. sessionStorage is used because app-handling.context
-// calls history.replaceState(undefined, ...) on mount, which wipes router state.
-const BANK_TX_CACHE_PREFIX = 'bankTx:';
+import { readCachedBankTx } from 'src/util/bank-tx-cache';
 
 function loadBankTx(id?: string, state?: unknown): BankTxSearchResult | undefined {
   const fromState = (state as { bankTx?: BankTxSearchResult } | null)?.bankTx;
   if (fromState) return fromState;
-  if (!id) return undefined;
-  try {
-    const cached = sessionStorage.getItem(`${BANK_TX_CACHE_PREFIX}${id}`);
-    return cached ? (JSON.parse(cached) as BankTxSearchResult) : undefined;
-  } catch {
-    return undefined;
-  }
+  return id ? readCachedBankTx(id) : undefined;
 }
 
 export default function ComplianceBankTxScreen(): JSX.Element {
@@ -61,7 +51,6 @@ export default function ComplianceBankTxScreen(): JSX.Element {
   return (
     <div className="w-full flex flex-col gap-6 max-w-4xl text-left">
       <div className="bg-white rounded-lg shadow-sm p-4">
-        <h2 className="text-dfxGray-700 mb-3">Bank Transaction</h2>
         <table className="text-sm text-dfxBlue-800 text-left">
           <tbody>
             {rows.map(([label, value]) => (

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -1,0 +1,78 @@
+import { StyledButton, StyledButtonWidth, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { useLocation, useParams } from 'react-router-dom';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { BankTxSearchResult } from 'src/hooks/compliance.hook';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+
+function loadBankTx(id?: string, state?: unknown): BankTxSearchResult | undefined {
+  const fromState = (state as { bankTx?: BankTxSearchResult } | null)?.bankTx;
+  if (fromState) return fromState;
+  if (!id) return undefined;
+  try {
+    const cached = sessionStorage.getItem(`bankTx:${id}`);
+    return cached ? (JSON.parse(cached) as BankTxSearchResult) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export default function ComplianceBankTxScreen(): JSX.Element {
+  useComplianceGuard();
+
+  const { id } = useParams<{ id: string }>();
+  const { translate } = useSettingsContext();
+  const { navigate, goBack } = useNavigation();
+  const location = useLocation();
+  const bankTx = loadBankTx(id, location.state);
+
+  useLayoutOptions({ title: translate('screens/compliance', 'Bank Transaction'), backButton: true });
+
+  if (!bankTx) {
+    return (
+      <StyledVerticalStack gap={6} full center>
+        <ErrorHint message={translate('screens/compliance', 'No data available. Please open from search.')} />
+        <StyledButton label={translate('general/actions', 'Back')} onClick={goBack} width={StyledButtonWidth.MD} />
+      </StyledVerticalStack>
+    );
+  }
+
+  const rows: [string, string | number | undefined][] = [
+    [translate('screens/compliance', 'ID'), bankTx.id],
+    [translate('screens/compliance', 'Transaction ID'), bankTx.transactionId],
+    [translate('screens/compliance', 'Type'), bankTx.type],
+    [translate('screens/compliance', 'Account Service Ref'), bankTx.accountServiceRef],
+    [translate('screens/compliance', 'Amount'), `${bankTx.amount} ${bankTx.currency}`],
+    [translate('screens/compliance', 'User name'), bankTx.name],
+    [translate('screens/compliance', 'IBAN'), bankTx.iban],
+  ];
+
+  return (
+    <StyledVerticalStack gap={6} full>
+      <div className="w-full overflow-x-auto">
+        <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
+          <tbody>
+            {rows.map(([label, value]) => (
+              <tr key={label} className="border-b border-dfxGray-300 last:border-0">
+                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800 align-top w-1/3">
+                  {label}
+                </th>
+                <td className="px-4 py-3 text-left text-sm text-dfxBlue-800 break-all">{value ?? '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {bankTx.transactionId && (
+        <StyledButton
+          label={translate('screens/compliance', 'Return')}
+          onClick={() => navigate(`/compliance/bank-tx/${bankTx.transactionId}/return`)}
+          width={StyledButtonWidth.FULL}
+        />
+      )}
+    </StyledVerticalStack>
+  );
+}

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -1,18 +1,22 @@
 import { StyledButton, StyledButtonColor, StyledButtonWidth, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useLocation, useParams } from 'react-router-dom';
-import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { BankTxSearchResult } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 
+// Row data is cached under this key on click in the compliance search list
+// and read back here. sessionStorage is used because app-handling.context
+// calls history.replaceState(undefined, ...) on mount, which wipes router state.
+const BANK_TX_CACHE_PREFIX = 'bankTx:';
+
 function loadBankTx(id?: string, state?: unknown): BankTxSearchResult | undefined {
   const fromState = (state as { bankTx?: BankTxSearchResult } | null)?.bankTx;
   if (fromState) return fromState;
   if (!id) return undefined;
   try {
-    const cached = sessionStorage.getItem(`bankTx:${id}`);
+    const cached = sessionStorage.getItem(`${BANK_TX_CACHE_PREFIX}${id}`);
     return cached ? (JSON.parse(cached) as BankTxSearchResult) : undefined;
   } catch {
     return undefined;
@@ -28,38 +32,42 @@ export default function ComplianceBankTxScreen(): JSX.Element {
   const location = useLocation();
   const bankTx = loadBankTx(id, location.state);
 
-  useLayoutOptions({ title: translate('screens/compliance', 'Bank Transaction'), backButton: true });
+  useLayoutOptions({ title: 'Bank Transaction Details', backButton: true });
 
   if (!bankTx) {
     return (
       <StyledVerticalStack gap={6} full center>
-        <ErrorHint message={translate('screens/compliance', 'No data available. Please open from search.')} />
-        <StyledButton label={translate('general/actions', 'Back')} onClick={goBack} width={StyledButtonWidth.MD} />
+        <p className="text-dfxGray-700">No data available. Please open from search.</p>
+        <StyledButton
+          label={translate('general/actions', 'Back')}
+          onClick={goBack}
+          width={StyledButtonWidth.MD}
+          color={StyledButtonColor.GRAY_OUTLINE}
+        />
       </StyledVerticalStack>
     );
   }
 
   const rows: [string, string | number | undefined][] = [
-    [translate('screens/compliance', 'ID'), bankTx.id],
-    [translate('screens/compliance', 'Transaction ID'), bankTx.transactionId],
-    [translate('screens/compliance', 'Type'), bankTx.type],
-    [translate('screens/compliance', 'Account Service Ref'), bankTx.accountServiceRef],
-    [translate('screens/compliance', 'Amount'), `${bankTx.amount} ${bankTx.currency}`],
-    [translate('screens/compliance', 'User name'), bankTx.name],
-    [translate('screens/compliance', 'IBAN'), bankTx.iban],
+    ['ID', bankTx.id],
+    ['Transaction ID', bankTx.transactionId],
+    ['Type', bankTx.type],
+    ['Account Service Ref', bankTx.accountServiceRef],
+    ['Amount', `${bankTx.amount} ${bankTx.currency}`],
+    ['User name', bankTx.name],
+    ['IBAN', bankTx.iban],
   ];
 
   return (
-    <StyledVerticalStack gap={6} full>
-      <div className="w-full overflow-x-auto">
-        <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
+    <div className="w-full flex flex-col gap-6 max-w-4xl text-left">
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <h2 className="text-dfxGray-700 mb-3">Bank Transaction</h2>
+        <table className="text-sm text-dfxBlue-800 text-left">
           <tbody>
             {rows.map(([label, value]) => (
-              <tr key={label} className="border-b border-dfxGray-300 last:border-0">
-                <th className="px-4 py-3 text-left text-sm font-semibold text-dfxBlue-800 align-top w-1/3">
-                  {label}
-                </th>
-                <td className="px-4 py-3 text-left text-sm text-dfxBlue-800 break-all">{value ?? '-'}</td>
+              <tr key={label}>
+                <td className="pr-4 py-1 font-medium whitespace-nowrap align-top">{label}:</td>
+                <td className="py-1 break-all">{value ?? '-'}</td>
               </tr>
             ))}
           </tbody>
@@ -68,12 +76,12 @@ export default function ComplianceBankTxScreen(): JSX.Element {
 
       {bankTx.transactionId && (
         <StyledButton
-          label={translate('screens/compliance', 'Return')}
-          onClick={() => navigate(`/compliance/bank-tx/${bankTx.transactionId}/return`)}
+          label="Return"
+          onClick={() => navigate(`compliance/bank-tx/${bankTx.transactionId}/return`)}
           width={StyledButtonWidth.FULL}
           color={StyledButtonColor.BLUE}
         />
       )}
-    </StyledVerticalStack>
+    </div>
   );
 }

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -6,6 +6,7 @@ import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { readCachedBankTx } from 'src/util/bank-tx-cache';
+import { DetailRow } from 'src/util/compliance-helpers';
 
 function loadBankTx(id?: string, state?: unknown): BankTxSearchResult | undefined {
   const fromState = (state as { bankTx?: BankTxSearchResult } | null)?.bankTx;
@@ -38,27 +39,18 @@ export default function ComplianceBankTxScreen(): JSX.Element {
     );
   }
 
-  const rows: [string, string | number | undefined][] = [
-    ['ID', bankTx.id],
-    ['Transaction ID', bankTx.transactionId],
-    ['Type', bankTx.type],
-    ['Account Service Ref', bankTx.accountServiceRef],
-    ['Amount', `${bankTx.amount} ${bankTx.currency}`],
-    ['User name', bankTx.name],
-    ['IBAN', bankTx.iban],
-  ];
-
   return (
     <div className="w-full flex flex-col gap-6 max-w-4xl text-left">
       <div className="bg-white rounded-lg shadow-sm p-4">
         <table className="text-sm text-dfxBlue-800 text-left">
           <tbody>
-            {rows.map(([label, value]) => (
-              <tr key={label}>
-                <td className="pr-4 py-1 font-medium whitespace-nowrap align-top">{label}:</td>
-                <td className="py-1 break-all">{value ?? '-'}</td>
-              </tr>
-            ))}
+            <DetailRow label="ID" value={bankTx.id} />
+            <DetailRow label="Transaction ID" value={bankTx.transactionId} />
+            <DetailRow label="Type" value={bankTx.type} />
+            <DetailRow label="Account Service Ref" value={bankTx.accountServiceRef} />
+            <DetailRow label="Amount" value={`${bankTx.amount} ${bankTx.currency}`} />
+            <DetailRow label="Name" value={bankTx.name} />
+            <DetailRow label="IBAN" value={bankTx.iban} mono />
           </tbody>
         </table>
       </div>

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -1,4 +1,4 @@
-import { StyledButton, StyledButtonWidth, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { StyledButton, StyledButtonColor, StyledButtonWidth, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useLocation, useParams } from 'react-router-dom';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
@@ -71,6 +71,7 @@ export default function ComplianceBankTxScreen(): JSX.Element {
           label={translate('screens/compliance', 'Return')}
           onClick={() => navigate(`/compliance/bank-tx/${bankTx.transactionId}/return`)}
           width={StyledButtonWidth.FULL}
+          color={StyledButtonColor.BLUE}
         />
       )}
     </StyledVerticalStack>

--- a/src/screens/compliance.screen.tsx
+++ b/src/screens/compliance.screen.tsx
@@ -26,6 +26,7 @@ import {
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
+import { cacheBankTx } from 'src/util/bank-tx-cache';
 
 interface FormData {
   key: string;
@@ -191,7 +192,7 @@ export default function ComplianceScreen(): JSX.Element {
             color={IconColor.BLUE}
             size={IconSize.SM}
             onClick={() => {
-              sessionStorage.setItem(`bankTx:${b.id}`, JSON.stringify(b));
+              cacheBankTx(b);
               navigate(`compliance/bank-tx/${b.id}`);
             }}
           />

--- a/src/screens/compliance.screen.tsx
+++ b/src/screens/compliance.screen.tsx
@@ -186,14 +186,15 @@ export default function ComplianceScreen(): JSX.Element {
       label: '',
       render: (b: BankTxSearchResult) => (
         <div className="flex gap-2 justify-end items-center">
-          {b.transactionId && (
-            <StyledIconButton
-              icon={IconVariant.BACK}
-              color={IconColor.BLUE}
-              size={IconSize.SM}
-              onClick={() => navigate(`compliance/bank-tx/${b.transactionId}/return`)}
-            />
-          )}
+          <StyledIconButton
+            icon={IconVariant.FORWARD}
+            color={IconColor.BLUE}
+            size={IconSize.SM}
+            onClick={() => {
+              sessionStorage.setItem(`bankTx:${b.id}`, JSON.stringify(b));
+              navigate(`compliance/bank-tx/${b.id}`);
+            }}
+          />
         </div>
       ),
     },

--- a/src/util/bank-tx-cache.ts
+++ b/src/util/bank-tx-cache.ts
@@ -1,0 +1,20 @@
+import { BankTxSearchResult } from 'src/hooks/compliance.hook';
+
+// Used to carry a bank-tx row from the compliance search list into the
+// details screen. sessionStorage is needed because app-handling.context
+// calls history.replaceState(undefined, ...) on mount, which wipes router
+// state, and there is no backend endpoint to refetch a single bank-tx.
+const BANK_TX_CACHE_PREFIX = 'bankTx:';
+
+export function cacheBankTx(bankTx: BankTxSearchResult): void {
+  sessionStorage.setItem(`${BANK_TX_CACHE_PREFIX}${bankTx.id}`, JSON.stringify(bankTx));
+}
+
+export function readCachedBankTx(id: string): BankTxSearchResult | undefined {
+  try {
+    const cached = sessionStorage.getItem(`${BANK_TX_CACHE_PREFIX}${id}`);
+    return cached ? (JSON.parse(cached) as BankTxSearchResult) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/util/bank-tx-cache.ts
+++ b/src/util/bank-tx-cache.ts
@@ -4,7 +4,7 @@ import { BankTxSearchResult } from 'src/hooks/compliance.hook';
 // details screen. sessionStorage is needed because app-handling.context
 // calls history.replaceState(undefined, ...) on mount, which wipes router
 // state, and there is no backend endpoint to refetch a single bank-tx.
-const BANK_TX_CACHE_PREFIX = 'bankTx:';
+const BANK_TX_CACHE_PREFIX = 'dfx.bankTx.';
 
 export function cacheBankTx(bankTx: BankTxSearchResult): void {
   sessionStorage.setItem(`${BANK_TX_CACHE_PREFIX}${bankTx.id}`, JSON.stringify(bankTx));


### PR DESCRIPTION
## Summary
- New `compliance/bank-tx/:id` details screen listing all fields from the bank-tx search result (ID, Transaction ID, Type, Account Service Ref, Amount, User name, IBAN)
- Card-based layout matches the existing compliance detail screens (see `compliance-support-issue.screen.tsx`)
- Search row now shows a `>` chevron that opens the details page; clicking navigates via cached row data
- Details page has a `Return` button that links into the existing `compliance/bank-tx/:id/return` refund flow, shown only when a linked transaction exists

## UX notes
- The chevron is now shown for every unassigned bank-tx row, not only rows with a linked `transactionId`. Rows without a linked transaction still open the details page (useful for inspection) — the `Return` button is then hidden.
- Row data is cached in `sessionStorage` on click because `app-handling.context` calls `history.replaceState(undefined, ...)` on mount, which wipes router state. There is no backend endpoint to re-fetch a single bank-tx by id.

## Test plan
- [ ] Run compliance search that returns unassigned bank transactions
- [ ] Click the `>` chevron in an Unassigned Bank Transactions row → details page opens with all fields populated
- [ ] Click `Return` → existing refund form loads with the correct transaction
- [ ] Back button returns to the search results
- [ ] Row without `transactionId` → details page renders, Return button hidden