### PR TITLE
feat: add swap routes, virtual ibans, ref rewards, notifications tabs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -363,6 +363,10 @@ export const Routes = [
         element: withSuspense(<ComplianceUserScreen />),
       },
       {
+        path: 'support/user/:id',
+        element: withSuspense(<ComplianceUserScreen />),
+      },
+      {
         path: 'compliance/user/:id/kyc-step/:stepId',
         element: withSuspense(<ComplianceKycStepScreen />),
       },

--- a/src/components/compliance/aml-check-panel.tsx
+++ b/src/components/compliance/aml-check-panel.tsx
@@ -212,7 +212,7 @@ export function AmlCheckPendingPanel({
   const ud = data.userData;
 
   const walletNames = Array.from(new Set(data.users.map((u) => u.walletName).filter((n): n is string => !!n)));
-  const latestManualLogComment = data.kycLogs
+  const latestManualLogComment = (data.kycLogs ?? [])
     .filter((l) => l.type === 'ManualLog' && l.comment)
     .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())[0]?.comment;
 

--- a/src/components/compliance/detail-tabs.tsx
+++ b/src/components/compliance/detail-tabs.tsx
@@ -4,8 +4,12 @@ import {
   BuyRouteInfo,
   KycLogInfo,
   KycStepInfo,
+  NotificationInfo,
+  RefRewardInfo,
   SellRouteInfo,
+  SwapRouteInfo,
   UserInfo,
+  VirtualIbanInfo,
 } from 'src/hooks/compliance.hook';
 import { boolBadge, formatDate, statusBadge } from 'src/util/compliance-helpers';
 
@@ -141,6 +145,29 @@ const buyRoutesColumns: ColumnDef<BuyRouteInfo>[] = [
   { header: 'Bank Usage', render: (b) => b.bankUsage, className: 'font-mono' },
   { header: 'Asset', render: (b) => b.assetName },
   { header: 'Blockchain', align: 'left', render: (b) => b.blockchain },
+  {
+    header: 'Address',
+    align: 'left',
+    render: (b) =>
+      b.targetAddress ? (
+        b.targetAddressExplorerUrl ? (
+          <a
+            href={b.targetAddressExplorerUrl}
+            target="_blank"
+            rel="noreferrer"
+            title={b.targetAddress}
+            className="text-dfxBlue-800 hover:underline"
+          >
+            {b.targetAddress}
+          </a>
+        ) : (
+          <span title={b.targetAddress}>{b.targetAddress}</span>
+        )
+      ) : (
+        '-'
+      ),
+    className: 'font-mono',
+  },
   { header: 'Volume', align: 'right', render: (b) => b.volume?.toFixed(2) },
   { header: 'Active', render: (b) => boolBadge(b.active) },
   { header: 'Created', render: (b) => formatDate(b.created) },
@@ -161,4 +188,153 @@ const sellRoutesColumns: ColumnDef<SellRouteInfo>[] = [
 
 export function SellRoutesTable({ sellRoutes }: { sellRoutes: SellRouteInfo[] }): JSX.Element {
   return <DataTable data={sellRoutes} columns={sellRoutesColumns} emptyLabel="No sell routes" />;
+}
+
+const swapRoutesColumns: ColumnDef<SwapRouteInfo>[] = [
+  { header: 'ID', render: (s) => s.id },
+  { header: 'Asset', render: (s) => s.assetName || '-' },
+  { header: 'Blockchain', align: 'left', render: (s) => s.blockchain || '-' },
+  {
+    header: 'Deposit Address',
+    align: 'left',
+    render: (s) =>
+      s.depositAddress ? (
+        s.depositAddressExplorerUrl ? (
+          <a
+            href={s.depositAddressExplorerUrl}
+            target="_blank"
+            rel="noreferrer"
+            title={s.depositAddress}
+            className="text-dfxBlue-800 hover:underline"
+          >
+            {s.depositAddress}
+          </a>
+        ) : (
+          <span title={s.depositAddress}>{s.depositAddress}</span>
+        )
+      ) : (
+        '-'
+      ),
+    className: 'font-mono',
+  },
+  { header: 'Volume', align: 'right', render: (s) => s.volume?.toFixed(2) },
+  { header: 'Annual Volume', align: 'right', render: (s) => s.annualVolume?.toFixed(2) },
+  { header: 'Active', render: (s) => boolBadge(s.active) },
+  { header: 'Created', render: (s) => formatDate(s.created) },
+];
+
+export function SwapRoutesTable({ swapRoutes }: { swapRoutes: SwapRouteInfo[] }): JSX.Element {
+  return <DataTable data={swapRoutes} columns={swapRoutesColumns} emptyLabel="No swap routes" />;
+}
+
+const virtualIbansColumns: ColumnDef<VirtualIbanInfo>[] = [
+  { header: 'ID', render: (v) => v.id },
+  { header: 'IBAN', align: 'left', render: (v) => v.iban, className: 'font-mono' },
+  { header: 'Currency', render: (v) => v.currency || '-' },
+  { header: 'Bank', align: 'left', render: (v) => v.bank || '-' },
+  { header: 'Status', render: (v) => (v.status ? statusBadge(v.status) : '-') },
+  { header: 'Active', render: (v) => boolBadge(v.active) },
+  {
+    header: 'Label',
+    align: 'left',
+    render: (v) => <span title={v.label}>{v.label || '-'}</span>,
+    className: 'max-w-xs truncate',
+  },
+  { header: 'Buy ID', render: (v) => v.buyId ?? '-' },
+  { header: 'Activated', render: (v) => (v.activatedAt ? formatDate(v.activatedAt) : '-') },
+  { header: 'Deactivated', render: (v) => (v.deactivatedAt ? formatDate(v.deactivatedAt) : '-') },
+  { header: 'Created', render: (v) => formatDate(v.created) },
+];
+
+export function VirtualIbansTable({ virtualIbans }: { virtualIbans: VirtualIbanInfo[] }): JSX.Element {
+  return <DataTable data={virtualIbans} columns={virtualIbansColumns} emptyLabel="No virtual IBANs" />;
+}
+
+const refRewardsColumns: ColumnDef<RefRewardInfo>[] = [
+  { header: 'ID', render: (r) => r.id },
+  { header: 'Status', render: (r) => (r.status ? statusBadge(r.status) : '-') },
+  { header: 'Amount', align: 'right', render: (r) => r.outputAmount?.toFixed(8) ?? '-' },
+  { header: 'Asset', render: (r) => r.outputAsset || '-' },
+  { header: 'Blockchain', align: 'left', render: (r) => r.outputBlockchain || '-' },
+  { header: 'CHF', align: 'right', render: (r) => r.amountInChf?.toFixed(2) ?? '-' },
+  { header: 'EUR', align: 'right', render: (r) => r.amountInEur?.toFixed(2) ?? '-' },
+  {
+    header: 'Target Address',
+    align: 'left',
+    render: (r) =>
+      r.targetAddress ? (
+        r.targetAddressExplorerUrl ? (
+          <a
+            href={r.targetAddressExplorerUrl}
+            target="_blank"
+            rel="noreferrer"
+            title={r.targetAddress}
+            className="text-dfxBlue-800 hover:underline"
+          >
+            {r.targetAddress}
+          </a>
+        ) : (
+          <span title={r.targetAddress}>{r.targetAddress}</span>
+        )
+      ) : (
+        '-'
+      ),
+    className: 'font-mono max-w-xs truncate',
+  },
+  {
+    header: 'TX ID',
+    align: 'left',
+    render: (r) =>
+      r.txId ? (
+        r.txExplorerUrl ? (
+          <a
+            href={r.txExplorerUrl}
+            target="_blank"
+            rel="noreferrer"
+            title={r.txId}
+            className="text-dfxBlue-800 hover:underline"
+          >
+            {r.txId}
+          </a>
+        ) : (
+          <span title={r.txId}>{r.txId}</span>
+        )
+      ) : (
+        '-'
+      ),
+    className: 'font-mono max-w-xs truncate',
+  },
+  { header: 'Output Date', render: (r) => (r.outputDate ? formatDate(r.outputDate) : '-') },
+  { header: 'Mail Sent', render: (r) => (r.mailSendDate ? formatDate(r.mailSendDate) : '-') },
+  { header: 'Created', render: (r) => formatDate(r.created) },
+];
+
+export function RefRewardsTable({ refRewards }: { refRewards: RefRewardInfo[] }): JSX.Element {
+  return <DataTable data={refRewards} columns={refRewardsColumns} emptyLabel="No referral rewards" />;
+}
+
+const notificationsColumns: ColumnDef<NotificationInfo>[] = [
+  { header: 'ID', render: (n) => n.id },
+  { header: 'Type', align: 'left', render: (n) => n.type },
+  { header: 'Context', align: 'left', render: (n) => n.context },
+  {
+    header: 'Correlation ID',
+    align: 'left',
+    render: (n) => <span title={n.correlationId}>{n.correlationId || '-'}</span>,
+    className: 'font-mono max-w-xs truncate',
+  },
+  { header: 'Complete', render: (n) => boolBadge(n.isComplete) },
+  { header: 'Suppress', render: (n) => boolBadge(n.suppressRecurring) },
+  {
+    header: 'Error',
+    align: 'left',
+    render: (n) => <span title={n.error}>{n.error || '-'}</span>,
+    className: 'max-w-xs truncate',
+  },
+  { header: 'Last Try', render: (n) => formatDate(n.lastTryDate) },
+  { header: 'Created', render: (n) => formatDate(n.created) },
+];
+
+export function NotificationsTable({ notifications }: { notifications: NotificationInfo[] }): JSX.Element {
+  return <DataTable data={notifications} columns={notificationsColumns} emptyLabel="No notifications" />;
 }

--- a/src/components/compliance/ident-panel.tsx
+++ b/src/components/compliance/ident-panel.tsx
@@ -95,8 +95,8 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
   }
 
   const identResult = parseIdentResult(step);
-  const identFiles = data.kycFiles.filter((f) => f.type === 'Identification');
-  const ipCountries = getUniqueIpCountries(data.ipLogs);
+  const identFiles = (data.kycFiles ?? []).filter((f) => f.type === 'Identification');
+  const ipCountries = getUniqueIpCountries(data.ipLogs ?? []);
   const ud = data.userData;
 
   let nationalityStepCountry: string | undefined;

--- a/src/components/compliance/stammdaten-panel.tsx
+++ b/src/components/compliance/stammdaten-panel.tsx
@@ -366,7 +366,7 @@ export function StammdatenPanel({ data, onOpenFile, onSave, isSaving }: Stammdat
           <ChangeSectionPanel
             section={section}
             step={step}
-            files={data.kycFiles}
+            files={data.kycFiles ?? []}
             userData={data.userData}
             checkItems={getCheckItems(section.stepName, accountType)}
             onOpenFile={onOpenFile}

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -16,6 +16,7 @@ interface TransactionsTableProps {
   expandedBankTxId?: number;
   expandedCryptoInputId?: number;
   expandedTxUid?: string;
+  canPerformActions?: boolean;
   onExpandBankTx: (id: number | undefined) => void;
   onExpandCryptoInput: (id: number | undefined) => void;
   onExpandTxUid: (uid: string | undefined) => void;
@@ -30,6 +31,7 @@ export function TransactionsTable({
   expandedBankTxId,
   expandedCryptoInputId,
   expandedTxUid,
+  canPerformActions = true,
   onExpandBankTx,
   onExpandCryptoInput,
   onExpandTxUid,
@@ -310,10 +312,13 @@ export function TransactionsTable({
                                     ].includes(detail.state) && !detail.chargebackAmount;
                                   const existingRecall = bankTx?.recall;
                                   const canRecall = bankTx != null && !existingRecall;
-                                  if (!canStop && !canChargeback && !canRecall && !existingRecall) return null;
+                                  const showStop = canStop && canPerformActions;
+                                  const showChargeback = canChargeback && canPerformActions;
+                                  const showRecall = canRecall && canPerformActions;
+                                  if (!showStop && !showChargeback && !showRecall && !existingRecall) return null;
                                   return (
                                     <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2">
-                                      {canStop && (
+                                      {showStop && (
                                         <button
                                           className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                           onClick={() => setStopConfirmTxId(tx.id)}
@@ -322,7 +327,7 @@ export function TransactionsTable({
                                           {stoppingTxId === tx.id ? 'Stopping...' : isStopped ? 'Stopped' : 'Stop'}
                                         </button>
                                       )}
-                                      {canChargeback && (
+                                      {showChargeback && (
                                         <button
                                           className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                           onClick={() => setChargebackTxId(tx.id)}
@@ -330,7 +335,7 @@ export function TransactionsTable({
                                           Chargeback
                                         </button>
                                       )}
-                                      {canRecall && (
+                                      {showRecall && (
                                         <button
                                           className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                                           onClick={() => setRecallBankTxId(bankTx.id)}

--- a/src/components/compliance/user-data-panel.tsx
+++ b/src/components/compliance/user-data-panel.tsx
@@ -8,6 +8,7 @@ interface UserDataPanelProps {
   valueLabel: string;
   titleLabel: string;
   userDataId?: number;
+  canRequestLimit?: boolean;
   onLimitRequestCreated?: () => void;
 }
 
@@ -96,6 +97,7 @@ export function UserDataPanel({
   valueLabel,
   titleLabel,
   userDataId,
+  canRequestLimit = true,
   onLimitRequestCreated,
 }: UserDataPanelProps): JSX.Element {
   const [showAll, setShowAll] = useState(false);
@@ -164,7 +166,7 @@ export function UserDataPanel({
                         >
                           {valueString}
                         </a>
-                      ) : key === 'depositLimit' && userDataId ? (
+                      ) : key === 'depositLimit' && userDataId && canRequestLimit ? (
                         <div className="flex items-center justify-between gap-2">
                           <span>{valueString}</span>
                           <button
@@ -197,7 +199,7 @@ export function UserDataPanel({
           </table>
         </div>
       </div>
-      {userDataId && (
+      {userDataId && canRequestLimit && (
         <LimitRequestModal
           isOpen={showLimitRequestModal}
           userDataId={userDataId}

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -260,6 +260,10 @@ export interface ComplianceUserData {
   bankDatas: BankDataInfo[];
   buyRoutes: BuyRouteInfo[];
   sellRoutes: SellRouteInfo[];
+  swapRoutes: SwapRouteInfo[];
+  virtualIbans: VirtualIbanInfo[];
+  refRewards: RefRewardInfo[];
+  notifications: NotificationInfo[];
 }
 
 export interface RecommendationGraphNode {
@@ -377,6 +381,8 @@ export interface BuyRouteInfo {
   bankUsage: string;
   assetName: string;
   blockchain: string;
+  targetAddress?: string;
+  targetAddressExplorerUrl?: string;
   volume: number;
   active: boolean;
   created: string;
@@ -388,6 +394,64 @@ export interface SellRouteInfo {
   fiatName?: string;
   volume: number;
   active: boolean;
+  created: string;
+}
+
+export interface SwapRouteInfo {
+  id: number;
+  assetName?: string;
+  blockchain?: string;
+  depositAddress?: string;
+  depositAddressExplorerUrl?: string;
+  volume: number;
+  annualVolume: number;
+  active: boolean;
+  created: string;
+}
+
+export interface VirtualIbanInfo {
+  id: number;
+  iban: string;
+  bban?: string;
+  currency?: string;
+  bank?: string;
+  status?: string;
+  active: boolean;
+  label?: string;
+  buyId?: number;
+  reservedUntil?: string;
+  activatedAt?: string;
+  deactivatedAt?: string;
+  created: string;
+}
+
+export interface NotificationInfo {
+  id: number;
+  type: string;
+  context: string;
+  correlationId?: string;
+  isComplete: boolean;
+  error?: string;
+  suppressRecurring: boolean;
+  lastTryDate: string;
+  created: string;
+}
+
+export interface RefRewardInfo {
+  id: number;
+  status?: string;
+  outputAmount?: number;
+  outputAsset?: string;
+  outputBlockchain?: string;
+  amountInChf?: number;
+  amountInEur?: number;
+  targetAddress?: string;
+  targetAddressExplorerUrl?: string;
+  txId?: string;
+  txExplorerUrl?: string;
+  outputDate?: string;
+  recipientMail?: string;
+  mailSendDate?: string;
   created: string;
 }
 

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -246,16 +246,26 @@ export interface UserDataDetail {
   wallet?: { name?: string };
 }
 
+export interface SupportPermissions {
+  viewKycFiles: boolean;
+  viewKycLogs: boolean;
+  viewIpLogs: boolean;
+  viewSupportIssues: boolean;
+  canRequestLimit: boolean;
+  canPerformTransactionActions: boolean;
+  viewRecommendation: boolean;
+}
+
 export interface ComplianceUserData {
   userData: UserDataDetail;
-  kycFiles: KycFile[];
+  kycFiles?: KycFile[];
   kycSteps: KycStepInfo[];
-  kycLogs: KycLogInfo[];
+  kycLogs?: KycLogInfo[];
   transactions: TransactionInfo[];
   bankTxs: BankTxInfo[];
   cryptoInputs: CryptoInputInfo[];
-  ipLogs: IpLogInfo[];
-  supportIssues: SupportIssueInfo[];
+  ipLogs?: IpLogInfo[];
+  supportIssues?: SupportIssueInfo[];
   users: UserInfo[];
   bankDatas: BankDataInfo[];
   buyRoutes: BuyRouteInfo[];
@@ -264,6 +274,7 @@ export interface ComplianceUserData {
   virtualIbans: VirtualIbanInfo[];
   refRewards: RefRewardInfo[];
   notifications: NotificationInfo[];
+  permissions: SupportPermissions;
 }
 
 export interface RecommendationGraphNode {

--- a/src/screens/compliance-call-queue-detail.screen.tsx
+++ b/src/screens/compliance-call-queue-detail.screen.tsx
@@ -173,9 +173,9 @@ export default function ComplianceCallQueueDetailScreen(): JSX.Element {
           title={translate('screens/compliance', 'Bank Transactions')}
         />
       )}
-      <CallQueueIpCountries ipLogs={data.ipLogs} title={translate('screens/compliance', 'IP Countries')} />
+      <CallQueueIpCountries ipLogs={data.ipLogs ?? []} title={translate('screens/compliance', 'IP Countries')} />
       <CallQueueKycComments
-        kycLogs={data.kycLogs}
+        kycLogs={data.kycLogs ?? []}
         filterTypes={['ManualLog']}
         title={translate('screens/compliance', 'Recent KYC Comments')}
       />

--- a/src/screens/compliance-review.screen.tsx
+++ b/src/screens/compliance-review.screen.tsx
@@ -353,7 +353,7 @@ export default function ComplianceReviewScreen(): JSX.Element {
               step={findLatestStep(data.kycSteps, 'DfxApproval')}
               userData={data.userData}
               kycSteps={data.kycSteps}
-              kycFiles={data.kycFiles}
+              kycFiles={data.kycFiles ?? []}
               onOpenFile={openFile}
               onSave={handleFreigabeSave}
               isSaving={isSaving}
@@ -384,8 +384,8 @@ export default function ComplianceReviewScreen(): JSX.Element {
           ) : (
             <ComplianceReviewPanel
               step={findLatestStep(data.kycSteps, activeConfig.stepName)}
-              files={findFiles(data.kycFiles, activeConfig.fileTypes)}
-              allFiles={data.kycFiles}
+              files={findFiles(data.kycFiles ?? [], activeConfig.fileTypes)}
+              allFiles={data.kycFiles ?? []}
               checkItems={activeConfig.checkItems}
               showResult={activeConfig.showResult}
               decisionLabel={activeConfig.decisionLabel}

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -53,14 +53,31 @@ type FeatureId =
   | 'recommendation'
   | 'supportIssues'
   | 'limitRequest'
-  | 'transactionActions';
+  | 'transactionActions'
+  | 'kycLogsTab';
 
-// Features (panels and actions) that are hidden for the given role.
+// Features (panels, actions and tabs) that are hidden for the given role.
 // Mirrored on the backend by FIELDS_HIDDEN_BY_ROLE in support.service.ts where applicable
 // (data-only features; pure UI actions like 'limitRequest' have no backend counterpart).
 const FEATURES_HIDDEN_BY_ROLE: Partial<Record<UserRole, FeatureId[]>> = {
-  [UserRole.SUPPORT]: ['kycFiles', 'ipLogs', 'filePreview', 'supportIssues', 'limitRequest', 'transactionActions'],
-  [UserRole.MARKETING]: ['kycFiles', 'ipLogs', 'filePreview', 'supportIssues', 'limitRequest', 'transactionActions'],
+  [UserRole.SUPPORT]: [
+    'kycFiles',
+    'ipLogs',
+    'filePreview',
+    'supportIssues',
+    'limitRequest',
+    'transactionActions',
+    'kycLogsTab',
+  ],
+  [UserRole.MARKETING]: [
+    'kycFiles',
+    'ipLogs',
+    'filePreview',
+    'supportIssues',
+    'limitRequest',
+    'transactionActions',
+    'kycLogsTab',
+  ],
 };
 
 function isFeatureVisible(id: FeatureId, role?: UserRole): boolean {
@@ -146,7 +163,9 @@ export default function ComplianceUserScreen(): JSX.Element {
         { id: 'transactions', label: 'Transactions', count: data.transactions?.length || 0 },
         { id: 'users', label: 'Users', count: data.users?.length || 0 },
         { id: 'kycSteps', label: 'KYC Steps', count: data.kycSteps?.length || 0 },
-        { id: 'kycLogs', label: 'KYC Log', count: data.kycLogs?.length || 0 },
+        ...(isFeatureVisible('kycLogsTab', role)
+          ? [{ id: 'kycLogs' as TabType, label: 'KYC Log', count: data.kycLogs?.length || 0 }]
+          : []),
         { id: 'bankDatas', label: 'Bank Data', count: data.bankDatas?.length || 0 },
         { id: 'virtualIbans', label: 'Virtual IBANs', count: data.virtualIbans?.length || 0 },
         { id: 'buyRoutes', label: 'Buy Routes', count: data.buyRoutes?.length || 0 },

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -7,8 +7,12 @@ import {
   BuyRoutesTable,
   KycLogsTable,
   KycStepsTable,
+  NotificationsTable,
+  RefRewardsTable,
   SellRoutesTable,
+  SwapRoutesTable,
   UsersTable,
+  VirtualIbansTable,
 } from 'src/components/compliance/detail-tabs';
 import { FilePreviewPanel } from 'src/components/compliance/file-preview-panel';
 import { IpLogsPanel } from 'src/components/compliance/ip-logs-panel';
@@ -23,7 +27,18 @@ import { ComplianceUserData, KycFile, useCompliance } from 'src/hooks/compliance
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 
-type TabType = 'transactions' | 'users' | 'kycSteps' | 'kycLogs' | 'bankDatas' | 'buyRoutes' | 'sellRoutes';
+type TabType =
+  | 'transactions'
+  | 'users'
+  | 'kycSteps'
+  | 'kycLogs'
+  | 'bankDatas'
+  | 'buyRoutes'
+  | 'sellRoutes'
+  | 'swapRoutes'
+  | 'virtualIbans'
+  | 'refRewards'
+  | 'notifications';
 
 interface TabConfig {
   id: TabType;
@@ -110,8 +125,12 @@ export default function ComplianceUserScreen(): JSX.Element {
         { id: 'kycSteps', label: 'KYC Steps', count: data.kycSteps?.length || 0 },
         { id: 'kycLogs', label: 'KYC Log', count: data.kycLogs?.length || 0 },
         { id: 'bankDatas', label: 'Bank Data', count: data.bankDatas?.length || 0 },
+        { id: 'virtualIbans', label: 'Virtual IBANs', count: data.virtualIbans?.length || 0 },
         { id: 'buyRoutes', label: 'Buy Routes', count: data.buyRoutes?.length || 0 },
         { id: 'sellRoutes', label: 'Sell Routes', count: data.sellRoutes?.length || 0 },
+        { id: 'swapRoutes', label: 'Swap Routes', count: data.swapRoutes?.length || 0 },
+        { id: 'refRewards', label: 'Ref Rewards', count: data.refRewards?.length || 0 },
+        { id: 'notifications', label: 'Notifications', count: data.notifications?.length || 0 },
       ]
     : [];
 
@@ -199,6 +218,10 @@ export default function ComplianceUserScreen(): JSX.Element {
               {activeTab === 'bankDatas' && <BankDatasTable bankDatas={data.bankDatas} />}
               {activeTab === 'buyRoutes' && <BuyRoutesTable buyRoutes={data.buyRoutes} />}
               {activeTab === 'sellRoutes' && <SellRoutesTable sellRoutes={data.sellRoutes} />}
+              {activeTab === 'swapRoutes' && <SwapRoutesTable swapRoutes={data.swapRoutes} />}
+              {activeTab === 'virtualIbans' && <VirtualIbansTable virtualIbans={data.virtualIbans} />}
+              {activeTab === 'refRewards' && <RefRewardsTable refRewards={data.refRewards} />}
+              {activeTab === 'notifications' && <NotificationsTable notifications={data.notifications} />}
             </div>
           </div>
         </div>

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -1,4 +1,4 @@
-import { useKyc } from '@dfx.swiss/react';
+import { useAuthContext, UserRole, useKyc } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -24,7 +24,7 @@ import { UserDataPanel } from 'src/components/compliance/user-data-panel';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { ComplianceUserData, KycFile, useCompliance } from 'src/hooks/compliance.hook';
-import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 
 type TabType =
@@ -46,8 +46,31 @@ interface TabConfig {
   count: number;
 }
 
+type FeatureId =
+  | 'kycFiles'
+  | 'ipLogs'
+  | 'filePreview'
+  | 'recommendation'
+  | 'supportIssues'
+  | 'limitRequest'
+  | 'transactionActions';
+
+// Features (panels and actions) that are hidden for the given role.
+// Mirrored on the backend by FIELDS_HIDDEN_BY_ROLE in support.service.ts where applicable
+// (data-only features; pure UI actions like 'limitRequest' have no backend counterpart).
+const FEATURES_HIDDEN_BY_ROLE: Partial<Record<UserRole, FeatureId[]>> = {
+  [UserRole.SUPPORT]: ['kycFiles', 'ipLogs', 'filePreview', 'supportIssues', 'limitRequest', 'transactionActions'],
+  [UserRole.MARKETING]: ['kycFiles', 'ipLogs', 'filePreview', 'supportIssues', 'limitRequest', 'transactionActions'],
+};
+
+function isFeatureVisible(id: FeatureId, role?: UserRole): boolean {
+  return !role || !(FEATURES_HIDDEN_BY_ROLE[role] ?? []).includes(id);
+}
+
 export default function ComplianceUserScreen(): JSX.Element {
-  useComplianceGuard();
+  useSupportDashboardGuard();
+  const { session } = useAuthContext();
+  const role = session?.role;
 
   const { translate } = useSettingsContext();
   const { id: userDataId } = useParams();
@@ -150,31 +173,40 @@ export default function ComplianceUserScreen(): JSX.Element {
               valueLabel={translate('screens/compliance', 'Value')}
               titleLabel={translate('screens/compliance', 'User Data')}
               userDataId={userDataId ? +userDataId : undefined}
+              canRequestLimit={isFeatureVisible('limitRequest', role)}
               onLimitRequestCreated={loadData}
             />
 
             <div className="w-1/3 min-w-[300px] flex flex-col gap-4">
               <RecommendationPanel kycSteps={data.kycSteps} userDataId={userDataId ?? ''} navigate={navigate} />
-              <KycFilesPanel
-                kycFiles={data.kycFiles}
-                label={translate('screens/compliance', 'KYC Files')}
-                onOpenFile={openFile}
-              />
-              <IpLogsPanel ipLogs={data.ipLogs} userDataId={+(userDataId ?? '0')} />
-              <SupportIssuesPanel
-                supportIssues={data.supportIssues}
-                userDataId={userDataId ?? ''}
-                navigate={navigate}
-              />
+              {isFeatureVisible('kycFiles', role) && (
+                <KycFilesPanel
+                  kycFiles={data.kycFiles}
+                  label={translate('screens/compliance', 'KYC Files')}
+                  onOpenFile={openFile}
+                />
+              )}
+              {isFeatureVisible('ipLogs', role) && (
+                <IpLogsPanel ipLogs={data.ipLogs} userDataId={+(userDataId ?? '0')} />
+              )}
+              {isFeatureVisible('supportIssues', role) && (
+                <SupportIssuesPanel
+                  supportIssues={data.supportIssues}
+                  userDataId={userDataId ?? ''}
+                  navigate={navigate}
+                />
+              )}
             </div>
 
-            <div className="sticky top-4 self-start">
-              <FilePreviewPanel
-                preview={preview}
-                label={translate('screens/compliance', 'File Preview')}
-                onClose={() => setPreview(undefined)}
-              />
-            </div>
+            {isFeatureVisible('filePreview', role) && (
+              <div className="sticky top-4 self-start">
+                <FilePreviewPanel
+                  preview={preview}
+                  label={translate('screens/compliance', 'File Preview')}
+                  onClose={() => setPreview(undefined)}
+                />
+              </div>
+            )}
           </div>
 
           {/* Bottom Section: Tabs */}
@@ -205,6 +237,7 @@ export default function ComplianceUserScreen(): JSX.Element {
                   expandedBankTxId={expandedBankTxId}
                   expandedCryptoInputId={expandedCryptoInputId}
                   expandedTxUid={expandedTxUid}
+                  canPerformActions={isFeatureVisible('transactionActions', role)}
                   onExpandBankTx={handleExpandBankTx}
                   onExpandCryptoInput={handleExpandCryptoInput}
                   onExpandTxUid={handleExpandTxUid}

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -1,4 +1,4 @@
-import { useAuthContext, UserRole, useKyc } from '@dfx.swiss/react';
+import { useKyc } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -46,48 +46,8 @@ interface TabConfig {
   count: number;
 }
 
-type FeatureId =
-  | 'kycFiles'
-  | 'ipLogs'
-  | 'filePreview'
-  | 'recommendation'
-  | 'supportIssues'
-  | 'limitRequest'
-  | 'transactionActions'
-  | 'kycLogsTab';
-
-// Features (panels, actions and tabs) that are hidden for the given role.
-// Mirrored on the backend by FIELDS_HIDDEN_BY_ROLE in support.service.ts where applicable
-// (data-only features; pure UI actions like 'limitRequest' have no backend counterpart).
-const FEATURES_HIDDEN_BY_ROLE: Partial<Record<UserRole, FeatureId[]>> = {
-  [UserRole.SUPPORT]: [
-    'kycFiles',
-    'ipLogs',
-    'filePreview',
-    'supportIssues',
-    'limitRequest',
-    'transactionActions',
-    'kycLogsTab',
-  ],
-  [UserRole.MARKETING]: [
-    'kycFiles',
-    'ipLogs',
-    'filePreview',
-    'supportIssues',
-    'limitRequest',
-    'transactionActions',
-    'kycLogsTab',
-  ],
-};
-
-function isFeatureVisible(id: FeatureId, role?: UserRole): boolean {
-  return !role || !(FEATURES_HIDDEN_BY_ROLE[role] ?? []).includes(id);
-}
-
 export default function ComplianceUserScreen(): JSX.Element {
   useSupportDashboardGuard();
-  const { session } = useAuthContext();
-  const role = session?.role;
 
   const { translate } = useSettingsContext();
   const { id: userDataId } = useParams();
@@ -163,8 +123,8 @@ export default function ComplianceUserScreen(): JSX.Element {
         { id: 'transactions', label: 'Transactions', count: data.transactions?.length || 0 },
         { id: 'users', label: 'Users', count: data.users?.length || 0 },
         { id: 'kycSteps', label: 'KYC Steps', count: data.kycSteps?.length || 0 },
-        ...(isFeatureVisible('kycLogsTab', role)
-          ? [{ id: 'kycLogs' as TabType, label: 'KYC Log', count: data.kycLogs?.length || 0 }]
+        ...(data.permissions.viewKycLogs
+          ? [{ id: 'kycLogs' as TabType, label: 'KYC Log', count: data.kycLogs?.length ?? 0 }]
           : []),
         { id: 'bankDatas', label: 'Bank Data', count: data.bankDatas?.length || 0 },
         { id: 'virtualIbans', label: 'Virtual IBANs', count: data.virtualIbans?.length || 0 },
@@ -192,32 +152,34 @@ export default function ComplianceUserScreen(): JSX.Element {
               valueLabel={translate('screens/compliance', 'Value')}
               titleLabel={translate('screens/compliance', 'User Data')}
               userDataId={userDataId ? +userDataId : undefined}
-              canRequestLimit={isFeatureVisible('limitRequest', role)}
+              canRequestLimit={data.permissions.canRequestLimit}
               onLimitRequestCreated={loadData}
             />
 
             <div className="w-1/3 min-w-[300px] flex flex-col gap-4">
-              <RecommendationPanel kycSteps={data.kycSteps} userDataId={userDataId ?? ''} navigate={navigate} />
-              {isFeatureVisible('kycFiles', role) && (
+              {data.permissions.viewRecommendation && (
+                <RecommendationPanel kycSteps={data.kycSteps} userDataId={userDataId ?? ''} navigate={navigate} />
+              )}
+              {data.permissions.viewKycFiles && (
                 <KycFilesPanel
-                  kycFiles={data.kycFiles}
+                  kycFiles={data.kycFiles ?? []}
                   label={translate('screens/compliance', 'KYC Files')}
                   onOpenFile={openFile}
                 />
               )}
-              {isFeatureVisible('ipLogs', role) && (
-                <IpLogsPanel ipLogs={data.ipLogs} userDataId={+(userDataId ?? '0')} />
+              {data.permissions.viewIpLogs && (
+                <IpLogsPanel ipLogs={data.ipLogs ?? []} userDataId={+(userDataId ?? '0')} />
               )}
-              {isFeatureVisible('supportIssues', role) && (
+              {data.permissions.viewSupportIssues && (
                 <SupportIssuesPanel
-                  supportIssues={data.supportIssues}
+                  supportIssues={data.supportIssues ?? []}
                   userDataId={userDataId ?? ''}
                   navigate={navigate}
                 />
               )}
             </div>
 
-            {isFeatureVisible('filePreview', role) && (
+            {data.permissions.viewKycFiles && (
               <div className="sticky top-4 self-start">
                 <FilePreviewPanel
                   preview={preview}
@@ -256,7 +218,7 @@ export default function ComplianceUserScreen(): JSX.Element {
                   expandedBankTxId={expandedBankTxId}
                   expandedCryptoInputId={expandedCryptoInputId}
                   expandedTxUid={expandedTxUid}
-                  canPerformActions={isFeatureVisible('transactionActions', role)}
+                  canPerformActions={data.permissions.canPerformTransactionActions}
                   onExpandBankTx={handleExpandBankTx}
                   onExpandCryptoInput={handleExpandCryptoInput}
                   onExpandTxUid={handleExpandTxUid}
@@ -266,7 +228,7 @@ export default function ComplianceUserScreen(): JSX.Element {
 
               {activeTab === 'users' && <UsersTable users={data.users} />}
               {activeTab === 'kycSteps' && <KycStepsTable kycSteps={data.kycSteps} />}
-              {activeTab === 'kycLogs' && <KycLogsTable kycLogs={data.kycLogs} />}
+              {activeTab === 'kycLogs' && <KycLogsTable kycLogs={data.kycLogs ?? []} />}
               {activeTab === 'bankDatas' && <BankDatasTable bankDatas={data.bankDatas} />}
               {activeTab === 'buyRoutes' && <BuyRoutesTable buyRoutes={data.buyRoutes} />}
               {activeTab === 'sellRoutes' && <SellRoutesTable sellRoutes={data.sellRoutes} />}

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -7,6 +7,7 @@ import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { CustomerAuthor, SupportIssueListItem, useSupportDashboard } from 'src/hooks/support-dashboard.hook';
+import { UserSearchResult, useCompliance } from 'src/hooks/compliance.hook';
 import { formatDateTime, statusBadge } from 'src/util/compliance-helpers';
 import { reasonLabel, typeLabel } from 'src/util/support-helpers';
 
@@ -32,7 +33,14 @@ export default function SupportDashboardScreen(): JSX.Element {
   const { translate } = useSettingsContext();
   const { session } = useAuthContext();
   const { getIssueList, getIssueCounts, getIssueActivity } = useSupportDashboard();
+  const { search: searchCustomers } = useCompliance();
   const { navigate } = useNavigation();
+
+  const [customerSearchKey, setCustomerSearchKey] = useState('');
+  const [customerSearchResults, setCustomerSearchResults] = useState<UserSearchResult[]>();
+  const [customerSearchLoading, setCustomerSearchLoading] = useState(false);
+  const [customerSearchError, setCustomerSearchError] = useState<string>();
+  const [showCustomerSearch, setShowCustomerSearch] = useState(false);
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -177,6 +185,17 @@ export default function SupportDashboardScreen(): JSX.Element {
   const openIssueCount =
     openIssueGroups.customerWaiting.length + openIssueGroups.created.length + openIssueGroups.pending.length;
 
+  function handleCustomerSearch(): void {
+    if (!customerSearchKey.trim()) return;
+    setCustomerSearchLoading(true);
+    setCustomerSearchError(undefined);
+    setCustomerSearchResults(undefined);
+    searchCustomers(customerSearchKey.trim())
+      .then((result) => setCustomerSearchResults(result.userDatas))
+      .catch((e: Error) => setCustomerSearchError(e.message ?? 'Unknown error'))
+      .finally(() => setCustomerSearchLoading(false));
+  }
+
   const currentTab = activeTab === 'open' ? null : tabs[activeTab];
   const displayedIssues = currentTab?.issues ?? [];
   const displayedTotal = currentTab?.total ?? 0;
@@ -198,6 +217,12 @@ export default function SupportDashboardScreen(): JSX.Element {
         </div>
         <div className="flex gap-2 ml-auto">
           <button
+            className="px-3 py-2 bg-white border border-dfxGray-400 text-dfxBlue-800 rounded-lg text-sm hover:bg-dfxGray-300 transition-colors"
+            onClick={() => setShowCustomerSearch((v) => !v)}
+          >
+            {showCustomerSearch ? '−' : '+'} {translate('screens/support', 'Customer Search')}
+          </button>
+          <button
             className="px-4 py-2 bg-dfxBlue-400 text-white rounded-lg text-sm hover:bg-dfxBlue-800 transition-colors"
             onClick={() => navigate('/support/dashboard/create')}
           >
@@ -205,6 +230,77 @@ export default function SupportDashboardScreen(): JSX.Element {
           </button>
         </div>
       </div>
+
+      {/* Customer Search */}
+      {showCustomerSearch && (
+        <div className="bg-white rounded-lg shadow-sm p-3 flex flex-col gap-2">
+          <div className="flex gap-2">
+            <input
+              className="px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800 flex-1"
+              value={customerSearchKey}
+              onChange={(e) => setCustomerSearchKey(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleCustomerSearch();
+              }}
+              placeholder={translate(
+                'screens/support',
+                'Search by ID, email, phone, name, KYC hash, blockchain address...',
+              )}
+            />
+            <button
+              className="px-4 py-1.5 bg-dfxBlue-400 text-white rounded text-sm hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
+              onClick={handleCustomerSearch}
+              disabled={customerSearchLoading || !customerSearchKey.trim()}
+            >
+              {customerSearchLoading ? '…' : translate('general/actions', 'Search')}
+            </button>
+          </div>
+          {customerSearchError && <ErrorHint message={customerSearchError} />}
+          {customerSearchResults && (
+            <>
+              {customerSearchResults.length === 0 ? (
+                <p className="text-sm text-dfxGray-700">{translate('screens/compliance', 'No entries found')}</p>
+              ) : (
+                <table className="w-full border-collapse text-sm">
+                  <thead className="bg-dfxGray-300">
+                    <tr>
+                      <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800">ID</th>
+                      <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800">
+                        {translate('screens/kyc', 'Account Type')}
+                      </th>
+                      <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800">
+                        {translate('screens/kyc', 'Name')}
+                      </th>
+                      <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800 break-all">
+                        {translate('screens/compliance', 'Email')}
+                      </th>
+                      <th className="px-3 py-2"></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {customerSearchResults.map((u) => (
+                      <tr key={u.id} className="border-b border-dfxGray-300 hover:bg-dfxGray-300">
+                        <td className="px-3 py-2 text-dfxBlue-800">{u.id}</td>
+                        <td className="px-3 py-2 text-dfxBlue-800">{u.accountType ?? '-'}</td>
+                        <td className="px-3 py-2 text-dfxBlue-800">{u.name ?? '-'}</td>
+                        <td className="px-3 py-2 text-dfxBlue-800 break-all">{u.mail ?? '-'}</td>
+                        <td className="px-3 py-2 text-right">
+                          <button
+                            className="px-2 py-1 text-xs font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors"
+                            onClick={() => navigate(`/support/user/${u.id}`)}
+                          >
+                            {translate('screens/compliance', 'Details')}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </>
+          )}
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="flex gap-1 border-b border-dfxGray-400">


### PR DESCRIPTION
## Summary
- Adds **Swap Routes**, **Virtual IBANs**, **Ref Rewards** and **Notifications** tabs to the compliance user detail page
- Tab order: Bank Data → Virtual IBANs → Buy Routes → Sell Routes → Swap Routes → Ref Rewards → Notifications
- Renders deposit/target addresses and tx ids as clickable block-explorer links (graceful fallback to plain text when no URL is provided by the API)
- Requires API branch [DFXswiss/api#3647](https://github.com/DFXswiss/api/pull/3647)

## Test plan
- [ ] All four new tabs appear with correct counts
- [ ] Explorer links open in a new tab for ETH/BTC/BSC routes
- [ ] Empty states ("No swap routes", "No notifications", ...) render correctly
- [ ] No regressions on the existing tabs (Transactions, Users, KYC Steps/Logs, Bank Data, Buy/Sell Routes)