### PR TITLE
feat: recall creation for bank transactions in compliance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const SafeScreen = lazy(() => import('./screens/safe.screen'));
 const TelegramSupportScreen = lazy(() => import('./screens/telegram-support.screen'));
 const ComplianceScreen = lazy(() => import('./screens/compliance.screen'));
 const ComplianceBankTxScreen = lazy(() => import('./screens/compliance-bank-tx.screen'));
+const ComplianceBankTxRecallScreen = lazy(() => import('./screens/compliance-bank-tx-recall.screen'));
 const ComplianceBankTxReturnScreen = lazy(() => import('./screens/compliance-bank-tx-return.screen'));
 const ComplianceKycFilesScreen = lazy(() => import('./screens/compliance-kyc-files.screen'));
 const ComplianceKycFilesDetailsScreen = lazy(() => import('./screens/compliance-kyc-files-details.screen'));
@@ -371,6 +372,10 @@ export const Routes = [
       {
         path: 'compliance/bank-tx/:id',
         element: withSuspense(<ComplianceBankTxScreen />),
+      },
+      {
+        path: 'compliance/bank-tx/:id/recall',
+        element: withSuspense(<ComplianceBankTxRecallScreen />),
       },
       {
         path: 'compliance/bank-tx/:id/return',

--- a/src/dto/recall.dto.ts
+++ b/src/dto/recall.dto.ts
@@ -20,3 +20,13 @@ export interface RecallListEntry {
   checkoutTx?: { id: number };
   user?: { id: number };
 }
+
+export interface CreateRecallDto {
+  bankTxId?: number;
+  checkoutTxId?: number;
+  sequence: number;
+  comment: string;
+  fee: number;
+  reason: RecallReason;
+  userId?: number;
+}

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -10,7 +10,7 @@ import {
 } from '@dfx.swiss/react';
 import { MrosListEntry } from 'src/dto/mros.dto';
 import { CustodyOrderListEntry } from 'src/dto/order.dto';
-import { RecallListEntry } from 'src/dto/recall.dto';
+import { CreateRecallDto, RecallListEntry } from 'src/dto/recall.dto';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
 import { useMemo } from 'react';
 import { downloadFile, downloadPdfFromString, filenameDateFormat } from 'src/util/utils';
@@ -525,6 +525,14 @@ export function useCompliance() {
     });
   }
 
+  async function createRecall(dto: CreateRecallDto): Promise<void> {
+    return call<void>({
+      url: 'recall',
+      method: 'POST',
+      data: dto,
+    });
+  }
+
   async function getRecommendationGraph(userDataId: number): Promise<RecommendationGraph> {
     return call<RecommendationGraph>({
       url: `support/recommendation-graph/${userDataId}`,
@@ -664,6 +672,7 @@ export function useCompliance() {
       approveCustodyOrder,
       getMrosList,
       getRecalls,
+      createRecall,
       updateKycStep,
       updateUserData,
       createLimitRequest,

--- a/src/screens/compliance-bank-tx-recall.screen.tsx
+++ b/src/screens/compliance-bank-tx-recall.screen.tsx
@@ -48,7 +48,7 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
     defaultValues: { fee: '500', comment: 'n.a.' },
   });
 
-  useLayoutOptions({ title: 'Recall erfassen', backButton: true });
+  useLayoutOptions({ title: translate('screens/compliance', 'Recall erfassen'), backButton: true });
 
   async function onSubmit(formData: FormData) {
     if (!id) return;
@@ -97,7 +97,7 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
         <StyledDropdown<RecallReason>
           rootRef={rootRef}
           name="reason"
-          label="Reason"
+          label={translate('screens/compliance', 'Reason')}
           placeholder={translate('general/actions', 'Select') + '...'}
           items={Object.values(RecallReason).filter((r) => r !== RecallReason.UNKNOWN)}
           labelFunc={(item) => item}
@@ -108,13 +108,13 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
         <StyledInput
           name="fee"
           type="number"
-          label="Fee"
+          label={translate('screens/compliance', 'Fee')}
           placeholder="0"
           full
           smallLabel
         />
 
-        <StyledInput name="comment" label="Comment" full smallLabel />
+        <StyledInput name="comment" label={translate('screens/compliance', 'Comment')} full smallLabel />
 
         {error && (
           <div>

--- a/src/screens/compliance-bank-tx-recall.screen.tsx
+++ b/src/screens/compliance-bank-tx-recall.screen.tsx
@@ -82,7 +82,9 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
     return (
       <StyledVerticalStack gap={6} full center>
         <div className="text-center">
-          <h2 className="text-dfxBlue-800 text-xl font-semibold mb-4">Recall created successfully</h2>
+          <h2 className="text-dfxBlue-800 text-xl font-semibold mb-4">
+            {translate('screens/compliance', 'Recall created successfully')}
+          </h2>
           <StyledButton label={translate('general/actions', 'Back')} onClick={() => navigate(-1)} width={StyledButtonWidth.MD} />
         </div>
       </StyledVerticalStack>
@@ -122,7 +124,7 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
 
         <StyledButton
           type="submit"
-          label="Submit"
+          label={translate('general/actions', 'Create recall')}
           onClick={handleSubmit(onSubmit)}
           width={StyledButtonWidth.FULL}
           disabled={!isValid}

--- a/src/screens/compliance-bank-tx-recall.screen.tsx
+++ b/src/screens/compliance-bank-tx-recall.screen.tsx
@@ -1,0 +1,138 @@
+import { Utils, Validations } from '@dfx.swiss/react';
+import {
+  Form,
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledDropdown,
+  StyledInput,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
+import { ErrorHint } from 'src/components/error-hint';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { RecallReason } from 'src/dto/recall.dto';
+import { useCompliance } from 'src/hooks/compliance.hook';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+
+interface FormData {
+  reason: RecallReason;
+  comment: string;
+  fee: string;
+}
+
+export default function ComplianceBankTxRecallScreen(): JSX.Element {
+  useComplianceGuard();
+
+  const { id } = useParams<{ id: string }>();
+  const { translate, translateError } = useSettingsContext();
+  const { createRecall } = useCompliance();
+  const { goBack } = useNavigation();
+  const { rootRef } = useLayoutContext();
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid, errors },
+  } = useForm<FormData>({ mode: 'onTouched' });
+
+  useLayoutOptions({ title: 'Recall erfassen', backButton: true });
+
+  async function onSubmit(formData: FormData) {
+    if (!id) return;
+
+    setIsSubmitting(true);
+    setError(undefined);
+
+    try {
+      await createRecall({
+        bankTxId: +id,
+        sequence: 1,
+        reason: formData.reason,
+        comment: formData.comment,
+        fee: Number(formData.fee),
+      });
+      setSuccess(true);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const rules = Utils.createRules({
+    reason: Validations.Required,
+    comment: Validations.Required,
+    fee: [Validations.Required, Validations.Custom((v) => (isNaN(Number(v)) ? 'pattern' : true))],
+  });
+
+  if (success) {
+    return (
+      <StyledVerticalStack gap={6} full center>
+        <div className="text-center">
+          <h2 className="text-dfxBlue-800 text-xl font-semibold mb-4">Recall created successfully</h2>
+          <StyledButton label={translate('general/actions', 'Back')} onClick={goBack} width={StyledButtonWidth.MD} />
+        </div>
+      </StyledVerticalStack>
+    );
+  }
+
+  return (
+    <Form control={control} rules={rules} errors={errors} onSubmit={handleSubmit(onSubmit)} translate={translateError}>
+      <StyledVerticalStack gap={6} full>
+        <StyledDropdown<RecallReason>
+          rootRef={rootRef}
+          name="reason"
+          label="Reason"
+          placeholder={translate('general/actions', 'Select') + '...'}
+          items={Object.values(RecallReason).filter((r) => r !== RecallReason.UNKNOWN)}
+          labelFunc={(item) => item}
+          full
+          smallLabel
+        />
+
+        <StyledInput
+          name="fee"
+          type="number"
+          label="Fee"
+          placeholder="0"
+          full
+          smallLabel
+        />
+
+        <StyledInput name="comment" label="Comment" full smallLabel />
+
+        {error && (
+          <div>
+            <ErrorHint message={error} />
+          </div>
+        )}
+
+        <StyledButton
+          type="submit"
+          label="Submit"
+          onClick={handleSubmit(onSubmit)}
+          width={StyledButtonWidth.FULL}
+          disabled={!isValid}
+          isLoading={isSubmitting}
+        />
+
+        <StyledButton
+          label={translate('general/actions', 'Cancel')}
+          onClick={goBack}
+          width={StyledButtonWidth.FULL}
+          color={StyledButtonColor.WHITE}
+        />
+      </StyledVerticalStack>
+    </Form>
+  );
+}

--- a/src/screens/compliance-bank-tx-recall.screen.tsx
+++ b/src/screens/compliance-bank-tx-recall.screen.tsx
@@ -32,7 +32,7 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const { translate, translateError } = useSettingsContext();
   const { createRecall } = useCompliance();
-  const { goBack } = useNavigation();
+  const { navigate } = useNavigation();
   const { rootRef } = useLayoutContext();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -43,7 +43,10 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
     control,
     handleSubmit,
     formState: { isValid, errors },
-  } = useForm<FormData>({ mode: 'onTouched' });
+  } = useForm<FormData>({
+    mode: 'onTouched',
+    defaultValues: { fee: '500', comment: 'n.a.' },
+  });
 
   useLayoutOptions({ title: 'Recall erfassen', backButton: true });
 
@@ -80,7 +83,7 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
       <StyledVerticalStack gap={6} full center>
         <div className="text-center">
           <h2 className="text-dfxBlue-800 text-xl font-semibold mb-4">Recall created successfully</h2>
-          <StyledButton label={translate('general/actions', 'Back')} onClick={goBack} width={StyledButtonWidth.MD} />
+          <StyledButton label={translate('general/actions', 'Back')} onClick={() => navigate(-1)} width={StyledButtonWidth.MD} />
         </div>
       </StyledVerticalStack>
     );
@@ -128,7 +131,7 @@ export default function ComplianceBankTxRecallScreen(): JSX.Element {
 
         <StyledButton
           label={translate('general/actions', 'Cancel')}
-          onClick={goBack}
+          onClick={() => navigate(-1)}
           width={StyledButtonWidth.FULL}
           color={StyledButtonColor.WHITE}
         />

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -55,6 +55,13 @@ export default function ComplianceBankTxScreen(): JSX.Element {
         </table>
       </div>
 
+      <StyledButton
+        label="Recall erfassen"
+        onClick={() => navigate(`compliance/bank-tx/${bankTx.id}/recall`)}
+        width={StyledButtonWidth.FULL}
+        color={StyledButtonColor.BLUE}
+      />
+
       {bankTx.transactionId && (
         <StyledButton
           label="Return"

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -56,7 +56,7 @@ export default function ComplianceBankTxScreen(): JSX.Element {
       </div>
 
       <StyledButton
-        label="Recall erfassen"
+        label={translate('screens/compliance', 'Recall erfassen')}
         onClick={() => navigate(`compliance/bank-tx/${bankTx.id}/recall`)}
         width={StyledButtonWidth.FULL}
         color={StyledButtonColor.BLUE}
@@ -64,7 +64,7 @@ export default function ComplianceBankTxScreen(): JSX.Element {
 
       {bankTx.transactionId && (
         <StyledButton
-          label="Return"
+          label={translate('screens/compliance', 'Return')}
           onClick={() => navigate(`compliance/bank-tx/${bankTx.transactionId}/return`)}
           width={StyledButtonWidth.FULL}
           color={StyledButtonColor.BLUE}


### PR DESCRIPTION
## Summary
- Adds a `Recall erfassen` button to the bank transaction details screen
- Opens a new `compliance/bank-tx/:id/recall` form screen to create a recall via `POST /recall`
- Form fields: `reason` (RecallReason dropdown, excluding `Unknown`), `fee` (number), `comment` (text). `sequence` is fixed to 1; `bankTxId` comes from the URL.

## Changes
- `CreateRecallDto` added to `src/dto/recall.dto.ts`
- `createRecall` method added to `src/hooks/compliance.hook.ts`
- New screen `src/screens/compliance-bank-tx-recall.screen.tsx` (mirrors the return-screen pattern)
- New route and lazy import in `src/App.tsx`

## Test plan
- [ ] Open a bank transaction via compliance search → click `Recall erfassen`
- [ ] Submit with a valid reason / fee / comment → success screen, recall visible in `compliance/recalls`
- [ ] Cancel returns to details screen
- [ ] Form validation blocks empty fields and non-numeric fee