### PR TITLE
feat: compliance freigabe refinements

### DIFF
--- a/src/components/compliance/compliance-review-configs.ts
+++ b/src/components/compliance/compliance-review-configs.ts
@@ -5,6 +5,7 @@ export type ReviewCheckTab =
   | 'signatoryPower'
   | 'beneficialOwner'
   | 'operationalActivity'
+  | 'financialData'
   | 'freigabe'
   | 'stammdaten'
   | 'ident'
@@ -231,6 +232,17 @@ export const reviewTabs: ReviewTabConfig[] = [
         href: '/kyc/log?userDataId={id}&eventDate={today}',
       },
     ],
+  },
+  {
+    key: 'financialData',
+    label: 'Financial Data',
+    group: 'onboarding',
+    stepName: 'FinancialData',
+    fileTypes: [],
+    showResult: true,
+    decisionLabel: 'Entscheid:',
+    rejectionReasons: [],
+    checkItems: [],
   },
   // --- Management Tabs ---
   {

--- a/src/components/compliance/compliance-review-panel.tsx
+++ b/src/components/compliance/compliance-review-panel.tsx
@@ -57,12 +57,16 @@ export function renderResultTable(result: string | undefined): JSX.Element | nul
       return (
         <table className="w-full">
           <tbody>
-            {entries.map((entry) => (
-              <tr key={entry.key}>
-                <td className="py-0.5 pr-4 text-left text-sm text-dfxBlue-800 w-56 align-top">{entry.key}</td>
-                <td className="py-0.5 text-left text-sm text-dfxBlue-800">{formatResultValue(entry.value)}</td>
-              </tr>
-            ))}
+            {entries.map((entry) => {
+              const isRisky = typeof entry.value === 'string' && entry.value === 'yes_risky_business';
+              const rowClass = isRisky ? 'bg-dfxRed-100/20' : '';
+              return (
+                <tr key={entry.key} className={rowClass}>
+                  <td className="py-0.5 pr-4 text-left text-sm text-dfxBlue-800 w-56 align-top">{entry.key}</td>
+                  <td className="py-0.5 text-left text-sm text-dfxBlue-800">{formatResultValue(entry.value)}</td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       );
@@ -202,9 +206,7 @@ export function ComplianceReviewPanel({
       {showResult && step.result && (
         <div>
           <h3 className="text-dfxGray-700 mb-2 font-semibold text-sm">Result</h3>
-          <div className="bg-white rounded-lg shadow-sm overflow-auto max-h-[30vh]">
-            {renderResultTable(step.result)}
-          </div>
+          <div className="bg-white rounded-lg shadow-sm">{renderResultTable(step.result)}</div>
         </div>
       )}
 

--- a/src/components/compliance/freigabe-panel.tsx
+++ b/src/components/compliance/freigabe-panel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { LimitRequestModal } from 'src/components/compliance/limit-request-modal';
+import { useCallQueueClerks } from 'src/hooks/call-queue-clerks.hook';
 import { KycFile, KycStepInfo } from 'src/hooks/compliance.hook';
 import { formatDate, formatDateTime, formatValue, statusBadge } from 'src/util/compliance-helpers';
 
@@ -32,7 +32,6 @@ interface OnboardingComplianceReviewFreigabePanelProps {
   onOpenFile: (file: KycFile) => void;
   onSave: (params: ComplianceReviewFreigabeSaveParams) => Promise<void>;
   isSaving: boolean;
-  onLimitRequestCreated?: () => void;
 }
 
 interface SavedComment {
@@ -214,11 +213,13 @@ function DropdownField({
   value,
   options,
   onChange,
+  disabled,
 }: {
   label: string;
   value: string;
   options: { value: string; label: string }[];
   onChange: (v: string) => void;
+  disabled?: boolean;
 }): JSX.Element {
   return (
     <tr>
@@ -226,9 +227,10 @@ function DropdownField({
       <td className="py-1" />
       <td className="py-1 text-right">
         <select
-          className={`px-2 py-1 text-sm border border-dfxGray-400 rounded ${value === 'Akzeptiert' ? 'bg-dfxGreen-100/20 text-dfxGreen-100' : value === 'Abgelehnt' ? 'bg-dfxRed-100/20 text-dfxRed-100' : 'bg-white text-dfxBlue-800'}`}
+          className={`px-2 py-1 text-sm border border-dfxGray-400 rounded disabled:opacity-50 disabled:cursor-not-allowed ${value === 'Akzeptiert' ? 'bg-dfxGreen-100/20 text-dfxGreen-100' : value === 'Abgelehnt' ? 'bg-dfxRed-100/20 text-dfxRed-100' : 'bg-white text-dfxBlue-800'}`}
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
         >
           <option value="">—</option>
           {options.map((o) => (
@@ -277,7 +279,6 @@ export function ComplianceReviewFreigabePanel({
   onOpenFile,
   onSave,
   isSaving,
-  onLimitRequestCreated,
 }: OnboardingComplianceReviewFreigabePanelProps): JSX.Element {
   // Derived from predecessor step status (read-only, like in GS)
   const ownerDirectoryStep = findStep(kycSteps, 'OwnerDirectory');
@@ -297,14 +298,13 @@ export function ComplianceReviewFreigabePanel({
 
   const [complexOrgStructure, setComplexOrgStructure] = useState('');
   const [highRisk, setHighRisk] = useState('');
-  const [depositLimit, setDepositLimit] = useState('');
   const [amlAccountType, setAmlAccountType] = useState('');
   const [commentGmeR, setCommentGmeR] = useState('');
   const [reasonSeatingCompany, setReasonSeatingCompany] = useState('');
   const [businessActivities, setBusinessActivities] = useState('');
   const [finalDecision, setFinalDecision] = useState<DecisionValue>('');
   const [processedBy, setProcessedBy] = useState('');
-  const [showLimitRequestModal, setShowLimitRequestModal] = useState(false);
+  const { clerks, isLoading: isLoadingClerks } = useCallQueueClerks();
 
   // Load saved state from result.complianceReview and result text fields
   useEffect(() => {
@@ -324,7 +324,6 @@ export function ComplianceReviewFreigabePanel({
         if (saved && typeof saved === 'object') {
           if (saved.complexOrgStructure) setComplexOrgStructure(saved.complexOrgStructure);
           if (saved.highRisk) setHighRisk(saved.highRisk);
-          if (saved.depositLimit) setDepositLimit(saved.depositLimit);
           if (saved.amlAccountType) setAmlAccountType(saved.amlAccountType);
           if (saved.processedBy) setProcessedBy(saved.processedBy);
           if (saved.finalDecision) setFinalDecision(saved.finalDecision as DecisionValue);
@@ -377,6 +376,18 @@ export function ComplianceReviewFreigabePanel({
     // Comment: plain text for GS compatibility
     const comment = finalDecision === 'Abgelehnt' ? 'Blocked' : undefined;
 
+    // depositLimit is always 100000 at onboarding (for all account types).
+    // For Personal: organization-only fields are hidden in the UI; force fixed values for amlAccountType
+    // and skip complexOrgStructure/highRisk so they neither land in result, userDataUpdate nor PDF.
+    const isPersonal = accountType === 'Personal';
+    const effectiveComplexOrg = isPersonal ? '' : complexOrgStructure;
+    const effectiveHighRisk = isPersonal ? '' : highRisk;
+    const effectiveDepositLimit = '100000';
+    const effectiveAmlAccountType = isPersonal ? 'natural person' : amlAccountType;
+    const effectiveCommentGmeR = isPersonal ? '' : commentGmeR;
+    const effectiveReasonSeatingCompany = isPersonal ? '' : reasonSeatingCompany;
+    const effectiveBusinessActivities = isPersonal ? '' : businessActivities;
+
     // Result: merge text fields + complianceReview into existing result
     let existingResult: Record<string, unknown> = {};
     if (step.result) {
@@ -387,15 +398,15 @@ export function ComplianceReviewFreigabePanel({
       }
     }
 
-    existingResult.CommentGmeR = commentGmeR || undefined;
-    existingResult.ReasonSeatingCompany = reasonSeatingCompany || undefined;
-    existingResult.BusinessActivities = businessActivities || undefined;
+    existingResult.CommentGmeR = effectiveCommentGmeR || undefined;
+    existingResult.ReasonSeatingCompany = effectiveReasonSeatingCompany || undefined;
+    existingResult.BusinessActivities = effectiveBusinessActivities || undefined;
 
     existingResult.complianceReview = {
-      complexOrgStructure: complexOrgStructure || undefined,
-      highRisk: highRisk || undefined,
-      depositLimit: depositLimit || undefined,
-      amlAccountType: amlAccountType || undefined,
+      complexOrgStructure: effectiveComplexOrg || undefined,
+      highRisk: effectiveHighRisk || undefined,
+      depositLimit: effectiveDepositLimit || undefined,
+      amlAccountType: effectiveAmlAccountType || undefined,
       processedBy: processedBy || undefined,
       finalDecision,
     } as SavedComment;
@@ -403,10 +414,10 @@ export function ComplianceReviewFreigabePanel({
     const result = JSON.stringify(existingResult);
 
     const userDataUpdate: Record<string, unknown> = {};
-    if (complexOrgStructure) userDataUpdate.complexOrgStructure = complexOrgStructure === 'Ja';
-    if (highRisk) userDataUpdate.highRisk = highRisk === 'Ja';
-    if (depositLimit) userDataUpdate.depositLimit = parseInt(depositLimit);
-    if (amlAccountType) userDataUpdate.amlAccountType = amlAccountType;
+    if (effectiveComplexOrg) userDataUpdate.complexOrgStructure = effectiveComplexOrg === 'Ja';
+    if (effectiveHighRisk) userDataUpdate.highRisk = effectiveHighRisk === 'Ja';
+    if (effectiveDepositLimit) userDataUpdate.depositLimit = Number.parseInt(effectiveDepositLimit);
+    if (effectiveAmlAccountType) userDataUpdate.amlAccountType = effectiveAmlAccountType;
 
     await onSave({
       stepId: step.id,
@@ -417,13 +428,13 @@ export function ComplianceReviewFreigabePanel({
       pdfData: {
         finalDecision,
         processedBy,
-        complexOrgStructure: complexOrgStructure || undefined,
-        highRisk: highRisk || undefined,
-        depositLimit: depositLimit || undefined,
-        amlAccountType: amlAccountType || undefined,
-        commentGmeR: commentGmeR || undefined,
-        reasonSeatingCompany: reasonSeatingCompany || undefined,
-        businessActivities: businessActivities || undefined,
+        complexOrgStructure: effectiveComplexOrg || undefined,
+        highRisk: effectiveHighRisk || undefined,
+        depositLimit: effectiveDepositLimit || undefined,
+        amlAccountType: effectiveAmlAccountType || undefined,
+        commentGmeR: effectiveCommentGmeR || undefined,
+        reasonSeatingCompany: effectiveReasonSeatingCompany || undefined,
+        businessActivities: effectiveBusinessActivities || undefined,
       },
     });
   }
@@ -550,6 +561,11 @@ export function ComplianceReviewFreigabePanel({
           </colgroup>
           <tbody>
             {/* Section 6: Documents */}
+            <tr>
+              <td colSpan={3} className="text-sm font-bold text-dfxBlue-800 pt-4 pb-1">
+                Documents:
+              </td>
+            </tr>
             <DocLink label="Deckblatt" file={deckblatt} onOpenFile={onOpenFile} />
             <DocLink label="Identifikationsdokument" file={identDoc} onOpenFile={onOpenFile} />
             <DocLink label="Identifizierungsformular" file={identForm} onOpenFile={onOpenFile} />
@@ -594,79 +610,64 @@ export function ComplianceReviewFreigabePanel({
             </tr>
 
             {/* Section 7: Decision Fields */}
-            <DropdownField
-              label="Complex organization structure:"
-              value={complexOrgStructure}
-              options={[
-                { value: 'Ja', label: 'Ja' },
-                { value: 'Nein', label: 'Nein' },
-              ]}
-              onChange={setComplexOrgStructure}
-            />
-            <DropdownField
-              label='Risiko Einstufung als "Geschäftsbeziehung mit erhöhtem Risiko":'
-              value={highRisk}
-              options={[
-                { value: 'Ja', label: 'Ja' },
-                { value: 'Nein', label: 'Nein' },
-              ]}
-              onChange={setHighRisk}
-            />
-            <tr>
-              <td className="py-1 pr-4 text-left text-sm text-dfxBlue-800 w-56 align-top">depositLimit in CHF:</td>
-              <td className="py-1 text-right">
-                {userData.id != null && (
-                  <button
-                    className="px-3 py-1 text-xs text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded transition-colors whitespace-nowrap"
-                    onClick={() => setShowLimitRequestModal(true)}
-                  >
-                    Limit Request
-                  </button>
-                )}
-              </td>
-              <td className="py-1 text-right">
-                <select
-                  className="px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
-                  value={depositLimit}
-                  onChange={(e) => setDepositLimit(e.target.value)}
-                >
-                  <option value="">—</option>
-                  <option value="100000">100&apos;000</option>
-                  <option value="500000">500&apos;000</option>
-                </select>
-              </td>
-            </tr>
-            <DropdownField
-              label="amlAccountType:"
-              value={amlAccountType}
-              options={[
-                { value: 'operativ tätige Gesellschaft', label: 'operativ tätige Gesellschaft' },
-                { value: 'Sitzgesellschaft', label: 'Sitzgesellschaft' },
-                { value: 'Einzelunternehmen', label: 'Einzelunternehmen' },
-                { value: 'Stiftung', label: 'Stiftung' },
-                { value: 'Verein', label: 'Verein' },
-                { value: 'natural person', label: 'natural person' },
-              ]}
-              onChange={setAmlAccountType}
-            />
-            <TextareaField
-              label="Wenn GmeR:
+            {accountType !== 'Personal' && (
+              <>
+                <DropdownField
+                  label="Complex organization structure:"
+                  value={complexOrgStructure}
+                  options={[
+                    { value: 'Ja', label: 'Ja' },
+                    { value: 'Nein', label: 'Nein' },
+                  ]}
+                  onChange={setComplexOrgStructure}
+                />
+                <DropdownField
+                  label='Risiko Einstufung als "Geschäftsbeziehung mit erhöhtem Risiko":'
+                  value={highRisk}
+                  options={[
+                    { value: 'Ja', label: 'Ja' },
+                    { value: 'Nein', label: 'Nein' },
+                  ]}
+                  onChange={setHighRisk}
+                />
+              </>
+            )}
+            {accountType !== 'Personal' && (
+              <DropdownField
+                label="amlAccountType:"
+                value={amlAccountType}
+                options={[
+                  { value: 'operativ tätige Gesellschaft', label: 'operativ tätige Gesellschaft' },
+                  { value: 'Sitzgesellschaft', label: 'Sitzgesellschaft' },
+                  { value: 'Einzelunternehmen', label: 'Einzelunternehmen' },
+                  { value: 'Stiftung', label: 'Stiftung' },
+                  { value: 'Verein', label: 'Verein' },
+                ]}
+                onChange={setAmlAccountType}
+              />
+            )}
+            {accountType !== 'Personal' && (
+              <>
+                <TextareaField
+                  label="Wenn GmeR:
 Kommentar für die Aufnahme"
-              value={commentGmeR}
-              onChange={setCommentGmeR}
-            />
-            <TextareaField
-              label="Wenn Sitzgesellschaft:
+                  value={commentGmeR}
+                  onChange={setCommentGmeR}
+                />
+                <TextareaField
+                  label="Wenn Sitzgesellschaft:
 Gründe für die Verwendung einer Sitzgesellschaften"
-              value={reasonSeatingCompany}
-              onChange={setReasonSeatingCompany}
-            />
-            <TextareaField
-              label="Bei Einzelunternehmen und Organisationen:
+                  value={reasonSeatingCompany}
+                  onChange={setReasonSeatingCompany}
+                />
+                <TextareaField
+                  label="Bei Einzelunternehmen und Organisationen:
 Beschreibung der Geschäftlichen Aktivitäten"
-              value={businessActivities}
-              onChange={setBusinessActivities}
-            />
+                  value={businessActivities}
+                  onChange={setBusinessActivities}
+                />
+              </>
+            )}
 
             {/* Spacer */}
             <tr>
@@ -699,11 +700,9 @@ Beschreibung der Geschäftlichen Aktivitäten"
             <DropdownField
               label="Bearbeitet von:"
               value={processedBy}
-              options={[
-                { value: 'Vesa Rasaj', label: 'Vesa Rasaj' },
-                { value: 'Cyrill Thommen', label: 'Cyrill Thommen' },
-              ]}
+              options={clerks.map((c) => ({ value: c, label: c }))}
               onChange={setProcessedBy}
+              disabled={isLoadingClerks}
             />
           </tbody>
         </table>
@@ -719,17 +718,6 @@ Beschreibung der Geschäftlichen Aktivitäten"
           </button>
         </div>
       </div>
-      {userData.id != null && (
-        <LimitRequestModal
-          isOpen={showLimitRequestModal}
-          userDataId={Number(userData.id)}
-          defaultName={[extractField(userData, 'firstname'), extractField(userData, 'surname')]
-            .filter((v) => v !== '-')
-            .join(' ')}
-          onClose={() => setShowLimitRequestModal(false)}
-          onCreated={onLimitRequestCreated}
-        />
-      )}
     </>
   );
 }

--- a/src/components/compliance/quick-links-section.tsx
+++ b/src/components/compliance/quick-links-section.tsx
@@ -1,0 +1,38 @@
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useNavigation } from 'src/hooks/navigation.hook';
+import { todayAsString } from 'src/util/compliance-helpers';
+
+interface QuickLink {
+  label: string;
+  path: string;
+}
+
+export function QuickLinksSection(): JSX.Element {
+  const { translate } = useSettingsContext();
+  const { navigate } = useNavigation();
+
+  const links: QuickLink[] = [{ label: 'Aktennotiz erstellen', path: `kyc/log?eventDate=${todayAsString()}` }];
+
+  return (
+    <div className="w-full">
+      <h2 className="text-dfxGray-700 flex items-center justify-center gap-2 select-none">
+        {translate('screens/compliance', 'Quick links')}
+      </h2>
+      <div className="w-full overflow-x-auto">
+        <table className="w-full border-collapse bg-white rounded-lg shadow-sm">
+          <tbody>
+            {links.map((link) => (
+              <tr
+                key={link.path}
+                className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300 cursor-pointer"
+                onClick={() => navigate(link.path)}
+              >
+                <td className="px-4 py-3 text-left text-sm text-dfxBlue-300 underline">{link.label}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/compliance-review.screen.tsx
+++ b/src/screens/compliance-review.screen.tsx
@@ -357,7 +357,6 @@ export default function ComplianceReviewScreen(): JSX.Element {
               onOpenFile={openFile}
               onSave={handleFreigabeSave}
               isSaving={isSaving}
-              onLimitRequestCreated={loadData}
             />
           ) : effectiveTab === 'stammdaten' ? (
             <StammdatenPanel data={data} onOpenFile={openFile} onSave={handleSave} isSaving={isSaving} />

--- a/src/screens/compliance.screen.tsx
+++ b/src/screens/compliance.screen.tsx
@@ -17,6 +17,7 @@ import { useLocation } from 'react-router-dom';
 import { CallQueuesSection } from 'src/components/compliance/call-queues-section';
 import { PendingOnboardingsSection } from 'src/components/compliance/pending-onboardings-section';
 import { PendingReviewsSection } from 'src/components/compliance/pending-reviews-section';
+import { QuickLinksSection } from 'src/components/compliance/quick-links-section';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { CallQueueSummaryEntry, PendingReviewSummaryEntry } from '@dfx.swiss/react';
@@ -361,6 +362,7 @@ export default function ComplianceScreen(): JSX.Element {
         <PendingOnboardingsSection entries={pendingOnboardings} />
         <PendingReviewsSection entries={pendingReviews} />
         <CallQueuesSection entries={callQueues} />
+        <QuickLinksSection />
       </StyledVerticalStack>
     </Form>
   );


### PR DESCRIPTION
## Summary
- Hide organization-only fields in the freigabe panel for Personal accounts and force `amlAccountType = 'natural person'`
- Hardcode `depositLimit` to 100'000 at onboarding (later adjustable via Limit Request)
- Load clerks dynamically from `support/call-queues/clerks` with loading state on the "Bearbeitet von" dropdown
- Add `financialData` review tab (mirrors `beneficialOwner` pattern)
- Add quick links section on the compliance screen ("Aktennotiz erstellen")
- Highlight `yes_risky_business` answers in the result table
- Remove the inline LimitRequestModal from the freigabe panel

## Test plan
- [ ] Open compliance review for a Personal onboarding → org-only fields are hidden, save persists `amlAccountType = 'natural person'` and `depositLimit = 100000`
- [ ] Open compliance review for an Organization onboarding → all fields visible, values save correctly
- [ ] "Bearbeitet von" dropdown is disabled during initial load and populated from call-queue clerks afterwards
- [ ] FinancialData tab shows the result table with risky-business rows highlighted
- [ ] Quick links section on compliance screen navigates to the Aktennotiz form with today's date prefilled