### PR TITLE
fix: default booking and value date to today on sepa-manual form

### DIFF
--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -18,6 +18,7 @@ import { ErrorHint } from 'src/components/error-hint';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { buildCamt053Xml } from 'src/util/camt053-builder';
+import { todayAsString } from 'src/util/compliance-helpers';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useAdminGuard } from '../hooks/guard.hook';
 
@@ -68,6 +69,8 @@ export default function SepaManualScreen(): JSX.Element {
     defaultValues: {
       currency: 'EUR',
       direction: CreditDebitIndicator.CRDT,
+      bookingDate: todayAsString(),
+      valueDate: todayAsString(),
     },
   });
 


### PR DESCRIPTION
## Summary
On `/sepa/manual`, `Booking date` and `Value date` are now pre-filled with today's date (YYYY-MM-DD) so the admin doesn't have to set them manually every time.

Uses the shared `todayAsString()` helper from `compliance-helpers.tsx` (already used on the MROS create form).

## Test plan
- [ ] Open `/sepa/manual` → both date fields show today
- [ ] Submitting without touching the dates uses today