### PR TITLE
feat: polish compliance bank tx list after API search extension

### DIFF
--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -6,9 +6,7 @@ import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { readCachedBankTx } from 'src/util/bank-tx-cache';
-import { DetailRow } from 'src/util/compliance-helpers';
-
-const UNASSIGNED_BANK_TX_TYPES = ['GSheet', 'Unknown', 'Pending'];
+import { BankTxUnassignedTypes, DetailRow } from 'src/util/compliance-helpers';
 
 function loadBankTx(id?: string, state?: unknown): BankTxSearchResult | undefined {
   const fromState = (state as { bankTx?: BankTxSearchResult } | null)?.bankTx;
@@ -64,7 +62,7 @@ export default function ComplianceBankTxScreen(): JSX.Element {
         color={StyledButtonColor.BLUE}
       />
 
-      {bankTx.transactionId && UNASSIGNED_BANK_TX_TYPES.includes(bankTx.type) && (
+      {bankTx.transactionId && BankTxUnassignedTypes.includes(bankTx.type) && (
         <StyledButton
           label={translate('screens/compliance', 'Return')}
           onClick={() => navigate(`compliance/bank-tx/${bankTx.transactionId}/return`)}

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -8,6 +8,8 @@ import { useNavigation } from 'src/hooks/navigation.hook';
 import { readCachedBankTx } from 'src/util/bank-tx-cache';
 import { DetailRow } from 'src/util/compliance-helpers';
 
+const UNASSIGNED_BANK_TX_TYPES = ['GSheet', 'Unknown', 'Pending'];
+
 function loadBankTx(id?: string, state?: unknown): BankTxSearchResult | undefined {
   const fromState = (state as { bankTx?: BankTxSearchResult } | null)?.bankTx;
   if (fromState) return fromState;
@@ -62,7 +64,7 @@ export default function ComplianceBankTxScreen(): JSX.Element {
         color={StyledButtonColor.BLUE}
       />
 
-      {bankTx.transactionId && (
+      {bankTx.transactionId && UNASSIGNED_BANK_TX_TYPES.includes(bankTx.type) && (
         <StyledButton
           label={translate('screens/compliance', 'Return')}
           onClick={() => navigate(`compliance/bank-tx/${bankTx.transactionId}/return`)}

--- a/src/screens/compliance.screen.tsx
+++ b/src/screens/compliance.screen.tsx
@@ -312,9 +312,7 @@ export default function ComplianceScreen(): JSX.Element {
 
               {searchResult.bankTx.length > 0 && (
                 <div className="w-full">
-                  <h2 className="text-dfxGray-700">
-                    {translate('screens/compliance', 'Unassigned Bank Transactions')}
-                  </h2>
+                  <h2 className="text-dfxGray-700">{translate('screens/compliance', 'Matching Bank Transactions')}</h2>
                   <div className="w-full overflow-x-auto">
                     <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
                       <thead>

--- a/src/screens/compliance.screen.tsx
+++ b/src/screens/compliance.screen.tsx
@@ -312,7 +312,7 @@ export default function ComplianceScreen(): JSX.Element {
 
               {searchResult.bankTx.length > 0 && (
                 <div className="w-full">
-                  <h2 className="text-dfxGray-700">{translate('screens/compliance', 'Matching Bank Transactions')}</h2>
+                  <h2 className="text-dfxGray-700">{translate('screens/compliance', 'Bank Transactions')}</h2>
                   <div className="w-full overflow-x-auto">
                     <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
                       <thead>

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -396,7 +396,7 @@
     "No entries found": "Keine Einträge gefunden",
     "found by {{type}}": "gefunden per {{type}}",
     "Customers": "Kunden",
-    "Matching Bank Transactions": "Passende Banktransaktionen"
+    "Bank Transactions": "Banktransaktionen"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -396,7 +396,7 @@
     "No entries found": "Keine Einträge gefunden",
     "found by {{type}}": "gefunden per {{type}}",
     "Customers": "Kunden",
-    "Unassigned Bank Transactions": "Nicht zugeordnete Banktransaktionen"
+    "Matching Bank Transactions": "Passende Banktransaktionen"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -396,7 +396,7 @@
     "No entries found": "Aucune entrée trouvée",
     "found by {{type}}": "trouvés par {{type}}",
     "Customers": "Clients",
-    "Matching Bank Transactions": "Transactions bancaires correspondantes"
+    "Bank Transactions": "Transactions bancaires"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -396,7 +396,7 @@
     "No entries found": "Aucune entrée trouvée",
     "found by {{type}}": "trouvés par {{type}}",
     "Customers": "Clients",
-    "Unassigned Bank Transactions": "Transactions bancaires non attribuées"
+    "Matching Bank Transactions": "Transactions bancaires correspondantes"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -396,7 +396,7 @@
     "No entries found": "Nessuna voce trovata",
     "found by {{type}}": "trovati tramite {{type}}",
     "Customers": "Clienti",
-    "Matching Bank Transactions": "Transazioni bancarie corrispondenti"
+    "Bank Transactions": "Transazioni bancarie"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -396,7 +396,7 @@
     "No entries found": "Nessuna voce trovata",
     "found by {{type}}": "trovati tramite {{type}}",
     "Customers": "Clienti",
-    "Unassigned Bank Transactions": "Transazioni bancarie non assegnate"
+    "Matching Bank Transactions": "Transazioni bancarie corrispondenti"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -122,6 +122,10 @@ export function todayAsString(): string {
   return new Date().toISOString().split('T')[0];
 }
 
+// Mirrors `BankTxUnassignedTypes` in DFXswiss/api (bank-tx.entity.ts).
+// Only these types still allow a manual Return via compliance.
+export const BankTxUnassignedTypes = ['GSheet', 'Unknown', 'Pending'];
+
 export function formatDate(value: string): string {
   return new Date(value).toLocaleDateString();
 }


### PR DESCRIPTION
## Summary
Follow-up to DFXswiss/api#3615, which extended the compliance search to also return `BankTxReturn` and `BankTxRepeat` rows (in addition to the existing unassigned `GSheet`/`Unknown`/`Pending` types).

Four UI adjustments:

1. **Rename section header** on `compliance.screen.tsx` from _"Unassigned Bank Transactions"_ → _"Bank Transactions"_. The list is no longer limited to unassigned txs, and the shorter label is consistent with the sibling "Customers" section under the same "Matching Entries" H1.
2. **Translations updated** (`de.json`, `fr.json`, `it.json`) — replaced the old key with the new one so non-English users see a proper localized label instead of the English fallback.
3. **Hide Return button** on `compliance-bank-tx.screen.tsx` for non-unassigned types. Triggering a refund on a `BankTxReturn`/`BankTxRepeat` row would fail on the API side (`support.service.ts` short-circuits via `BankTxTypeUnassigned`), so the button was a dead end. Only shown now for `GSheet`/`Unknown`/`Pending`.
4. **Refactor** — moved the `BankTxUnassignedTypes` constant from a local magic-string array in the screen to a shared export in `compliance-helpers.tsx`. Naming mirrors the API constant (`bank-tx.entity.ts`) for discoverability; a comment in the helper links back to the source of truth.

The _Recall erfassen_ button is left unchanged — a recall can still be meaningful for completed txs.

## Test plan
- [ ] Search for a name that matches a `BankTxReturn` → section header shows "Bank Transactions", detail page shows **no** Return button (only Recall).
- [ ] Search for a name that matches a `Pending` tx → detail page **still** shows Return button.
- [ ] Switch UI to DE/FR/IT → section header localized correctly ("Banktransaktionen" / "Transactions bancaires" / "Transazioni bancarie").