### PR TITLE
fix: match 2FA-required via stable code instead of message heuristic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.3.0-beta.270",
+        "@dfx.swiss/react": "^1.3.2-beta.0",
         "@dfx.swiss/react-components": "^1.3.0-beta.270",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -2631,15 +2631,24 @@
         "@ethersproject/wordlists": "5.8.0"
       }
     },
-    "node_modules/@dfx.swiss/react": {
-      "version": "1.3.0-beta.270",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.0-beta.270.tgz",
-      "integrity": "sha512-r81/MQXanHEWkAydl8u7X1jkl6a7t04bozHbkEXrYYKkdUTeXnDDHQ4Pvm6bDOUxkMWFz+L88vg+rupFB7T/ZA==",
+    "node_modules/@dfx.swiss/core": {
+      "version": "0.2.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.2.2-beta.0.tgz",
+      "integrity": "sha512-yh6TR7xwPnhGGXCU4M9ydZbMbwSygrKPozhzJVSIs8A0iNh5ZZJynR/czEsO+GwQnfhcXTyBBCtnue2dJBlhxw==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
+        "libphonenumber-js": "^1.10.39"
+      }
+    },
+    "node_modules/@dfx.swiss/react": {
+      "version": "1.3.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.2-beta.0.tgz",
+      "integrity": "sha512-FwS8AtwAGwne50rNh/h0RdBVIompkuba5WEoTEJbUsYT6BwPqkYTucVwlA6ThHiEr33Wm4wwtVt/Udnz0GX0rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dfx.swiss/core": "^0.2.2-beta.0",
         "jwt-decode": "^3.1.2",
-        "libphonenumber-js": "^1.10.39",
         "react": "^18.2.0",
         "typescript": "^4.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.3.0-beta.270",
+    "@dfx.swiss/react": "^1.3.2-beta.0",
     "@dfx.swiss/react-components": "^1.3.0-beta.270",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -257,7 +257,7 @@ export default function KycScreen(): JSX.Element {
         setIsLoading(true);
         navigate({ search: `?code=${e.switchToCode}` });
         logout();
-      } else if (e.statusCode === 403 && e.message?.includes('2FA')) {
+      } else if (e.code === 'TFA_REQUIRED') {
         setParams({ autoStart: 'true' });
         navigate('/2fa', { setRedirect: true });
       } else if (e.statusCode === 409 && e.message?.includes('exists')) {


### PR DESCRIPTION
## Summary
Switches the `403 → /2fa` navigation in `KycScreen.callKyc` from a fragile message heuristic to a stable, machine-readable error code:

```diff
-      } else if (e.statusCode === 403 && e.message?.includes('2FA')) {
+      } else if (e.code === 'TFA_REQUIRED') {
         setParams({ autoStart: 'true' });
         navigate('/2fa', { setRedirect: true });
       }
```

Plus: bumps `@dfx.swiss/react` to `^1.3.2-beta.0`, which exposes the new `code` field on `ApiError`.

## Why this is needed

The previous check `e.statusCode === 403 && e.message?.includes('2FA')` had two problems:

1. **Brittle**: it relies on the English message text. If the backend ever changes wording, translates, or restructures the message, the 2FA redirect silently breaks.
2. **Over-eager**: many other 403 paths in the DFX API contain no `2FA` substring but still hit this branch when chained with other matchers — and a future 403 message *containing* "2FA" (e.g. an admin-permission error mentioning "2FA setup") would be misrouted into the verification flow.

The DFX backend now emits a stable `code: "TFA_REQUIRED"` for genuine 2FA-required responses (DFXswiss/api PR — merged), and `@dfx.swiss/react` surfaces that field on `ApiError` as of `1.3.2-beta.0` (DFXswiss/packages#163 — merged + published).

Matching on `e.code === 'TFA_REQUIRED'` is:
- **Stable** — independent of message wording
- **Specific** — only triggers for the actual 2FA case, never for unrelated 403s

## Compatibility

- `@dfx.swiss/react@1.3.2-beta.0` is fully backwards compatible — `code` is optional on `ApiError`. All existing call sites that don't read `code` continue to work unchanged.
- Backend change is also backwards compatible: it adds the `code` field while keeping the original message text intact.

## Out of scope
- 2FA handling outside the KYC flow (e.g. in Buy/Sell/Swap/Settings screens) is still missing — those endpoints will return `code: 'TFA_REQUIRED'` but the surrounding cubits don't react. That's a feature gap to address in a follow-up PR.

## Test plan
- [ ] On a multi-address account (which triggers strict 2FA), navigate to a KYC page (e.g. address change) without a verified 2FA log entry. Verify the app routes to `/2fa` with `autoStart=true` instead of showing a generic error.
- [ ] Verify other 403 paths (account blocked, IP country blocked, etc.) no longer accidentally redirect to `/2fa` — they should surface as generic errors.
- [ ] Verify successful 2FA verification then completes the originally requested KYC operation (`setRedirect: true` flow).