### PR TITLE
feat: show existing recall state on bank-tx views

### DIFF
--- a/src/components/compliance/recall-details-modal.tsx
+++ b/src/components/compliance/recall-details-modal.tsx
@@ -1,0 +1,37 @@
+import { StyledButton, StyledButtonColor, StyledButtonWidth, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { Modal } from 'src/components/modal';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { RecallInfo } from 'src/hooks/compliance.hook';
+import { RecallDetails } from './recall-details';
+
+interface RecallDetailsModalProps {
+  readonly isOpen: boolean;
+  readonly recall: RecallInfo | undefined;
+  readonly onClose: () => void;
+}
+
+export function RecallDetailsModal({ isOpen, recall, onClose }: RecallDetailsModalProps): JSX.Element {
+  const { translate } = useSettingsContext();
+
+  if (!isOpen || !recall) return <></>;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="bg-white rounded-lg shadow-sm p-6 max-w-lg mx-auto w-full">
+        <h2 className="text-lg font-semibold text-dfxBlue-800 mb-4 text-left">
+          {translate('screens/compliance', 'Recall')}
+        </h2>
+
+        <StyledVerticalStack gap={4} full>
+          <RecallDetails recall={recall} />
+          <StyledButton
+            label={translate('general/actions', 'Close')}
+            onClick={onClose}
+            width={StyledButtonWidth.FULL}
+            color={StyledButtonColor.STURDY_WHITE}
+          />
+        </StyledVerticalStack>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/compliance/recall-details.tsx
+++ b/src/components/compliance/recall-details.tsx
@@ -1,0 +1,17 @@
+import { RecallInfo } from 'src/hooks/compliance.hook';
+import { DetailRow, formatDateTime } from 'src/util/compliance-helpers';
+
+export function RecallDetails({ recall }: { recall: RecallInfo }): JSX.Element {
+  return (
+    <table className="text-sm text-dfxBlue-800 text-left">
+      <tbody>
+        <DetailRow label="ID" value={recall.id} />
+        <DetailRow label="Created" value={formatDateTime(recall.created)} />
+        <DetailRow label="Sequence" value={recall.sequence} />
+        <DetailRow label="Reason" value={recall.reason} />
+        <DetailRow label="Fee" value={recall.fee} />
+        <DetailRow label="Comment" value={recall.comment} />
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -2,9 +2,10 @@ import { Transaction, TransactionState, useTransaction } from '@dfx.swiss/react'
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { Fragment, useState } from 'react';
 import { ChargebackModal } from 'src/components/compliance/chargeback-modal';
+import { RecallDetailsModal } from 'src/components/compliance/recall-details-modal';
 import { RecallModal } from 'src/components/compliance/recall-modal';
 import { ConfirmDialog } from 'src/components/confirm-dialog';
-import { BankTxInfo, CryptoInputInfo, TransactionInfo, useCompliance } from 'src/hooks/compliance.hook';
+import { BankTxInfo, CryptoInputInfo, RecallInfo, TransactionInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { DetailRow, TransactionDetailRows, formatDate, statusBadge } from 'src/util/compliance-helpers';
 
 interface TransactionsTableProps {
@@ -46,6 +47,7 @@ export function TransactionsTable({
   const [stopError, setStopError] = useState<string>();
   const [chargebackTxId, setChargebackTxId] = useState<number>();
   const [recallBankTxId, setRecallBankTxId] = useState<number>();
+  const [viewingRecall, setViewingRecall] = useState<RecallInfo>();
 
   async function confirmStop(): Promise<void> {
     const txId = stopConfirmTxId;
@@ -306,8 +308,9 @@ export function TransactionsTable({
                                       TransactionState.LIMIT_EXCEEDED,
                                       TransactionState.UNASSIGNED,
                                     ].includes(detail.state) && !detail.chargebackAmount;
-                                  const canRecall = bankTx != null;
-                                  if (!canStop && !canChargeback && !canRecall) return null;
+                                  const existingRecall = bankTx?.recall;
+                                  const canRecall = bankTx != null && !existingRecall;
+                                  if (!canStop && !canChargeback && !canRecall && !existingRecall) return null;
                                   return (
                                     <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2">
                                       {canStop && (
@@ -333,6 +336,14 @@ export function TransactionsTable({
                                           onClick={() => setRecallBankTxId(bankTx.id)}
                                         >
                                           Recall
+                                        </button>
+                                      )}
+                                      {existingRecall && (
+                                        <button
+                                          className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
+                                          onClick={() => setViewingRecall(existingRecall)}
+                                        >
+                                          Recall #{existingRecall.id}
                                         </button>
                                       )}
                                     </div>
@@ -391,6 +402,11 @@ export function TransactionsTable({
         bankTxId={recallBankTxId}
         onClose={() => setRecallBankTxId(undefined)}
         onSuccess={() => setRecallBankTxId(undefined)}
+      />
+      <RecallDetailsModal
+        isOpen={viewingRecall != null}
+        recall={viewingRecall}
+        onClose={() => setViewingRecall(undefined)}
       />
     </div>
   );

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -101,6 +101,7 @@ export interface BankTxSearchResult {
   type: string;
   name?: string;
   iban?: string;
+  recall?: RecallInfo;
 }
 
 export interface BankTxInfo {
@@ -113,6 +114,16 @@ export interface BankTxInfo {
   name?: string;
   iban?: string;
   remittanceInfo?: string;
+  recall?: RecallInfo;
+}
+
+export interface RecallInfo {
+  id: number;
+  created: string;
+  sequence: number;
+  reason?: string;
+  comment: string;
+  fee: number;
 }
 
 export interface IpLogInfo {

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -1,5 +1,6 @@
 import { StyledButton, StyledButtonColor, StyledButtonWidth, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useLocation, useParams } from 'react-router-dom';
+import { RecallDetails } from 'src/components/compliance/recall-details';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { BankTxSearchResult } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
@@ -55,12 +56,19 @@ export default function ComplianceBankTxScreen(): JSX.Element {
         </table>
       </div>
 
-      <StyledButton
-        label={translate('screens/compliance', 'Recall erfassen')}
-        onClick={() => navigate(`compliance/bank-tx/${bankTx.id}/recall`)}
-        width={StyledButtonWidth.FULL}
-        color={StyledButtonColor.BLUE}
-      />
+      {bankTx.recall ? (
+        <div className="bg-white rounded-lg shadow-sm p-4">
+          <h2 className="text-dfxGray-700 mb-3">{translate('screens/compliance', 'Recall')}</h2>
+          <RecallDetails recall={bankTx.recall} />
+        </div>
+      ) : (
+        <StyledButton
+          label={translate('screens/compliance', 'Recall erfassen')}
+          onClick={() => navigate(`compliance/bank-tx/${bankTx.id}/recall`)}
+          width={StyledButtonWidth.FULL}
+          color={StyledButtonColor.BLUE}
+        />
+      )}
 
       {bankTx.transactionId && BankTxUnassignedTypes.includes(bankTx.type) && (
         <StyledButton

--- a/src/screens/compliance-bank-tx.screen.tsx
+++ b/src/screens/compliance-bank-tx.screen.tsx
@@ -43,6 +43,7 @@ export default function ComplianceBankTxScreen(): JSX.Element {
   return (
     <div className="w-full flex flex-col gap-6 max-w-4xl text-left">
       <div className="bg-white rounded-lg shadow-sm p-4">
+        <h2 className="text-dfxGray-700 mb-3">{translate('screens/compliance', 'Bank Transaction')}</h2>
         <table className="text-sm text-dfxBlue-800 text-left">
           <tbody>
             <DetailRow label="ID" value={bankTx.id} />


### PR DESCRIPTION
## Summary
When a bank tx already has a recall, hide the Recall erfassen action and show the recall info instead — in both views where recalls are created.

## Views
- **Bank Transaction Details page**: inline Recall card below the details, rendering all recall fields
- **User Data → Transactions tab**: action row shows a neutral "Recall #ID" button next to Stop/Chargeback; click opens a `RecallDetailsModal`

## Shared component
`RecallDetails` renders `id`, `created`, `sequence`, `reason`, `fee`, `comment` via the canonical `DetailRow` helper (same pattern used in `transactions-tab.tsx` and `compliance-bank-tx.screen.tsx`).

## Dependency
Requires DFXswiss/api PR **#3618** (recall on BankTxSupportInfo responses) to be merged and deployed — otherwise `bankTx.recall` is always `undefined` and the existing Recall erfassen button stays visible (backwards-compatible).

## Test plan
- [ ] Bank tx with no recall → Recall erfassen button visible on both views
- [ ] Bank tx with a recall → button disappears, recall info shown
- [ ] Click the "Recall #ID" button in the transactions tab → modal with all details
- [ ] Open bank-tx details page for a bank tx with a recall → inline Recall card rendered, details match