### PR TITLE
feat: add mros creation page in compliance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ const ComplianceSupportIssueScreen = lazy(() => import('./screens/compliance-sup
 const ComplianceRecommendationGraphScreen = lazy(() => import('./screens/compliance-recommendation-graph.screen'));
 const ComplianceCustodyOrdersScreen = lazy(() => import('./screens/compliance-custody-orders.screen'));
 const ComplianceMrosListScreen = lazy(() => import('./screens/compliance-mros-list.screen'));
+const ComplianceMrosCreateScreen = lazy(() => import('./screens/compliance-mros-create.screen'));
 const ComplianceRecallListScreen = lazy(() => import('./screens/compliance-recall-list.screen'));
 const ComplianceReviewScreen = lazy(() => import('./screens/compliance-review.screen'));
 const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
@@ -404,6 +405,10 @@ export const Routes = [
       {
         path: 'compliance/mros',
         element: withSuspense(<ComplianceMrosListScreen />),
+      },
+      {
+        path: 'compliance/mros/create',
+        element: withSuspense(<ComplianceMrosCreateScreen />),
       },
       {
         path: 'compliance/recalls',

--- a/src/dto/mros.dto.ts
+++ b/src/dto/mros.dto.ts
@@ -15,3 +15,11 @@ export interface MrosListEntry {
   caseManager: string;
   userData: { id: number };
 }
+
+export interface CreateMrosDto {
+  userDataId: number;
+  status: MrosStatus;
+  submissionDate?: string;
+  authorityReference?: string;
+  caseManager: string;
+}

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -8,7 +8,7 @@ import {
   ResponseType,
   useApi,
 } from '@dfx.swiss/react';
-import { MrosListEntry } from 'src/dto/mros.dto';
+import { CreateMrosDto, MrosListEntry } from 'src/dto/mros.dto';
 import { CustodyOrderListEntry } from 'src/dto/order.dto';
 import { CreateRecallDto, RecallListEntry } from 'src/dto/recall.dto';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
@@ -529,6 +529,14 @@ export function useCompliance() {
     });
   }
 
+  async function createMros(dto: CreateMrosDto): Promise<void> {
+    return call<void>({
+      url: 'mros',
+      method: 'POST',
+      data: dto,
+    });
+  }
+
   async function getRecalls(): Promise<RecallListEntry[]> {
     return call<RecallListEntry[]>({
       url: 'recall',
@@ -682,6 +690,7 @@ export function useCompliance() {
       getCustodyOrders,
       approveCustodyOrder,
       getMrosList,
+      createMros,
       getRecalls,
       createRecall,
       updateKycStep,

--- a/src/screens/compliance-mros-create.screen.tsx
+++ b/src/screens/compliance-mros-create.screen.tsx
@@ -41,12 +41,6 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
   const [success, setSuccess] = useState(false);
   const [caseManager, setCaseManager] = useState<string>();
 
-  useEffect(() => {
-    getProfile()
-      .then((p) => setCaseManager([p?.firstName, p?.lastName].filter(Boolean).join(' ')))
-      .catch(() => setCaseManager(''));
-  }, []);
-
   const {
     control,
     handleSubmit,
@@ -55,6 +49,12 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
     mode: 'onTouched',
     defaultValues: { status: MrosStatus.DRAFT, submissionDate: todayAsString() },
   });
+
+  useEffect(() => {
+    getProfile()
+      .then((p) => setCaseManager([p?.firstName, p?.lastName].filter(Boolean).join(' ')))
+      .catch(() => setCaseManager(''));
+  }, []);
 
   useLayoutOptions({ title: translate('screens/compliance', 'MROS erfassen'), backButton: true });
 

--- a/src/screens/compliance-mros-create.screen.tsx
+++ b/src/screens/compliance-mros-create.screen.tsx
@@ -1,4 +1,4 @@
-import { Utils, Validations } from '@dfx.swiss/react';
+import { Utils, Validations, useUser } from '@dfx.swiss/react';
 import {
   Form,
   StyledButton,
@@ -8,7 +8,7 @@ import {
   StyledInput,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { ErrorHint } from 'src/components/error-hint';
 import { useLayoutContext } from 'src/contexts/layout.context';
@@ -18,13 +18,13 @@ import { useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
+import { todayAsString } from 'src/util/compliance-helpers';
 
 interface FormData {
   userDataId: string;
   status: MrosStatus;
   submissionDate: string;
   authorityReference: string;
-  caseManager: string;
 }
 
 export default function ComplianceMrosCreateScreen(): JSX.Element {
@@ -32,12 +32,20 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
 
   const { translate, translateError } = useSettingsContext();
   const { createMros } = useCompliance();
+  const { getProfile } = useUser();
   const { navigate } = useNavigation();
   const { rootRef } = useLayoutContext();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string>();
   const [success, setSuccess] = useState(false);
+  const [caseManager, setCaseManager] = useState<string>();
+
+  useEffect(() => {
+    getProfile()
+      .then((p) => setCaseManager([p?.firstName, p?.lastName].filter(Boolean).join(' ')))
+      .catch(() => setCaseManager(''));
+  }, []);
 
   const {
     control,
@@ -45,12 +53,13 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
     formState: { isValid, errors },
   } = useForm<FormData>({
     mode: 'onTouched',
-    defaultValues: { status: MrosStatus.DRAFT },
+    defaultValues: { status: MrosStatus.DRAFT, submissionDate: todayAsString() },
   });
 
   useLayoutOptions({ title: translate('screens/compliance', 'MROS erfassen'), backButton: true });
 
   async function onSubmit(formData: FormData): Promise<void> {
+    if (!caseManager) return;
     setIsSubmitting(true);
     setError(undefined);
 
@@ -60,7 +69,7 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
         status: formData.status,
         submissionDate: formData.submissionDate || undefined,
         authorityReference: formData.authorityReference || undefined,
-        caseManager: formData.caseManager,
+        caseManager,
       });
       setSuccess(true);
     } catch (e) {
@@ -73,7 +82,6 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
   const rules = Utils.createRules({
     userDataId: [Validations.Required, Validations.Custom((v) => (isNaN(Number(v)) ? 'pattern' : true))],
     status: Validations.Required,
-    caseManager: Validations.Required,
   });
 
   if (success) {
@@ -126,14 +134,7 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
 
         <StyledInput
           name="authorityReference"
-          label={translate('screens/compliance', 'Authority Reference')}
-          full
-          smallLabel
-        />
-
-        <StyledInput
-          name="caseManager"
-          label={translate('screens/compliance', 'Case Manager')}
+          label={translate('screens/compliance', 'MROS ID')}
           full
           smallLabel
         />
@@ -149,7 +150,7 @@ export default function ComplianceMrosCreateScreen(): JSX.Element {
           label={translate('general/actions', 'Create MROS')}
           onClick={handleSubmit(onSubmit)}
           width={StyledButtonWidth.FULL}
-          disabled={!isValid}
+          disabled={!isValid || !caseManager}
           isLoading={isSubmitting}
         />
 

--- a/src/screens/compliance-mros-create.screen.tsx
+++ b/src/screens/compliance-mros-create.screen.tsx
@@ -1,0 +1,165 @@
+import { Utils, Validations } from '@dfx.swiss/react';
+import {
+  Form,
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledDropdown,
+  StyledInput,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorHint } from 'src/components/error-hint';
+import { useLayoutContext } from 'src/contexts/layout.context';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { MrosStatus } from 'src/dto/mros.dto';
+import { useCompliance } from 'src/hooks/compliance.hook';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useNavigation } from 'src/hooks/navigation.hook';
+
+interface FormData {
+  userDataId: string;
+  status: MrosStatus;
+  submissionDate: string;
+  authorityReference: string;
+  caseManager: string;
+}
+
+export default function ComplianceMrosCreateScreen(): JSX.Element {
+  useComplianceGuard();
+
+  const { translate, translateError } = useSettingsContext();
+  const { createMros } = useCompliance();
+  const { navigate } = useNavigation();
+  const { rootRef } = useLayoutContext();
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string>();
+  const [success, setSuccess] = useState(false);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isValid, errors },
+  } = useForm<FormData>({
+    mode: 'onTouched',
+    defaultValues: { status: MrosStatus.DRAFT },
+  });
+
+  useLayoutOptions({ title: translate('screens/compliance', 'MROS erfassen'), backButton: true });
+
+  async function onSubmit(formData: FormData): Promise<void> {
+    setIsSubmitting(true);
+    setError(undefined);
+
+    try {
+      await createMros({
+        userDataId: Number(formData.userDataId),
+        status: formData.status,
+        submissionDate: formData.submissionDate || undefined,
+        authorityReference: formData.authorityReference || undefined,
+        caseManager: formData.caseManager,
+      });
+      setSuccess(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const rules = Utils.createRules({
+    userDataId: [Validations.Required, Validations.Custom((v) => (isNaN(Number(v)) ? 'pattern' : true))],
+    status: Validations.Required,
+    caseManager: Validations.Required,
+  });
+
+  if (success) {
+    return (
+      <StyledVerticalStack gap={6} full center>
+        <div className="text-center">
+          <h2 className="text-dfxBlue-800 text-xl font-semibold mb-4">
+            {translate('screens/compliance', 'MROS created successfully')}
+          </h2>
+          <StyledButton
+            label={translate('general/actions', 'Back')}
+            onClick={() => navigate(-1)}
+            width={StyledButtonWidth.MD}
+          />
+        </div>
+      </StyledVerticalStack>
+    );
+  }
+
+  return (
+    <Form control={control} rules={rules} errors={errors} onSubmit={handleSubmit(onSubmit)} translate={translateError}>
+      <StyledVerticalStack gap={6} full>
+        <StyledInput
+          name="userDataId"
+          type="number"
+          label={translate('screens/compliance', 'User Data ID')}
+          placeholder="12345"
+          full
+          smallLabel
+        />
+
+        <StyledDropdown<MrosStatus>
+          rootRef={rootRef}
+          name="status"
+          label={translate('screens/compliance', 'Status')}
+          placeholder={translate('general/actions', 'Select') + '...'}
+          items={Object.values(MrosStatus)}
+          labelFunc={(item) => item}
+          full
+          smallLabel
+        />
+
+        <StyledInput
+          name="submissionDate"
+          type="date"
+          label={translate('screens/compliance', 'Submission Date')}
+          full
+          smallLabel
+        />
+
+        <StyledInput
+          name="authorityReference"
+          label={translate('screens/compliance', 'Authority Reference')}
+          full
+          smallLabel
+        />
+
+        <StyledInput
+          name="caseManager"
+          label={translate('screens/compliance', 'Case Manager')}
+          full
+          smallLabel
+        />
+
+        {error && (
+          <div>
+            <ErrorHint message={error} />
+          </div>
+        )}
+
+        <StyledButton
+          type="submit"
+          label={translate('general/actions', 'Create MROS')}
+          onClick={handleSubmit(onSubmit)}
+          width={StyledButtonWidth.FULL}
+          disabled={!isValid}
+          isLoading={isSubmitting}
+        />
+
+        <StyledButton
+          label={translate('general/actions', 'Cancel')}
+          onClick={() => navigate(-1)}
+          width={StyledButtonWidth.FULL}
+          color={StyledButtonColor.WHITE}
+        />
+      </StyledVerticalStack>
+    </Form>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a standalone `compliance/mros/create` page so compliance officers can record new MROS reports without leaving the services UI.

## Form fields (matches backend `CreateMrosDto`)
- `userDataId` (number, required)
- `status` (dropdown — Draft/Submitted/Confirmed/Closed, required, default Draft)
- `submissionDate` (date, optional)
- `authorityReference` (text, optional)
- `caseManager` (text, required)

## Notes
- Backend endpoint `POST /mros` already exists; no api change needed
- Screen mirrors the existing create-form pattern (`compliance-bank-tx-recall.screen.tsx`) with Form + Utils.createRules + useForm
- No button was added; the page is reached via the route directly

## Test plan
- [ ] Navigate to `/compliance/mros/create` → form rendered with status pre-filled as Draft
- [ ] Submit with required fields only → success screen
- [ ] Submit with all fields including submissionDate / authorityReference → success
- [ ] Cancel / Back returns to the previous page
- [ ] Validation blocks empty userDataId / non-numeric userDataId / empty caseManager