### PR TITLE
feat: add mros detail page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,7 @@ const ComplianceRecommendationGraphScreen = lazy(() => import('./screens/complia
 const ComplianceCustodyOrdersScreen = lazy(() => import('./screens/compliance-custody-orders.screen'));
 const ComplianceMrosListScreen = lazy(() => import('./screens/compliance-mros-list.screen'));
 const ComplianceMrosCreateScreen = lazy(() => import('./screens/compliance-mros-create.screen'));
+const ComplianceMrosDetailScreen = lazy(() => import('./screens/compliance-mros-detail.screen'));
 const ComplianceRecallListScreen = lazy(() => import('./screens/compliance-recall-list.screen'));
 const ComplianceReviewScreen = lazy(() => import('./screens/compliance-review.screen'));
 const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
@@ -409,6 +410,10 @@ export const Routes = [
       {
         path: 'compliance/mros/create',
         element: withSuspense(<ComplianceMrosCreateScreen />),
+      },
+      {
+        path: 'compliance/mros/:id',
+        element: withSuspense(<ComplianceMrosDetailScreen />),
       },
       {
         path: 'compliance/recalls',

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -529,6 +529,13 @@ export function useCompliance() {
     });
   }
 
+  async function getMrosById(id: number): Promise<MrosListEntry> {
+    return call<MrosListEntry>({
+      url: `mros/${id}`,
+      method: 'GET',
+    });
+  }
+
   async function createMros(dto: CreateMrosDto): Promise<void> {
     return call<void>({
       url: 'mros',
@@ -690,6 +697,7 @@ export function useCompliance() {
       getCustodyOrders,
       approveCustodyOrder,
       getMrosList,
+      getMrosById,
       createMros,
       getRecalls,
       createRecall,

--- a/src/screens/compliance-mros-detail.screen.tsx
+++ b/src/screens/compliance-mros-detail.screen.tsx
@@ -1,0 +1,63 @@
+import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { MrosListEntry } from 'src/dto/mros.dto';
+import { useCompliance } from 'src/hooks/compliance.hook';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { DetailRow, formatDateTime, mrosStatusBadge } from 'src/util/compliance-helpers';
+
+export default function ComplianceMrosDetailScreen(): JSX.Element {
+  useComplianceGuard();
+
+  const { id } = useParams<{ id: string }>();
+  const { translate } = useSettingsContext();
+  const { getMrosById } = useCompliance();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const [mros, setMros] = useState<MrosListEntry>();
+
+  useLayoutOptions({ title: translate('screens/compliance', 'MROS Report'), backButton: true });
+
+  useEffect(() => {
+    if (!id) return;
+    setIsLoading(true);
+    setError(undefined);
+    getMrosById(+id)
+      .then(setMros)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setIsLoading(false));
+  }, [id]);
+
+  if (isLoading) return <StyledLoadingSpinner size={SpinnerSize.LG} />;
+  if (error) return <ErrorHint message={error} />;
+  if (!mros) return <ErrorHint message={translate('screens/compliance', 'MROS report not found')} />;
+
+  return (
+    <StyledVerticalStack gap={6} full>
+      <div className="bg-white rounded-lg shadow-sm p-4">
+        <table className="text-sm text-dfxBlue-800 text-left">
+          <tbody>
+            <DetailRow label="ID" value={mros.id} />
+            <DetailRow label="Created" value={formatDateTime(String(mros.created))} />
+            <DetailRow label="Updated" value={formatDateTime(String(mros.updated))} />
+            <DetailRow label="UserData ID" value={mros.userData.id} />
+            <tr>
+              <td className="pr-3 py-0.5 font-medium whitespace-nowrap">Status:</td>
+              <td className="py-0.5">{mrosStatusBadge(mros.status)}</td>
+            </tr>
+            <DetailRow
+              label="Submission Date"
+              value={mros.submissionDate ? formatDateTime(String(mros.submissionDate)) : undefined}
+            />
+            <DetailRow label="MROS ID" value={mros.authorityReference} />
+            <DetailRow label="Case Manager" value={mros.caseManager} />
+          </tbody>
+        </table>
+      </div>
+    </StyledVerticalStack>
+  );
+}

--- a/src/screens/compliance-mros-list.screen.tsx
+++ b/src/screens/compliance-mros-list.screen.tsx
@@ -2,23 +2,12 @@ import { useSessionContext } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
-import { MrosListEntry, MrosStatus } from 'src/dto/mros.dto';
+import { MrosListEntry } from 'src/dto/mros.dto';
 import { useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
-
-const statusClasses: Record<MrosStatus, string> = {
-  [MrosStatus.DRAFT]: 'bg-dfxGray-400 text-dfxBlue-800',
-  [MrosStatus.SUBMITTED]: 'bg-dfxBlue-300/20 text-dfxBlue-400',
-  [MrosStatus.CONFIRMED]: 'bg-dfxGreen-100/20 text-dfxGreen-300',
-  [MrosStatus.CLOSED]: 'bg-dfxGray-700/20 text-dfxGray-800',
-};
-
-function statusBadge(status: MrosStatus): JSX.Element {
-  const classes = statusClasses[status] ?? 'bg-dfxGray-400 text-dfxBlue-800';
-
-  return <span className={`px-2 py-1 rounded-full text-xs font-semibold ${classes}`}>{status}</span>;
-}
+import { useNavigation } from 'src/hooks/navigation.hook';
+import { mrosStatusBadge } from 'src/util/compliance-helpers';
 
 export default function ComplianceMrosListScreen(): JSX.Element {
   useComplianceGuard();
@@ -26,6 +15,7 @@ export default function ComplianceMrosListScreen(): JSX.Element {
 
   const { isLoggedIn } = useSessionContext();
   const { getMrosList } = useCompliance();
+  const { navigate } = useNavigation();
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -82,12 +72,16 @@ export default function ComplianceMrosListScreen(): JSX.Element {
             <tbody>
               {data.length > 0 ? (
                 data.map((entry) => (
-                  <tr key={entry.id} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
+                  <tr
+                    key={entry.id}
+                    className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300 cursor-pointer"
+                    onClick={() => navigate(`compliance/mros/${entry.id}`)}
+                  >
                     <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.id}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.created)}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.updated)}</td>
                     <td className="px-4 py-3 text-right text-sm text-dfxBlue-800">{entry.userData.id}</td>
-                    <td className="px-4 py-3 text-left text-sm">{statusBadge(entry.status)}</td>
+                    <td className="px-4 py-3 text-left text-sm">{mrosStatusBadge(entry.status)}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{formatDate(entry.submissionDate)}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.authorityReference ?? '-'}</td>
                     <td className="px-4 py-3 text-left text-sm text-dfxBlue-800">{entry.caseManager}</td>

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -1,4 +1,5 @@
 import { Transaction } from '@dfx.swiss/react';
+import { MrosStatus } from 'src/dto/mros.dto';
 
 export function DetailRow({
   label,
@@ -116,6 +117,18 @@ export function statusBadge(status: string): JSX.Element {
 
 export function boolBadge(value: boolean, trueLabel = 'Yes', falseLabel = 'No'): JSX.Element {
   return statusBadge(value ? trueLabel : falseLabel);
+}
+
+const mrosStatusClasses: Record<MrosStatus, string> = {
+  [MrosStatus.DRAFT]: 'bg-dfxGray-400 text-dfxBlue-800',
+  [MrosStatus.SUBMITTED]: 'bg-dfxBlue-300/20 text-dfxBlue-400',
+  [MrosStatus.CONFIRMED]: 'bg-dfxGreen-100/20 text-dfxGreen-300',
+  [MrosStatus.CLOSED]: 'bg-dfxGray-700/20 text-dfxGray-800',
+};
+
+export function mrosStatusBadge(status: MrosStatus): JSX.Element {
+  const classes = mrosStatusClasses[status] ?? 'bg-dfxGray-400 text-dfxBlue-800';
+  return <span className={`px-2 py-1 rounded-full text-xs font-semibold ${classes}`}>{status}</span>;
 }
 
 export function todayAsString(): string {


### PR DESCRIPTION
## Summary
Clicking a row on `compliance/mros` now navigates to a dedicated detail page at `compliance/mros/:id`. The detail page fetches `GET /mros/:id` and renders all fields via the shared `DetailRow` helper.

## Changes
- `getMrosById` hook method (GET /mros/:id)
- New screen `compliance-mros-detail.screen.tsx` with loading / error / not-found states, matches the card-with-DetailRow layout used by `compliance-bank-tx.screen.tsx`
- `mrosStatusBadge` moved from `compliance-mros-list.screen.tsx` into `src/util/compliance-helpers.tsx` and reused in both list and detail
- List rows get `cursor-pointer` + onClick → navigate to detail
- Route registered in `App.tsx` after `compliance/mros/create` (static wins over dynamic in React Router v6)

## Test plan
- [ ] Open `/compliance/mros` → table rows show the hover + cursor feedback
- [ ] Click a row → detail page renders all fields (ID, Created, Updated, UserData ID, Status badge, Submission Date, MROS ID, Case Manager); hidden when empty via DetailRow
- [ ] Direct URL (`/compliance/mros/1`) works too
- [ ] `/compliance/mros/create` still renders the create form