### PR TITLE
feat: add recall button to user-data transactions tab

### DIFF
--- a/src/components/compliance/recall-modal.tsx
+++ b/src/components/compliance/recall-modal.tsx
@@ -1,0 +1,155 @@
+import { Utils, Validations } from '@dfx.swiss/react';
+import {
+  Form,
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledDropdown,
+  StyledInput,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorHint } from 'src/components/error-hint';
+import { Modal } from 'src/components/modal';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { RecallReason } from 'src/dto/recall.dto';
+import { useCompliance } from 'src/hooks/compliance.hook';
+
+interface RecallModalProps {
+  readonly isOpen: boolean;
+  readonly bankTxId: number | undefined;
+  readonly onClose: () => void;
+  readonly onSuccess: () => void;
+}
+
+interface RecallFormData {
+  reason: RecallReason;
+  comment: string;
+  fee: string;
+}
+
+export function RecallModal({ isOpen, bankTxId, onClose, onSuccess }: RecallModalProps): JSX.Element {
+  const { translate, translateError } = useSettingsContext();
+  const { createRecall } = useCompliance();
+  const { rootRef } = useLayoutContext();
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid, errors },
+    reset,
+  } = useForm<RecallFormData>({
+    mode: 'onTouched',
+    defaultValues: { fee: '500', comment: 'n.a.' },
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      setError(undefined);
+      reset({ fee: '500', comment: 'n.a.' });
+    }
+  }, [isOpen]);
+
+  async function onSubmit(formData: RecallFormData): Promise<void> {
+    if (!bankTxId) return;
+
+    setIsSubmitting(true);
+    setError(undefined);
+
+    try {
+      await createRecall({
+        bankTxId,
+        sequence: 1,
+        reason: formData.reason,
+        comment: formData.comment,
+        fee: Number(formData.fee),
+      });
+      onSuccess();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleClose(): void {
+    reset({ fee: '500', comment: 'n.a.' });
+    setError(undefined);
+    onClose();
+  }
+
+  const rules = Utils.createRules({
+    reason: Validations.Required,
+    comment: Validations.Required,
+    fee: [Validations.Required, Validations.Custom((v) => (isNaN(Number(v)) ? 'pattern' : true))],
+  });
+
+  if (!isOpen) return <></>;
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <div className="bg-white rounded-lg shadow-sm p-6 max-w-lg mx-auto w-full">
+        <h2 className="text-lg font-semibold text-dfxBlue-800 mb-4 text-left">
+          {translate('screens/compliance', 'Recall erfassen')}
+        </h2>
+
+        <Form
+          control={control}
+          rules={rules}
+          errors={errors}
+          onSubmit={handleSubmit(onSubmit)}
+          translate={translateError}
+        >
+          <StyledVerticalStack gap={4} full>
+            <StyledDropdown<RecallReason>
+              rootRef={rootRef}
+              name="reason"
+              label={translate('screens/compliance', 'Reason')}
+              placeholder={translate('general/actions', 'Select') + '...'}
+              items={Object.values(RecallReason).filter((r) => r !== RecallReason.UNKNOWN)}
+              labelFunc={(item) => item}
+              full
+              smallLabel
+            />
+
+            <StyledInput
+              name="fee"
+              type="number"
+              label={translate('screens/compliance', 'Fee')}
+              placeholder="0"
+              full
+              smallLabel
+            />
+
+            <StyledInput name="comment" label={translate('screens/compliance', 'Comment')} full smallLabel />
+
+            {error && <ErrorHint message={error} />}
+
+            <div className="flex gap-2 w-full">
+              <StyledButton
+                label={translate('general/actions', 'Cancel')}
+                onClick={handleClose}
+                width={StyledButtonWidth.FULL}
+                color={StyledButtonColor.STURDY_WHITE}
+                disabled={isSubmitting}
+              />
+              <StyledButton
+                type="submit"
+                label={translate('general/actions', 'Create recall')}
+                onClick={handleSubmit(onSubmit)}
+                width={StyledButtonWidth.FULL}
+                disabled={!isValid}
+                isLoading={isSubmitting}
+              />
+            </div>
+          </StyledVerticalStack>
+        </Form>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/compliance/recall-modal.tsx
+++ b/src/components/compliance/recall-modal.tsx
@@ -51,7 +51,7 @@ export function RecallModal({ isOpen, bankTxId, onClose, onSuccess }: RecallModa
   useEffect(() => {
     if (!isOpen) {
       setError(undefined);
-      reset({ fee: '500', comment: 'n.a.' });
+      reset();
     }
   }, [isOpen]);
 
@@ -78,7 +78,7 @@ export function RecallModal({ isOpen, bankTxId, onClose, onSuccess }: RecallModa
   }
 
   function handleClose(): void {
-    reset({ fee: '500', comment: 'n.a.' });
+    reset();
     setError(undefined);
     onClose();
   }

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -2,6 +2,7 @@ import { Transaction, TransactionState, useTransaction } from '@dfx.swiss/react'
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { Fragment, useState } from 'react';
 import { ChargebackModal } from 'src/components/compliance/chargeback-modal';
+import { RecallModal } from 'src/components/compliance/recall-modal';
 import { ConfirmDialog } from 'src/components/confirm-dialog';
 import { BankTxInfo, CryptoInputInfo, TransactionInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { DetailRow, TransactionDetailRows, formatDate, statusBadge } from 'src/util/compliance-helpers';
@@ -44,6 +45,7 @@ export function TransactionsTable({
   const [stopConfirmTxId, setStopConfirmTxId] = useState<number>();
   const [stopError, setStopError] = useState<string>();
   const [chargebackTxId, setChargebackTxId] = useState<number>();
+  const [recallBankTxId, setRecallBankTxId] = useState<number>();
 
   async function confirmStop(): Promise<void> {
     const txId = stopConfirmTxId;
@@ -294,33 +296,30 @@ export function TransactionsTable({
                             return (
                               <>
                                 <TransactionDetailRows tx={detail} />
-                                {((tx.type === 'BuyCrypto' && !tx.isCompleted) ||
-                                  ([
-                                    TransactionState.FAILED,
-                                    TransactionState.CHECK_PENDING,
-                                    TransactionState.KYC_REQUIRED,
-                                    TransactionState.LIMIT_EXCEEDED,
-                                    TransactionState.UNASSIGNED,
-                                  ].includes(detail.state) &&
-                                    !detail.chargebackAmount)) && (
-                                  <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2">
-                                    {tx.type === 'BuyCrypto' && !tx.isCompleted && (
-                                      <button
-                                        className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                                        onClick={() => setStopConfirmTxId(tx.id)}
-                                        disabled={stoppingTxId === tx.id || isStopped}
-                                      >
-                                        {stoppingTxId === tx.id ? 'Stopping...' : isStopped ? 'Stopped' : 'Stop'}
-                                      </button>
-                                    )}
-                                    {[
+                                {(() => {
+                                  const canStop = tx.type === 'BuyCrypto' && !tx.isCompleted;
+                                  const canChargeback =
+                                    [
                                       TransactionState.FAILED,
                                       TransactionState.CHECK_PENDING,
                                       TransactionState.KYC_REQUIRED,
                                       TransactionState.LIMIT_EXCEEDED,
                                       TransactionState.UNASSIGNED,
-                                    ].includes(detail.state) &&
-                                      !detail.chargebackAmount && (
+                                    ].includes(detail.state) && !detail.chargebackAmount;
+                                  const canRecall = bankTx != null;
+                                  if (!canStop && !canChargeback && !canRecall) return null;
+                                  return (
+                                    <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2">
+                                      {canStop && (
+                                        <button
+                                          className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                          onClick={() => setStopConfirmTxId(tx.id)}
+                                          disabled={stoppingTxId === tx.id || isStopped}
+                                        >
+                                          {stoppingTxId === tx.id ? 'Stopping...' : isStopped ? 'Stopped' : 'Stop'}
+                                        </button>
+                                      )}
+                                      {canChargeback && (
                                         <button
                                           className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                           onClick={() => setChargebackTxId(tx.id)}
@@ -328,8 +327,17 @@ export function TransactionsTable({
                                           Chargeback
                                         </button>
                                       )}
-                                  </div>
-                                )}
+                                      {canRecall && (
+                                        <button
+                                          className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                          onClick={() => setRecallBankTxId(bankTx.id)}
+                                        >
+                                          Recall
+                                        </button>
+                                      )}
+                                    </div>
+                                  );
+                                })()}
                               </>
                             );
                           })()
@@ -377,6 +385,12 @@ export function TransactionsTable({
           setChargebackTxId(undefined);
           onStopped?.();
         }}
+      />
+      <RecallModal
+        isOpen={recallBankTxId != null}
+        bankTxId={recallBankTxId}
+        onClose={() => setRecallBankTxId(undefined)}
+        onSuccess={() => setRecallBankTxId(undefined)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a `Recall` button to the expanded transaction detail in the user-data compliance page, next to `Stop` and `Chargeback`
- Button is shown whenever the transaction has a linked bank tx (Source = BankTx)
- Opens a new `RecallModal` modeled after `ChargebackModal` with reason dropdown, fee (pre-filled 500), comment (pre-filled "n.a.")

## Dependency
Requires DFXswiss/api PR **#3617** (auto-derive recall user from bank tx) to be merged and deployed, since the frontend intentionally omits `userId` from the payload.

## Design notes
- Mirrors the existing Stop / Chargeback button style exactly (`px-3 py-1 text-xs text-white bg-dfxRed-100 ...`)
- Wraps the three action-button conditions into an IIFE so the divider row only renders when at least one action is available
- No changes to `compliance-bank-tx-recall.screen.tsx` — the compliance-search flow keeps its dedicated page (as merged in #1066)

## Test plan
- [ ] Open user-data compliance page → Transactions tab → expand a tx with a linked bank tx → `Recall` button appears alongside `Stop`/`Chargeback`
- [ ] Click `Recall` → modal opens with defaults (fee=500, comment=n.a.)
- [ ] Select reason → submit → recall created, `recall.user` populated server-side, modal closes
- [ ] For a tx without a linked bank tx → no `Recall` button shown