### PR TITLE
feat: add sitemap link to navigation for admins

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -225,6 +225,15 @@ function NavigationMenu({ setIsNavigationOpen, small = false }: NavigationMenuCo
                   onClose={() => setIsNavigationOpen(false)}
                 />
               )}
+              {session?.role === UserRole.ADMIN && (
+                <NavigationLink
+                  icon={IconVariant.MENU}
+                  label={translate('screens/sitemap', 'Sitemap')}
+                  url="/sitemap"
+                  target="_self"
+                  onClose={() => setIsNavigationOpen(false)}
+                />
+              )}
             </>
           )}
 


### PR DESCRIPTION
## Summary
Adds a `Sitemap` entry in the main navigation, visible only to users with `UserRole.ADMIN`. Mirrors the existing role-gated pattern used for Compliance, Support Dashboard and RealUnit.

## Changes
- New `NavigationLink` to `/sitemap`, placed after RealUnit in the role-gated block
- Icon: `IconVariant.MENU`
- Gating: `session?.role === UserRole.ADMIN`

## Test plan
- [ ] Login as admin → open nav menu → Sitemap entry visible between RealUnit and DFX.swiss
- [ ] Login as compliance / support / regular user → Sitemap entry hidden