### PR TITLE
refactor(compliance): extract display helpers, split-pane hook and i18n

### DIFF
--- a/src/components/compliance/bank-data-panel.tsx
+++ b/src/components/compliance/bank-data-panel.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { BankDataInfo } from 'src/hooks/compliance.hook';
+import { BankDataInfo, UserDataDetail } from 'src/hooks/compliance.hook';
 import { statusBadge } from 'src/util/compliance-helpers';
 
 interface BankDataReviewPanelProps {
   bankDatas: BankDataInfo[];
-  userData: Record<string, unknown>;
+  userData: UserDataDetail;
   onApprove: (bankDataId: number) => Promise<void>;
   onReject: (bankDataId: number) => Promise<void>;
   isSaving: boolean;

--- a/src/components/compliance/call-queue/call-queue-address-info.tsx
+++ b/src/components/compliance/call-queue/call-queue-address-info.tsx
@@ -10,7 +10,7 @@ export function CallQueueAddressInfo({ userData, title }: Props): JSX.Element {
     ['Street', userData.street],
     ['House Number', userData.houseNumber],
     ['ZIP', userData.zip],
-    ['City', userData.location ?? userData.city],
+    ['City', userData.location],
     ['Country', userData.country?.name ?? userData.country?.symbol],
     ['Phone Call Times', userData.phoneCallTimes],
   ];

--- a/src/components/compliance/compliance-review-configs.ts
+++ b/src/components/compliance/compliance-review-configs.ts
@@ -1,3 +1,5 @@
+import { UserDataDetail } from 'src/hooks/compliance.hook';
+
 export type ReviewCheckTab =
   | 'legalEntity'
   | 'authority'
@@ -22,13 +24,13 @@ export interface CheckItemConfig {
   id: string;
   label: string;
   altLabel?: string;
-  altCondition?: (userData: Record<string, unknown>) => boolean;
+  altCondition?: (userData: UserDataDetail) => boolean;
   type?: CheckItemType;
   options?: string[];
   fileType?: string;
   href?: string;
   condition?: (checks: Record<string, string>) => boolean;
-  visibleCondition?: (userData: Record<string, unknown>) => boolean;
+  visibleCondition?: (userData: UserDataDetail) => boolean;
 }
 
 export interface ReviewTabConfig {
@@ -61,21 +63,18 @@ export const reviewTabs: ReviewTabConfig[] = [
       'Name nicht korrekt',
     ],
     checkItems: [
-      { id: 'nameMatch', label: 'Das Dokument lautet auf den Namen "{organizationName}"' },
+      { id: 'nameMatch', label: 'Das Dokument lautet auf den Namen "{organization.name}"' },
       {
         id: 'verifiedNameMatch',
         label:
-          'Der verifizierte Name des Kunden "{verifiedName}" stimmt mit dem Unternehmensnamen "{organizationName}" überein',
-        visibleCondition: (userData) => {
-          const v = userData['verifiedName'];
-          return typeof v === 'string' && v.trim().length > 0;
-        },
+          'Der verifizierte Name des Kunden "{verifiedName}" stimmt mit dem Unternehmensnamen "{organization.name}" überein',
+        visibleCondition: (userData) => !!userData.verifiedName && userData.verifiedName.trim().length > 0,
       },
       {
         id: 'legalEntityMatch',
         label: 'Das Unternehmen ist gemäss Onboarding eine "{legalEntity}"',
         altLabel: 'Es handelt sich um eine Einzelfirma',
-        altCondition: (userData) => userData['accountType'] === 'SoleProprietorship',
+        altCondition: (userData) => userData.accountType === 'SoleProprietorship',
       },
       { id: 'docAge', label: 'Das Dokument ist weniger als 3 Monate alt' },
       { id: 'legalFormConsistent', label: 'Die Rechtsform stimmt mit den Onboarding Infos überein' },
@@ -93,7 +92,7 @@ export const reviewTabs: ReviewTabConfig[] = [
     checkItems: [
       {
         id: 'authorityName',
-        label: 'Die Vollmacht lautet auf den Namen "{organizationName}"',
+        label: 'Die Vollmacht lautet auf den Namen "{organization.name}"',
       },
       {
         id: 'docAge',
@@ -152,7 +151,7 @@ export const reviewTabs: ReviewTabConfig[] = [
       '§',
     ],
     checkItems: [
-      { id: 'nameMatch', label: 'Das Dokument lautet auf den Namen "{organizationName}"' },
+      { id: 'nameMatch', label: 'Das Dokument lautet auf den Namen "{organization.name}"' },
       { id: 'plausible', label: 'Das Dokument ist plausibel' },
     ],
   },

--- a/src/components/compliance/compliance-review-header.tsx
+++ b/src/components/compliance/compliance-review-header.tsx
@@ -1,8 +1,8 @@
-import { KycStepInfo } from 'src/hooks/compliance.hook';
-import { formatDate } from 'src/util/compliance-helpers';
+import { KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook';
+import { buildAddress, display, formatDate, refName } from 'src/util/compliance-helpers';
 
 interface ComplianceReviewHeaderProps {
-  userData: Record<string, unknown>;
+  userData: UserDataDetail;
   kycSteps: KycStepInfo[];
 }
 
@@ -11,33 +11,6 @@ interface HeaderField {
   value: string;
   isLink?: boolean;
   href?: string;
-}
-
-function extractField(userData: Record<string, unknown>, key: string): string {
-  const value = userData[key];
-  if (value == null) return '-';
-  if (typeof value === 'object') {
-    const obj = value as Record<string, unknown>;
-    return (obj.name || obj.symbol || obj.displayName || obj.id || '-').toString();
-  }
-  return value.toString();
-}
-
-function buildAddress(userData: Record<string, unknown>): string {
-  const parts = [
-    [extractField(userData, 'organizationStreet'), extractField(userData, 'organizationHouseNumber')],
-    [extractField(userData, 'organizationZip'), extractField(userData, 'organizationLocation')],
-  ];
-
-  const lines = parts.map((p) => p.filter((v) => v !== '-').join(' ')).filter(Boolean);
-
-  const country = userData['organizationCountry'];
-  if (country && typeof country === 'object') {
-    const name = (country as Record<string, unknown>).name;
-    if (name) lines.push(name.toString());
-  }
-
-  return lines.length > 0 ? lines.join(', ') : '-';
 }
 
 function extractLegalEntityFromStep(kycSteps: KycStepInfo[], accountType: string): string {
@@ -66,43 +39,31 @@ function extractStepCreatedDate(kycSteps: KycStepInfo[]): string {
   return new Date(step.created).toLocaleDateString('de-CH');
 }
 
-export function ComplianceReviewHeader({ userData, kycSteps }: ComplianceReviewHeaderProps): JSX.Element {
-  const contactName =
-    [extractField(userData, 'firstname'), extractField(userData, 'surname')].filter((v) => v !== '-').join(' ') || '-';
-
-  const accountType = extractField(userData, 'accountType');
-
+export function ComplianceReviewHeader({ userData, kycSteps }: Readonly<ComplianceReviewHeaderProps>): JSX.Element {
+  const contactName = [userData.firstname, userData.surname].filter(Boolean).join(' ') || '-';
+  const accountType = display(userData.accountType);
   const isOrganization = accountType === 'Organization' || accountType === 'SoleProprietorship';
 
-  const personalAddress =
-    [
-      [extractField(userData, 'street'), extractField(userData, 'houseNumber')],
-      [extractField(userData, 'zip'), extractField(userData, 'location')],
-    ]
-      .map((p) => p.filter((v) => v !== '-').join(' '))
-      .filter(Boolean)
-      .join(', ') || '-';
-
   const fields: HeaderField[] = [
-    { label: 'UserDataId', value: extractField(userData, 'id') },
+    { label: 'UserDataId', value: display(userData.id) },
     { label: 'Account Type', value: accountType },
     ...(isOrganization
       ? [
-          { label: 'Organization', value: extractField(userData, 'organizationName') },
+          { label: 'Organization', value: display(userData.organization?.name) },
           { label: 'Legal Entity', value: extractLegalEntityFromStep(kycSteps, accountType) },
-          { label: 'Adresse', value: buildAddress(userData) },
+          { label: 'Adresse', value: buildAddress(userData.organization) },
           { label: 'Ansprechsperson', value: contactName },
         ]
       : [
           { label: 'Name', value: contactName },
-          { label: 'Adresse', value: personalAddress },
-          { label: 'Geburtstag', value: userData.birthday ? formatDate(String(userData.birthday)) : '-' },
-          { label: 'VerifiedName', value: extractField(userData, 'verifiedName') },
+          { label: 'Adresse', value: buildAddress(userData) },
+          { label: 'Geburtstag', value: userData.birthday ? formatDate(userData.birthday) : '-' },
+          { label: 'VerifiedName', value: display(userData.verifiedName) },
         ]),
-    { label: 'Mail', value: extractField(userData, 'mail') },
-    { label: 'Sprache', value: extractField(userData, 'language') },
-    { label: 'KYC Level', value: extractField(userData, 'kycLevel') },
-    { label: 'KYC Status', value: extractField(userData, 'kycStatus') },
+    { label: 'Mail', value: display(userData.mail) },
+    { label: 'Sprache', value: refName(userData.language) },
+    { label: 'KYC Level', value: display(userData.kycLevel) },
+    { label: 'KYC Status', value: display(userData.kycStatus) },
     ...(isOrganization ? [{ label: 'Datum Dokument eingereicht', value: extractStepCreatedDate(kycSteps) }] : []),
   ];
 

--- a/src/components/compliance/compliance-review-panel.tsx
+++ b/src/components/compliance/compliance-review-panel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { KycFile, KycStepInfo } from 'src/hooks/compliance.hook';
+import { KycFile, KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook';
 import { statusBadge, todayAsString } from 'src/util/compliance-helpers';
 import { CheckItemConfig } from './compliance-review-configs';
 
@@ -13,21 +13,27 @@ interface ComplianceReviewPanelProps {
   showResult?: boolean;
   decisionLabel: string;
   rejectionReasons: string[];
-  userData: Record<string, unknown>;
+  userData: UserDataDetail;
   onOpenFile: (file: KycFile) => void;
   onSave: (stepId: number, status: string, comment?: string, result?: string) => Promise<void>;
   isSaving: boolean;
 }
 
-function resolveLabel(label: string, userData: Record<string, unknown>): string {
-  return label.replace(/\{(\w+)\}/g, (_, key: string) => {
-    const value = userData[key];
-    if (value == null) return '-';
-    if (typeof value === 'object') {
-      const obj = value as Record<string, unknown>;
+// Resolves "{path}" placeholders, supporting dotted nested keys like "organization.name"
+// or "country.symbol". Falls back to '-' if any segment is missing.
+function resolveLabel(label: string, source: object): string {
+  return label.replace(/\{([\w.]+)\}/g, (_, path: string) => {
+    let cursor: unknown = source;
+    for (const segment of path.split('.')) {
+      if (cursor == null || typeof cursor !== 'object') return '-';
+      cursor = (cursor as Record<string, unknown>)[segment];
+    }
+    if (cursor == null) return '-';
+    if (typeof cursor === 'object') {
+      const obj = cursor as Record<string, unknown>;
       return (obj.name || obj.symbol || obj.id || '-').toString();
     }
-    return value.toString();
+    return String(cursor);
   });
 }
 

--- a/src/components/compliance/detail-tabs.tsx
+++ b/src/components/compliance/detail-tabs.tsx
@@ -82,12 +82,34 @@ export function UsersTable({ users }: { users: UserInfo[] }): JSX.Element {
   return <DataTable data={users} columns={usersColumns} emptyLabel="No users" />;
 }
 
+function formatStepResult(stepName: string, result?: string): string {
+  if (!result) return '-';
+  // Only Recommendation step results are shown (key = refCode | mail | invitationCode).
+  // Other steps store complex JSON that is not useful as a column value.
+  if (stepName !== 'Recommendation') return '-';
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (parsed && typeof parsed === 'object' && 'key' in parsed) {
+      return String((parsed as { key: unknown }).key);
+    }
+    return result;
+  } catch {
+    return result;
+  }
+}
+
 const kycStepsColumns: ColumnDef<KycStepInfo>[] = [
   { header: 'ID', render: (s) => s.id },
   { header: 'Name', align: 'left', render: (s) => s.name },
   { header: 'Type', align: 'left', render: (s) => s.type || '-' },
   { header: 'Status', render: (s) => statusBadge(s.status) },
   { header: 'Sequence', render: (s) => s.sequenceNumber },
+  {
+    header: 'Result',
+    align: 'left',
+    render: (s) => <span title={s.result}>{formatStepResult(s.name, s.result)}</span>,
+    className: 'max-w-xs truncate',
+  },
   {
     header: 'Comment',
     align: 'left',

--- a/src/components/compliance/freigabe-panel.tsx
+++ b/src/components/compliance/freigabe-panel.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useState } from 'react';
 import { useCallQueueClerks } from 'src/hooks/call-queue-clerks.hook';
-import { KycFile, KycStepInfo } from 'src/hooks/compliance.hook';
-import { formatDate, formatDateTime, formatValue, statusBadge } from 'src/util/compliance-helpers';
+import { KycFile, KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook';
+import {
+  buildAddress,
+  display,
+  formatDate,
+  formatDateTime,
+  formatValue,
+  refName,
+  statusBadge,
+} from 'src/util/compliance-helpers';
 
 type DecisionValue = '' | 'Akzeptiert' | 'Abgelehnt';
 
@@ -26,7 +34,7 @@ export interface ComplianceReviewFreigabeSaveParams {
 
 interface OnboardingComplianceReviewFreigabePanelProps {
   step: KycStepInfo | undefined;
-  userData: Record<string, unknown>;
+  userData: UserDataDetail;
   kycSteps: KycStepInfo[];
   kycFiles: KycFile[];
   onOpenFile: (file: KycFile) => void;
@@ -41,16 +49,6 @@ interface SavedComment {
   amlAccountType?: string;
   processedBy?: string;
   finalDecision?: string;
-}
-
-function extractField(data: Record<string, unknown>, key: string): string {
-  const value = data[key];
-  if (value == null) return '-';
-  if (typeof value === 'object') {
-    const obj = value as Record<string, unknown>;
-    return (obj.name || obj.symbol || obj.displayName || obj.id || '-').toString();
-  }
-  return value.toString();
 }
 
 function findStep(steps: KycStepInfo[], name: string): KycStepInfo | undefined {
@@ -342,31 +340,19 @@ export function ComplianceReviewFreigabePanel({
     );
   }
 
-  const accountType = extractField(userData, 'accountType');
+  const accountType = display(userData.accountType);
   const isOrganization = accountType === 'Organization';
   const legalEntityStep = findStep(kycSteps, 'LegalEntity');
   const legalEntityResult = parseResult(legalEntityStep);
   const legalEntity = legalEntityResult?.legalEntity ? String(legalEntityResult.legalEntity) : '';
   const isGmbH = legalEntity === 'GmbH';
 
-  const kycHash = extractField(userData, 'kycHash');
+  const kycHash = display(userData.kycHash);
   const financialDataStep = findStep(kycSteps, 'FinancialData');
   const beneficialOwnerStep = findStep(kycSteps, 'BeneficialOwner');
   const signatoryPowerStep = findStep(kycSteps, 'SignatoryPower');
   const operationalActivityStep = findStep(kycSteps, 'OperationalActivity');
   const operationalActivityResult = parseResult(operationalActivityStep);
-
-  function buildAddress(prefix: string): string {
-    const street = extractField(userData, `${prefix}Street`);
-    const houseNr = extractField(userData, `${prefix}HouseNumber`);
-    const zip = extractField(userData, `${prefix}Zip`);
-    const location = extractField(userData, `${prefix}Location`);
-    const country = extractField(userData, `${prefix}Country`);
-    const parts = [`${street} ${houseNr}`.trim(), `${zip} ${location}`.trim(), country]
-      .filter((p) => p && p !== '-')
-      .join(', ');
-    return parts || '-';
-  }
 
   async function handleSave(): Promise<void> {
     if (!step || !finalDecision) return;
@@ -441,28 +427,26 @@ export function ComplianceReviewFreigabePanel({
 
   // --- User info rows ---
   const userInfoRows = [
-    { label: 'UserDataId', value: extractField(userData, 'id') },
+    { label: 'UserDataId', value: display(userData.id) },
     { label: 'Account Type', value: accountType },
     {
       label: 'Name Kontoeröffner',
-      value:
-        [extractField(userData, 'firstname'), extractField(userData, 'surname')].filter((v) => v !== '-').join(' ') ||
-        '-',
+      value: [userData.firstname, userData.surname].filter(Boolean).join(' ') || '-',
     },
-    ...(isOrganization ? [{ label: 'Name Vertragspartei', value: extractField(userData, 'organizationName') }] : []),
-    { label: 'Privat-Adresse', value: buildAddress('') },
-    ...(isOrganization ? [{ label: 'Firmen-Adresse', value: buildAddress('organization') }] : []),
-    { label: 'Geburtstag', value: userData['birthday'] ? formatDate(String(userData['birthday'])) : '-' },
-    { label: 'Mail', value: extractField(userData, 'mail') },
-    { label: 'Phone', value: extractField(userData, 'phone') },
-    { label: 'Sprache', value: extractField(userData, 'language') },
-    { label: 'Nationalität', value: extractField(userData, 'nationality') },
-    { label: 'lastNameCheckDate', value: extractField(userData, 'lastNameCheckDate') },
-    { label: 'PEP', value: extractField(userData, 'pep') },
-    { label: 'HighRisk', value: extractField(userData, 'highRisk') },
-    { label: 'identDocumentId', value: extractField(userData, 'identDocumentId') },
-    { label: 'identificationType', value: extractField(userData, 'identificationType') },
-    { label: 'identDocumentType', value: extractField(userData, 'identDocumentType') },
+    ...(isOrganization ? [{ label: 'Name Vertragspartei', value: display(userData.organization?.name) }] : []),
+    { label: 'Privat-Adresse', value: buildAddress(userData) },
+    ...(isOrganization ? [{ label: 'Firmen-Adresse', value: buildAddress(userData.organization) }] : []),
+    { label: 'Geburtstag', value: userData.birthday ? formatDate(userData.birthday) : '-' },
+    { label: 'Mail', value: display(userData.mail) },
+    { label: 'Phone', value: display(userData.phone) },
+    { label: 'Sprache', value: refName(userData.language) },
+    { label: 'Nationalität', value: refName(userData.nationality) },
+    { label: 'lastNameCheckDate', value: userData.lastNameCheckDate ? formatDate(userData.lastNameCheckDate) : '-' },
+    { label: 'PEP', value: display(userData.pep) },
+    { label: 'HighRisk', value: display(userData.highRisk) },
+    { label: 'identDocumentId', value: display(userData.identDocumentId) },
+    { label: 'identificationType', value: display(userData.identificationType) },
+    { label: 'identDocumentType', value: display(userData.identDocumentType) },
     {
       label: 'kycHash',
       value: kycHash !== '-' ? kycHash : '-',
@@ -470,7 +454,7 @@ export function ComplianceReviewFreigabePanel({
       href: kycHash !== '-' ? `/kyc?code=${kycHash}` : undefined,
     },
     ...(isOrganization
-      ? [{ label: 'accountOpenerAuthorization', value: extractField(userData, 'accountOpenerAuthorization') }]
+      ? [{ label: 'accountOpenerAuthorization', value: display(userData.organization?.accountOpenerAuthorization) }]
       : []),
   ];
 

--- a/src/components/compliance/ident-panel.tsx
+++ b/src/components/compliance/ident-panel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ComplianceUserData, KycFile, KycStepInfo, IpLogInfo } from 'src/hooks/compliance.hook';
-import { statusBadge, formatDate, todayAsString } from 'src/util/compliance-helpers';
+import { display, formatDate, refName, statusBadge, todayAsString } from 'src/util/compliance-helpers';
 import { renderResultTable } from './compliance-review-panel';
 
 interface IdentPanelProps {
@@ -57,15 +57,6 @@ function parseIdentResult(step: KycStepInfo): IdentResult | undefined {
 function getUniqueIpCountries(ipLogs: IpLogInfo[]): string[] {
   const countries = ipLogs.map((l) => l.country).filter((c): c is string => !!c);
   return [...new Set(countries)];
-}
-
-function extractString(value: unknown): string {
-  if (value == null) return '-';
-  if (typeof value === 'object') {
-    const obj = value as Record<string, unknown>;
-    return String(obj.name ?? obj.symbol ?? obj.id ?? '-');
-  }
-  return String(value);
 }
 
 function InfoLine({ label, value }: { label: string; value: string }): JSX.Element {
@@ -152,22 +143,17 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
       <div>
         <h3 className="text-dfxGray-700 mb-2 font-semibold text-sm">User Daten</h3>
         <div className="bg-white rounded-lg shadow-sm">
-          <InfoLine label="UserDataId" value={extractString(ud.id)} />
-          <InfoLine label="Birthday" value={ud.birthday ? formatDate(String(ud.birthday)) : '-'} />
-          <InfoLine label="AccountType" value={extractString(ud.accountType)} />
+          <InfoLine label="UserDataId" value={display(ud.id)} />
+          <InfoLine label="Birthday" value={ud.birthday ? formatDate(ud.birthday) : '-'} />
+          <InfoLine label="AccountType" value={display(ud.accountType)} />
           <InfoLine
             label="Address"
-            value={
-              [ud.street, ud.houseNumber, ud.zip, ud.location]
-                .map((v) => extractString(v))
-                .filter((v) => v !== '-')
-                .join(', ') || '-'
-            }
+            value={[ud.street, ud.houseNumber, ud.zip, ud.location].filter(Boolean).join(', ') || '-'}
           />
           <InfoLine label="Document Type" value={identResult?.documentType ?? '-'} />
-          <InfoLine label="Mail" value={extractString(ud.mail)} />
-          <InfoLine label="Sprache" value={extractString(ud.language ?? ud.languageId)} />
-          <InfoLine label="VerifiedName" value={extractString(ud.verifiedName)} />
+          <InfoLine label="Mail" value={display(ud.mail)} />
+          <InfoLine label="Sprache" value={refName(ud.language)} />
+          <InfoLine label="VerifiedName" value={display(ud.verifiedName)} />
           {step.comment && <InfoLine label="Comment" value={step.comment} />}
         </div>
       </div>
@@ -184,7 +170,7 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
             </div>
             <div className="flex items-center px-3 py-2 border-b border-dfxGray-300">
               <span className="text-sm text-dfxBlue-800 font-medium w-48">Vorname</span>
-              <span className="text-sm text-dfxBlue-800 w-1/2">{extractString(ud.firstname)}</span>
+              <span className="text-sm text-dfxBlue-800 w-1/2">{display(ud.firstname)}</span>
               <span
                 className={`text-sm w-1/2 ${
                   identResult.firstname &&
@@ -199,7 +185,7 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
             </div>
             <div className="flex items-center px-3 py-2 border-b border-dfxGray-300 last:border-0">
               <span className="text-sm text-dfxBlue-800 font-medium w-48">Nachname</span>
-              <span className="text-sm text-dfxBlue-800 w-1/2">{extractString(ud.surname)}</span>
+              <span className="text-sm text-dfxBlue-800 w-1/2">{display(ud.surname)}</span>
               <span
                 className={`text-sm w-1/2 ${
                   identResult.lastname &&
@@ -240,7 +226,7 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
       {/* Aktennotiz Link */}
       <div className="bg-white rounded-lg shadow-sm">
         <a
-          href={`/kyc/log?userDataId=${extractString(ud.id)}&eventDate=${todayAsString()}`}
+          href={`/kyc/log?userDataId=${display(ud.id)}&eventDate=${todayAsString()}`}
           target="_blank"
           rel="noopener noreferrer"
           className="w-full px-3 py-2 text-left text-sm text-dfxBlue-300 underline hover:text-dfxBlue-800 transition-colors block"

--- a/src/components/compliance/stammdaten-panel.tsx
+++ b/src/components/compliance/stammdaten-panel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { ComplianceUserData, KycFile, KycStepInfo } from 'src/hooks/compliance.hook';
+import { ComplianceUserData, KycFile, KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook';
 import { statusBadge, formatDateTime } from 'src/util/compliance-helpers';
 
 interface StammdatenPanelProps {
@@ -89,7 +89,7 @@ function getCheckItems(stepName: string, accountType: string): DocumentCheckItem
   }
 }
 
-function buildComparisonRows(stepName: string, result: string, userData: Record<string, unknown>): ComparisonRow[] {
+function buildComparisonRows(stepName: string, result: string, userData: UserDataDetail): ComparisonRow[] {
   let parsed: Record<string, unknown>;
   try {
     parsed = JSON.parse(result) as Record<string, unknown>;
@@ -161,7 +161,7 @@ function ChangeSectionPanel({
   section: ChangeSection;
   step: KycStepInfo;
   files: KycFile[];
-  userData: Record<string, unknown>;
+  userData: UserDataDetail;
   checkItems: DocumentCheckItem[];
   onOpenFile: (file: KycFile) => void;
   onSave: (stepId: number, status: string, comment?: string, result?: string) => Promise<void>;

--- a/src/components/compliance/support-user-overview-panel.tsx
+++ b/src/components/compliance/support-user-overview-panel.tsx
@@ -1,0 +1,331 @@
+import { ReactNode, useState } from 'react';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { BankTxInfo, ComplianceUserData, CryptoInputInfo, TransactionInfo } from 'src/hooks/compliance.hook';
+import { formatDateTime } from 'src/util/compliance-helpers';
+
+interface Props {
+  data: ComplianceUserData;
+}
+
+interface CardProps {
+  label: string;
+  value: ReactNode;
+  hint?: ReactNode;
+  onClick?: () => void;
+}
+
+function StatsCard({ label, value, hint, onClick }: Readonly<CardProps>): JSX.Element {
+  const interactive = !!onClick;
+  return (
+    <div
+      className={`bg-white rounded-lg shadow-sm p-4 flex flex-col gap-1 min-w-0 ${
+        interactive ? 'cursor-pointer hover:bg-dfxGray-300 transition-colors' : ''
+      }`}
+      onClick={onClick}
+      onKeyDown={interactive ? (e) => (e.key === 'Enter' || e.key === ' ') && onClick?.() : undefined}
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
+    >
+      <div className="text-xs text-dfxGray-700 uppercase tracking-wide">{label}</div>
+      <div className="text-lg font-semibold text-dfxBlue-800 break-words">
+        {value === null || value === undefined || value === '' ? '-' : value}
+      </div>
+      {hint && <div className="text-xs text-dfxGray-700 break-words">{hint}</div>}
+    </div>
+  );
+}
+
+function mostRecent(
+  transactions: TransactionInfo[],
+  pred: (t: TransactionInfo) => boolean,
+): TransactionInfo | undefined {
+  return transactions.filter(pred).sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())[0];
+}
+
+function findTransaction(transactions: TransactionInfo[], query: string): TransactionInfo | undefined {
+  const q = query.trim();
+  if (!q) return undefined;
+
+  const asNum = Number(q);
+  if (!Number.isNaN(asNum)) {
+    const byNum = transactions.find((t) => t.id === asNum || t.buyCryptoId === asNum || t.buyFiatId === asNum);
+    if (byNum) return byNum;
+  }
+  return transactions.find((t) => t.uid === q);
+}
+
+function DetailRow({ label, value, wide }: Readonly<{ label: string; value: ReactNode; wide?: boolean }>): JSX.Element {
+  return (
+    <div className={`flex gap-2 py-1 border-b border-dfxGray-300 min-w-0 ${wide ? 'col-span-2' : ''}`}>
+      <div className="text-xs text-dfxGray-700 w-32 shrink-0 pt-0.5">{label}</div>
+      <div className="text-sm text-dfxBlue-800 break-all min-w-0 flex-1">{value || '-'}</div>
+    </div>
+  );
+}
+
+function DetailGrid({ children }: Readonly<{ children: ReactNode }>): JSX.Element {
+  return <div className="grid grid-cols-2 gap-x-6 gap-y-0">{children}</div>;
+}
+
+function TransactionDetail({
+  tx,
+  bankTx,
+  cryptoInput,
+}: Readonly<{ tx: TransactionInfo; bankTx?: BankTxInfo; cryptoInput?: CryptoInputInfo }>): JSX.Element {
+  const { translate } = useSettingsContext();
+  const inOut =
+    [
+      tx.inputAmount != null ? `${tx.inputAmount} ${tx.inputAsset ?? ''}`.trim() : undefined,
+      tx.outputAmount != null ? `${tx.outputAmount} ${tx.outputAsset ?? ''}`.trim() : undefined,
+    ]
+      .filter(Boolean)
+      .join(' → ') || undefined;
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-3">
+      <div className="text-xs text-dfxGray-700 uppercase tracking-wide mb-2">
+        {translate('screens/compliance', 'Transaction')} #{tx.id}
+        {tx.buyCryptoId && ` · BuyCrypto #${tx.buyCryptoId}`}
+        {tx.buyFiatId && ` · BuyFiat #${tx.buyFiatId}`}
+      </div>
+      <DetailGrid>
+        <DetailRow label="UID" value={<span className="font-mono text-xs">{tx.uid}</span>} />
+        <DetailRow label={translate('screens/compliance', 'Type')} value={tx.type} />
+        <DetailRow label={translate('screens/compliance', 'Source')} value={tx.sourceType} />
+        <DetailRow
+          label={translate('screens/compliance', 'Status')}
+          value={
+            tx.isCompleted
+              ? translate('screens/compliance', 'Completed')
+              : translate('screens/compliance', 'Processing')
+          }
+        />
+        <DetailRow label={translate('screens/compliance', 'Created')} value={formatDateTime(tx.created)} />
+        <DetailRow label={translate('screens/compliance', 'Amount')} value={inOut} />
+        <DetailRow
+          label={translate('screens/compliance', 'Volume')}
+          value={tx.amountInChf != null ? `${tx.amountInChf} CHF` : undefined}
+        />
+        <DetailRow label="EUR" value={tx.amountInEur != null ? `${tx.amountInEur} EUR` : undefined} />
+        <DetailRow label={translate('screens/compliance', 'AML Check')} value={tx.amlCheck} />
+        {tx.amlReason && <DetailRow label={translate('screens/compliance', 'AML Reason')} value={tx.amlReason} />}
+        {tx.chargebackDate && (
+          <DetailRow label={translate('screens/compliance', 'Chargeback')} value={formatDateTime(tx.chargebackDate)} />
+        )}
+        {tx.comment && <DetailRow label={translate('screens/compliance', 'Comment')} value={tx.comment} wide />}
+      </DetailGrid>
+
+      {bankTx && (
+        <>
+          <div className="text-xs text-dfxGray-700 uppercase tracking-wide mt-3 mb-2">Bank-TX #{bankTx.id}</div>
+          <DetailGrid>
+            <DetailRow label="Account-Service-Ref" value={bankTx.accountServiceRef} />
+            <DetailRow label={translate('screens/compliance', 'Type')} value={bankTx.type} />
+            <DetailRow
+              label={translate('screens/compliance', 'Amount')}
+              value={`${bankTx.amount} ${bankTx.currency}`}
+            />
+            <DetailRow label={translate('screens/compliance', 'Name')} value={bankTx.name} />
+            <DetailRow label="IBAN" value={bankTx.iban} />
+            {bankTx.remittanceInfo && (
+              <DetailRow label={translate('screens/compliance', 'Remittance Info')} value={bankTx.remittanceInfo} />
+            )}
+            {bankTx.recall && (
+              <DetailRow
+                label={translate('screens/compliance', 'Recall')}
+                value={`#${bankTx.recall.id} · Seq ${bankTx.recall.sequence} · ${bankTx.recall.reason ?? '-'}`}
+              />
+            )}
+          </DetailGrid>
+        </>
+      )}
+
+      {cryptoInput && (
+        <>
+          <div className="text-xs text-dfxGray-700 uppercase tracking-wide mt-3 mb-2">
+            Crypto-Input #{cryptoInput.id}
+          </div>
+          <DetailGrid>
+            <DetailRow label="In-TX-ID" value={<span className="font-mono text-xs">{cryptoInput.inTxId}</span>} />
+            <DetailRow label={translate('screens/compliance', 'Status')} value={cryptoInput.status} />
+            <DetailRow
+              label={translate('screens/compliance', 'Amount')}
+              value={`${cryptoInput.amount} ${cryptoInput.assetName ?? ''}`.trim()}
+            />
+            <DetailRow label={translate('screens/compliance', 'Blockchain')} value={cryptoInput.blockchain} />
+            {cryptoInput.senderAddresses && (
+              <DetailRow
+                label={translate('screens/compliance', 'Sender')}
+                value={<span className="font-mono text-xs">{cryptoInput.senderAddresses}</span>}
+              />
+            )}
+            {cryptoInput.returnTxId && (
+              <DetailRow
+                label={translate('screens/compliance', 'Return-TX')}
+                value={<span className="font-mono text-xs">{cryptoInput.returnTxId}</span>}
+              />
+            )}
+            {cryptoInput.purpose && (
+              <DetailRow label={translate('screens/compliance', 'Purpose')} value={cryptoInput.purpose} />
+            )}
+          </DetailGrid>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface LookupProps {
+  data: ComplianceUserData;
+  query: string;
+  setQuery: (q: string) => void;
+  submittedQuery: string;
+  setSubmittedQuery: (q: string) => void;
+}
+
+function TransactionLookup({
+  data,
+  query,
+  setQuery,
+  submittedQuery,
+  setSubmittedQuery,
+}: Readonly<LookupProps>): JSX.Element {
+  const { translate } = useSettingsContext();
+  const tx = submittedQuery ? findTransaction(data.transactions, submittedQuery) : undefined;
+  const bankTx = tx ? data.bankTxs.find((b) => b.transactionId === tx.id) : undefined;
+  const cryptoInput = tx ? data.cryptoInputs.find((c) => c.transactionId === tx.id) : undefined;
+
+  function submit(): void {
+    setSubmittedQuery(query.trim());
+  }
+
+  function reset(): void {
+    setQuery('');
+    setSubmittedQuery('');
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h3 className="text-xs text-dfxGray-700 uppercase tracking-wide">
+        {translate('screens/compliance', 'Transaction Search')}
+      </h3>
+      <div className="flex gap-2">
+        <input
+          className="px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800 flex-1 min-w-0"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && submit()}
+          placeholder={translate('screens/compliance', 'TX-ID, UID, BuyCrypto-ID or BuyFiat-ID')}
+        />
+        <button
+          className="px-3 py-1.5 text-xs font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-400 transition-colors disabled:opacity-50"
+          onClick={submit}
+          disabled={!query.trim()}
+        >
+          {translate('general/actions', 'Search')}
+        </button>
+        {submittedQuery && (
+          <button
+            className="px-3 py-1.5 text-xs font-medium bg-dfxGray-300 text-dfxBlue-800 rounded hover:bg-dfxGray-400 transition-colors"
+            onClick={reset}
+          >
+            {translate('general/actions', 'Back')}
+          </button>
+        )}
+      </div>
+      {submittedQuery && !tx && (
+        <p className="text-sm text-dfxRed-100">
+          {translate('screens/compliance', 'No transaction found for {{query}}', { query: submittedQuery })}
+        </p>
+      )}
+      {tx && <TransactionDetail tx={tx} bankTx={bankTx} cryptoInput={cryptoInput} />}
+    </div>
+  );
+}
+
+export function SupportUserOverviewPanel({ data }: Readonly<Props>): JSX.Element {
+  const { translate } = useSettingsContext();
+  const { userData, transactions, users, supportIssues } = data;
+
+  const [query, setQuery] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
+
+  const lastDeposit = mostRecent(transactions, (t) => t.buyCryptoId != null);
+  const lastWithdrawal = mostRecent(transactions, (t) => t.buyFiatId != null);
+
+  const onrampCount = transactions.filter((t) => t.buyCryptoId != null && t.isCompleted).length;
+  const offrampCount = transactions.filter((t) => t.buyFiatId != null && t.isCompleted).length;
+
+  const issuesTotal = supportIssues?.length ?? 0;
+  const issuesOpen = supportIssues?.filter((i) => i.state !== 'Completed').length ?? 0;
+
+  function selectTransaction(id: number): void {
+    const idStr = String(id);
+    setQuery(idStr);
+    setSubmittedQuery(idStr);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 text-left">
+      <h2 className="text-dfxGray-700 text-center">{translate('screens/compliance', 'Support Overview')}</h2>
+
+      <div className="grid grid-cols-2 gap-3">
+        <StatsCard
+          label={translate('screens/compliance', 'User')}
+          value={`#${userData.id}`}
+          hint={
+            <>
+              {userData.country?.name ?? '-'} · {translate('screens/compliance', 'KYC Level')}{' '}
+              {userData.kycLevel ?? '-'}
+            </>
+          }
+        />
+        <StatsCard
+          label={translate('screens/compliance', 'Status')}
+          value={userData.status ?? '-'}
+          hint={`${translate('screens/compliance', 'Risk')}: ${userData.riskStatus ?? '-'}`}
+        />
+        <StatsCard
+          label={translate('screens/compliance', 'Last Deposit')}
+          value={lastDeposit ? formatDateTime(lastDeposit.created) : '-'}
+          hint={
+            lastDeposit
+              ? `${lastDeposit.inputAmount ?? '-'} ${lastDeposit.inputAsset ?? ''} → ${lastDeposit.outputAsset ?? ''}`
+              : undefined
+          }
+          onClick={lastDeposit ? () => selectTransaction(lastDeposit.id) : undefined}
+        />
+        <StatsCard
+          label={translate('screens/compliance', 'Last Withdrawal')}
+          value={lastWithdrawal ? formatDateTime(lastWithdrawal.created) : '-'}
+          hint={
+            lastWithdrawal
+              ? `${lastWithdrawal.outputAsset ?? '-'} · ${
+                  lastWithdrawal.isCompleted
+                    ? translate('screens/compliance', 'Completed')
+                    : translate('screens/compliance', 'Processing')
+                }`
+              : undefined
+          }
+          onClick={lastWithdrawal ? () => selectTransaction(lastWithdrawal.id) : undefined}
+        />
+        <StatsCard label={translate('screens/compliance', 'Onramp (Buy)')} value={onrampCount} />
+        <StatsCard label={translate('screens/compliance', 'Offramp (Sell)')} value={offrampCount} />
+        <StatsCard label={translate('screens/compliance', 'Wallets / Addresses')} value={users.length} />
+        <StatsCard
+          label={translate('screens/compliance', 'Support Issues')}
+          value={issuesTotal}
+          hint={translate('screens/compliance', 'open: {{count}}', { count: issuesOpen })}
+        />
+      </div>
+
+      <TransactionLookup
+        data={data}
+        query={query}
+        setQuery={setQuery}
+        submittedQuery={submittedQuery}
+        setSubmittedQuery={setSubmittedQuery}
+      />
+    </div>
+  );
+}

--- a/src/components/compliance/user-data-panel.tsx
+++ b/src/components/compliance/user-data-panel.tsx
@@ -1,202 +1,230 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
+import { CollapsibleSection } from 'src/components/compliance/collapsible-section';
 import { LimitRequestModal } from 'src/components/compliance/limit-request-modal';
-import { formatDate, formatDateTime } from 'src/util/compliance-helpers';
+import { OrganizationDetail, UserDataDetail } from 'src/hooks/compliance.hook';
+import { display, formatDate, formatDateTime, Primitive, refName } from 'src/util/compliance-helpers';
 
 interface UserDataPanelProps {
-  userData: Record<string, unknown>;
-  keyLabel: string;
-  valueLabel: string;
-  titleLabel: string;
+  userData: UserDataDetail;
   userDataId?: number;
   canRequestLimit?: boolean;
+  wide?: boolean;
   onLimitRequestCreated?: () => void;
 }
 
-const fieldOrder = [
-  'id',
-  'firstname',
-  'accountType',
-  'kycStatus',
-  'kycLevel',
-  'kycType',
-  'kycHash',
-  'mail',
-  'phone',
-  'street',
-  'zip',
-  'country',
-  'nationality',
-  'language',
-  'birthday',
-  'status',
-  'riskStatus',
-  'highRisk',
-  'pep',
-  'amlAccountType',
-  'amlListAddedDate',
-  'amlListExpiredDate',
-  'amlListStatus',
-  'bankDatas',
-  'bankTransactionVerification',
-  'depositLimit',
-  'hasBankTx',
-  'hasIpRisk',
-  'identificationType',
-  'isTrustedReferrer',
-  'phoneCallStatus',
-  'postAmlCheck',
-  'tradeApprovalDate',
-  'verifiedName',
-  'wallet',
-  'currency',
-  'buyVolume',
-  'monthlyBuyVolume',
-  'annualBuyVolume',
-  'sellVolume',
-  'monthlySellVolume',
-  'annualSellVolume',
-  'cryptoVolume',
-  'monthlyCryptoVolume',
-  'annualCryptoVolume',
-  'created',
-  'updated',
-];
+interface Row {
+  key: string;
+  value: ReactNode;
+}
 
-const combinedFields: Record<string, string> = {
-  firstname: 'surname',
-  street: 'houseNumber',
-  zip: 'location',
-};
+function fmtDate(value: string | undefined): string {
+  return value ? formatDate(value) : '-';
+}
 
-const hiddenFields = [...Object.values(combinedFields), 'apiFilterCT', 'apiKeyCT'];
+function fmtDateTime(value: string | undefined): string {
+  return value ? formatDateTime(value) : '-';
+}
 
-function formatValue(key: string, value: unknown): string {
-  if (key.endsWith('Date') && typeof value === 'string' && value.includes('T')) {
-    return formatDate(value);
-  }
-  if ((key === 'created' || key === 'updated') && typeof value === 'string' && value.includes('T')) {
-    return formatDateTime(value);
-  }
-  if (key === 'birthday' && typeof value === 'string' && value.includes('T')) {
-    return formatDate(value);
-  }
-  if (Array.isArray(value)) {
-    return value.length > 0 ? value.map((i: Record<string, unknown>) => i.name || i.iban || i.id).join(', ') : '-';
-  }
-  if (value && typeof value === 'object') {
-    const obj = value as Record<string, unknown>;
-    const displayName = obj.name || obj.symbol || obj.displayName;
-    return displayName ? `${displayName} (${obj.id})` : String(obj.id);
-  }
-  return value?.toString() || '-';
+function combinedRow(key: string, secondary: string, primaryVal: Primitive, secondaryVal: Primitive): Row {
+  const combined = [primaryVal, secondaryVal].filter(Boolean).join(' ');
+  return { key: `${key} / ${secondary}`, value: combined || '-' };
+}
+
+function SectionTable({ rows, kycHash }: Readonly<{ rows: Row[]; kycHash?: string }>): JSX.Element {
+  return (
+    <table className="w-full border-collapse">
+      <tbody>
+        {rows.map((row, idx) => (
+          <tr key={`${row.key}-${idx}`} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
+            <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium align-top w-1/2">{row.key}</td>
+            <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 break-all">
+              {row.key === 'kycHash' && kycHash ? (
+                <a
+                  href={`/kyc?code=${kycHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
+                >
+                  {kycHash}
+                </a>
+              ) : (
+                row.value
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function userDataRows(d: UserDataDetail, depositLimitNode: ReactNode): Row[] {
+  return [
+    { key: 'id', value: display(d.id) },
+    { key: 'created', value: fmtDateTime(d.created) },
+    { key: 'status', value: display(d.status) },
+    { key: 'riskStatus', value: display(d.riskStatus) },
+    { key: 'kycStatus', value: display(d.kycStatus) },
+    { key: 'kycLevel', value: display(d.kycLevel) },
+    { key: 'depositLimit', value: depositLimitNode },
+    { key: 'wallet', value: refName(d.wallet) },
+  ];
+}
+
+function personalDataRows(d: UserDataDetail): Row[] {
+  return [
+    { key: 'accountType', value: display(d.accountType) },
+    { key: 'mail', value: display(d.mail) },
+    { key: 'verifiedName', value: display(d.verifiedName) },
+    { key: 'verifiedCountry', value: refName(d.verifiedCountry) },
+    combinedRow('firstname', 'surname', d.firstname, d.surname),
+    combinedRow('street', 'houseNumber', d.street, d.houseNumber),
+    combinedRow('zip', 'location', d.zip, d.location),
+    { key: 'country', value: refName(d.country) },
+    { key: 'nationality', value: refName(d.nationality) },
+    { key: 'language', value: refName(d.language) },
+    { key: 'birthday', value: fmtDate(d.birthday) },
+    { key: 'phone', value: display(d.phone) },
+  ];
+}
+
+function organizationRows(o: OrganizationDetail): Row[] {
+  return [
+    { key: 'name', value: display(o.name) },
+    combinedRow('street', 'houseNumber', o.street, o.houseNumber),
+    combinedRow('zip', 'location', o.zip, o.location),
+    { key: 'country', value: refName(o.country) },
+    { key: 'legalEntity', value: display(o.legalEntity) },
+    { key: 'signatoryPower', value: display(o.signatoryPower) },
+    { key: 'complexOrgStructure', value: display(o.complexOrgStructure) },
+    { key: 'allBeneficialOwnersName', value: display(o.allBeneficialOwnersName) },
+    { key: 'allBeneficialOwnersDomicile', value: display(o.allBeneficialOwnersDomicile) },
+    { key: 'accountOpenerAuthorization', value: display(o.accountOpenerAuthorization) },
+  ];
+}
+
+function kycAmlRows(d: UserDataDetail): Row[] {
+  return [
+    { key: 'kycType', value: display(d.kycType) },
+    { key: 'kycStatus', value: display(d.kycStatus) },
+    { key: 'kycLevel', value: display(d.kycLevel) },
+    { key: 'kycHash', value: display(d.kycHash) },
+    { key: 'kycFileId', value: display(d.kycFileId) },
+    { key: 'identDocumentId', value: display(d.identDocumentId) },
+    { key: 'identDocumentType', value: display(d.identDocumentType) },
+    { key: 'highRisk', value: display(d.highRisk) },
+    { key: 'pep', value: display(d.pep) },
+    { key: 'bankTransactionVerification', value: display(d.bankTransactionVerification) },
+    { key: 'olkypayAllowed', value: display(d.olkypayAllowed) },
+  ];
+}
+
+function paymentLinkRows(d: UserDataDetail): Row[] {
+  return [
+    { key: 'paymentLinksAllowed', value: display(d.paymentLinksAllowed) },
+    { key: 'paymentLinksConfig', value: display(d.paymentLinksConfig) },
+    { key: 'paymentLinksName', value: display(d.paymentLinksName) },
+  ];
+}
+
+function phoneCallRows(d: UserDataDetail): Row[] {
+  return [
+    { key: 'phoneCallStatus', value: display(d.phoneCallStatus) },
+    { key: 'phoneCallAccepted', value: display(d.phoneCallAccepted) },
+    { key: 'phoneCallCheckDate', value: fmtDateTime(d.phoneCallCheckDate) },
+    { key: 'phoneCallExternalAccountCheckDate', value: fmtDateTime(d.phoneCallExternalAccountCheckDate) },
+    { key: 'phoneCallExternalAccountCheckValues', value: display(d.phoneCallExternalAccountCheckValues) },
+    { key: 'phoneCallIpCheckDate', value: fmtDateTime(d.phoneCallIpCheckDate) },
+    { key: 'phoneCallIpCountryCheckDate', value: fmtDateTime(d.phoneCallIpCountryCheckDate) },
+    { key: 'phoneCallTimes', value: display(d.phoneCallTimes) },
+  ];
+}
+
+function volumeRows(d: UserDataDetail): Row[] {
+  return [
+    { key: 'buyVolume', value: display(d.buyVolume) },
+    { key: 'annualBuyVolume', value: display(d.annualBuyVolume) },
+    { key: 'sellVolume', value: display(d.sellVolume) },
+    { key: 'annualSellVolume', value: display(d.annualSellVolume) },
+    { key: 'cryptoVolume', value: display(d.cryptoVolume) },
+    { key: 'annualCryptoVolume', value: display(d.annualCryptoVolume) },
+  ];
+}
+
+function otherRows(d: UserDataDetail): Row[] {
+  return [
+    { key: 'isTrustedReferrer', value: display(d.isTrustedReferrer) },
+    { key: 'tradeApprovalDate', value: fmtDate(d.tradeApprovalDate) },
+    { key: 'deactivationDate', value: fmtDate(d.deactivationDate) },
+    { key: 'lastNameCheckDate', value: fmtDate(d.lastNameCheckDate) },
+    { key: 'letterSentDate', value: fmtDate(d.letterSentDate) },
+    { key: 'moderator', value: display(d.moderator) },
+  ];
 }
 
 export function UserDataPanel({
   userData,
-  keyLabel,
-  valueLabel,
-  titleLabel,
   userDataId,
   canRequestLimit = true,
+  wide = false,
   onLimitRequestCreated,
-}: UserDataPanelProps): JSX.Element {
-  const [showAll, setShowAll] = useState(false);
+}: Readonly<UserDataPanelProps>): JSX.Element {
   const [showLimitRequestModal, setShowLimitRequestModal] = useState(false);
 
-  const allEntries = Object.entries(userData)
-    .filter(([key]) => !hiddenFields.includes(key))
-    .sort(([a], [b]) => {
-      const indexA = fieldOrder.indexOf(a);
-      const indexB = fieldOrder.indexOf(b);
-      if (indexA === -1 && indexB === -1) return a.localeCompare(b);
-      if (indexA === -1) return 1;
-      if (indexB === -1) return -1;
-      return indexA - indexB;
-    });
-
-  const visibleEntries = showAll
-    ? allEntries
-    : allEntries.filter(([key]) => fieldOrder.includes(key) || combinedFields[key]);
-
-  const hiddenCount =
-    allEntries.length - allEntries.filter(([key]) => fieldOrder.includes(key) || combinedFields[key]).length;
+  const depositLimitNode: ReactNode =
+    userDataId && canRequestLimit ? (
+      <div className="flex items-center justify-between gap-2">
+        <span>{display(userData.depositLimit)}</span>
+        <button
+          className="px-3 py-1 text-xs text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded transition-colors whitespace-nowrap"
+          onClick={() => setShowLimitRequestModal(true)}
+        >
+          Limit Request
+        </button>
+      </div>
+    ) : (
+      display(userData.depositLimit)
+    );
 
   return (
     <>
-      <div>
-        <h2 className="text-dfxGray-700 mb-2">
-          {titleLabel} ({Object.keys(userData).length})
-        </h2>
-        <div className="bg-white rounded-lg shadow-sm">
-          <table className="w-full border-collapse">
-            <thead className="sticky top-0 bg-dfxGray-300">
-              <tr>
-                <th className="px-3 py-2 text-left text-sm font-semibold text-dfxBlue-800">{keyLabel}</th>
-                <th className="px-3 py-2 text-left text-sm font-semibold text-dfxBlue-800">{valueLabel}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {visibleEntries.map(([key, value]) => {
-                const valueString = formatValue(key, value);
-                const secondaryField = combinedFields[key];
+      <div className={`${wide ? 'w-full' : 'w-1/2'} min-w-0`}>
+        <div className="bg-white rounded-lg shadow-sm divide-y divide-dfxGray-300">
+          <CollapsibleSection title="UserData" initiallyOpen>
+            <SectionTable rows={userDataRows(userData, depositLimitNode)} />
+          </CollapsibleSection>
 
-                if (secondaryField) {
-                  const secondaryValue = userData[secondaryField] || '';
-                  const combinedValue = [valueString, secondaryValue].filter(Boolean).join(' ') || '-';
-                  return (
-                    <tr key={key} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
-                      <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium">
-                        {key} / {secondaryField}
-                      </td>
-                      <td className="px-3 py-2 text-left text-sm text-dfxBlue-800">{combinedValue}</td>
-                    </tr>
-                  );
-                }
+          <CollapsibleSection title="Personal Data" initiallyOpen>
+            <SectionTable rows={personalDataRows(userData)} />
+          </CollapsibleSection>
 
-                return (
-                  <tr key={key} className="border-b border-dfxGray-300 transition-colors hover:bg-dfxGray-300">
-                    <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium">{key}</td>
-                    <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 break-all">
-                      {key === 'kycHash' && valueString !== '-' ? (
-                        <a
-                          href={`/kyc?code=${valueString}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
-                        >
-                          {valueString}
-                        </a>
-                      ) : key === 'depositLimit' && userDataId && canRequestLimit ? (
-                        <div className="flex items-center justify-between gap-2">
-                          <span>{valueString}</span>
-                          <button
-                            className="px-3 py-1 text-xs text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded transition-colors whitespace-nowrap"
-                            onClick={() => setShowLimitRequestModal(true)}
-                          >
-                            Limit Request
-                          </button>
-                        </div>
-                      ) : (
-                        valueString
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-              {hiddenCount > 0 && (
-                <tr>
-                  <td colSpan={2} className="px-3 py-2 text-center">
-                    <button
-                      className="text-sm text-dfxBlue-300 hover:text-dfxBlue-800"
-                      onClick={() => setShowAll(!showAll)}
-                    >
-                      {showAll ? `Hide ${hiddenCount} fields` : `Show ${hiddenCount} more fields...`}
-                    </button>
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+          <CollapsibleSection title="Organization Data" initiallyOpen={!!userData.organization}>
+            {userData.organization ? (
+              <SectionTable rows={organizationRows(userData.organization)} />
+            ) : (
+              <div className="px-3 py-2 text-sm text-dfxGray-700">No organization linked.</div>
+            )}
+          </CollapsibleSection>
+
+          <CollapsibleSection title="KYC / AML">
+            <SectionTable rows={kycAmlRows(userData)} kycHash={userData.kycHash} />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="PaymentLink Data">
+            <SectionTable rows={paymentLinkRows(userData)} />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="PhoneCall">
+            <SectionTable rows={phoneCallRows(userData)} />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Volumes">
+            <SectionTable rows={volumeRows(userData)} />
+          </CollapsibleSection>
+
+          <CollapsibleSection title="Other">
+            <SectionTable rows={otherRows(userData)} />
+          </CollapsibleSection>
         </div>
       </div>
       {userDataId && canRequestLimit && (

--- a/src/components/compliance/user-data-panel.tsx
+++ b/src/components/compliance/user-data-panel.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from 'react';
 import { CollapsibleSection } from 'src/components/compliance/collapsible-section';
 import { LimitRequestModal } from 'src/components/compliance/limit-request-modal';
+import { useClipboard } from 'src/hooks/clipboard.hook';
 import { OrganizationDetail, UserDataDetail } from 'src/hooks/compliance.hook';
 import { display, formatDate, formatDateTime, Primitive, refName } from 'src/util/compliance-helpers';
 
@@ -8,8 +9,41 @@ interface UserDataPanelProps {
   userData: UserDataDetail;
   userDataId?: number;
   canRequestLimit?: boolean;
+  canCopyKycLinks?: boolean;
   wide?: boolean;
   onLimitRequestCreated?: () => void;
+}
+
+function kycServicesBaseUrl(): string {
+  return process.env.REACT_APP_PUBLIC_URL ?? window.location.origin;
+}
+
+function KycLinkButtons({ kycHash }: Readonly<{ kycHash: string }>): JSX.Element {
+  const kycLink = useClipboard();
+  const videoLink = useClipboard();
+  const base = kycServicesBaseUrl();
+  const buttonClass =
+    'px-2 py-0.5 text-xs font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors whitespace-nowrap';
+  return (
+    <div className="flex gap-2">
+      <button
+        type="button"
+        className={buttonClass}
+        onClick={() => kycLink.copy(`${base}/kyc?code=${kycHash}`)}
+        title="Copy KYC link"
+      >
+        {kycLink.isCopying ? '✓ KYC' : 'KYC'}
+      </button>
+      <button
+        type="button"
+        className={buttonClass}
+        onClick={() => videoLink.copy(`${base}/kyc?code=${kycHash}&step=ident/video`)}
+        title="Copy Video Ident link"
+      >
+        {videoLink.isCopying ? '✓ Video' : 'Video'}
+      </button>
+    </div>
+  );
 }
 
 interface Row {
@@ -30,7 +64,11 @@ function combinedRow(key: string, secondary: string, primaryVal: Primitive, seco
   return { key: `${key} / ${secondary}`, value: combined || '-' };
 }
 
-function SectionTable({ rows, kycHash }: Readonly<{ rows: Row[]; kycHash?: string }>): JSX.Element {
+function SectionTable({
+  rows,
+  kycHash,
+  canCopyKycLinks,
+}: Readonly<{ rows: Row[]; kycHash?: string; canCopyKycLinks?: boolean }>): JSX.Element {
   return (
     <table className="w-full border-collapse">
       <tbody>
@@ -39,14 +77,17 @@ function SectionTable({ rows, kycHash }: Readonly<{ rows: Row[]; kycHash?: strin
             <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 font-medium align-top w-1/2">{row.key}</td>
             <td className="px-3 py-2 text-left text-sm text-dfxBlue-800 break-all">
               {row.key === 'kycHash' && kycHash ? (
-                <a
-                  href={`/kyc?code=${kycHash}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
-                >
-                  {kycHash}
-                </a>
+                <div className="flex flex-col gap-2 items-start">
+                  <a
+                    href={`/kyc?code=${kycHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
+                  >
+                    {kycHash}
+                  </a>
+                  {canCopyKycLinks && <KycLinkButtons kycHash={kycHash} />}
+                </div>
               ) : (
                 row.value
               )}
@@ -166,6 +207,7 @@ export function UserDataPanel({
   userData,
   userDataId,
   canRequestLimit = true,
+  canCopyKycLinks = false,
   wide = false,
   onLimitRequestCreated,
 }: Readonly<UserDataPanelProps>): JSX.Element {
@@ -207,7 +249,7 @@ export function UserDataPanel({
           </CollapsibleSection>
 
           <CollapsibleSection title="KYC / AML">
-            <SectionTable rows={kycAmlRows(userData)} kycHash={userData.kycHash} />
+            <SectionTable rows={kycAmlRows(userData)} kycHash={userData.kycHash} canCopyKycLinks={canCopyKycLinks} />
           </CollapsibleSection>
 
           <CollapsibleSection title="PaymentLink Data">

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -212,38 +212,111 @@ export interface CryptoInputInfo {
   purpose?: string;
 }
 
-// Partial view of the backend UserData entity as exposed by the compliance endpoint.
-// Index signature keeps compatibility with legacy Record<string, unknown> consumers;
-// named fields add type safety for the values the UI actually reads.
-export interface UserDataDetail {
-  [key: string]: unknown;
+export interface CountryRef {
+  name?: string;
+  symbol?: string;
+}
+
+export interface LanguageRef {
+  name?: string;
+  symbol?: string;
+}
+
+export interface WalletRef {
+  name?: string;
+}
+
+export interface OrganizationDetail {
   id?: number;
-  accountType?: string;
-  status?: string;
-  kycStatus?: string;
-  kycLevel?: number;
-  firstname?: string;
-  surname?: string;
-  verifiedName?: string;
-  mail?: string;
-  phone?: string;
-  birthday?: string;
+  name?: string;
   street?: string;
   houseNumber?: string;
   zip?: string;
   location?: string;
-  city?: string;
+  country?: CountryRef;
+  legalEntity?: string;
+  signatoryPower?: string;
+  complexOrgStructure?: boolean;
+  allBeneficialOwnersName?: string;
+  allBeneficialOwnersDomicile?: string;
+  accountOpenerAuthorization?: string;
+}
+
+// Mirrors UserDataDetailDto on the backend. Values that are Date on the entity
+// arrive as ISO strings here.
+export interface UserDataDetail {
+  // UserData
+  id: number;
+  created?: string;
+  status?: string;
+  riskStatus?: string;
+  kycStatus?: string;
+  kycLevel?: number;
+  depositLimit?: number;
+  wallet?: WalletRef;
+
+  // Personal Data
+  accountType?: string;
+  mail?: string;
+  verifiedName?: string;
+  verifiedCountry?: CountryRef;
+  firstname?: string;
+  surname?: string;
+  street?: string;
+  houseNumber?: string;
+  zip?: string;
+  location?: string;
+  country?: CountryRef;
+  nationality?: CountryRef;
+  language?: LanguageRef;
+  birthday?: string;
+  phone?: string;
+
+  // Organization Data
+  organization?: OrganizationDetail;
+
+  // KYC / AML
+  kycType?: string;
+  kycHash?: string;
+  kycFileId?: number;
+  identDocumentId?: string;
+  identDocumentType?: string;
+  identificationType?: string;
+  highRisk?: boolean;
+  pep?: boolean;
+  bankTransactionVerification?: string;
+  olkypayAllowed?: boolean;
+
+  // PaymentLink Data
+  paymentLinksAllowed?: boolean;
+  paymentLinksConfig?: string;
+  paymentLinksName?: string;
+
+  // PhoneCall
   phoneCallStatus?: string;
-  phoneCallTimes?: string;
+  phoneCallAccepted?: boolean;
   phoneCallCheckDate?: string;
+  phoneCallExternalAccountCheckDate?: string;
+  phoneCallExternalAccountCheckValues?: string;
   phoneCallIpCheckDate?: string;
   phoneCallIpCountryCheckDate?: string;
-  phoneCallExternalAccountCheckDate?: string;
-  organization?: { name?: string };
-  nationality?: { name?: string };
-  language?: { name?: string; symbol?: string };
-  country?: { name?: string; symbol?: string };
-  wallet?: { name?: string };
+  phoneCallTimes?: string;
+
+  // Volumes
+  buyVolume?: number;
+  annualBuyVolume?: number;
+  sellVolume?: number;
+  annualSellVolume?: number;
+  cryptoVolume?: number;
+  annualCryptoVolume?: number;
+
+  // Other
+  isTrustedReferrer?: boolean;
+  tradeApprovalDate?: string;
+  deactivationDate?: string;
+  lastNameCheckDate?: string;
+  letterSentDate?: string;
+  moderator?: string;
 }
 
 export interface SupportPermissions {

--- a/src/hooks/split-pane.hook.ts
+++ b/src/hooks/split-pane.hook.ts
@@ -1,0 +1,45 @@
+import { MouseEvent as ReactMouseEvent, RefObject, useRef, useState } from 'react';
+
+interface UseSplitPaneOptions {
+  initial?: number;
+  min?: number;
+  max?: number;
+}
+
+interface UseSplitPaneResult {
+  containerRef: RefObject<HTMLDivElement>;
+  splitPercent: number;
+  setSplitPercent: (percent: number) => void;
+  handleSplitDrag: (e: ReactMouseEvent) => void;
+}
+
+export function useSplitPane({ initial = 70, min = 30, max = 80 }: UseSplitPaneOptions = {}): UseSplitPaneResult {
+  const [splitPercent, setSplitPercent] = useState(initial);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  function handleSplitDrag(e: ReactMouseEvent): void {
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+
+    const onMouseMove = (moveEvent: MouseEvent): void => {
+      const rect = container.getBoundingClientRect();
+      const percent = ((moveEvent.clientX - rect.left) / rect.width) * 100;
+      setSplitPercent(Math.min(max, Math.max(min, percent)));
+    };
+
+    const onMouseUp = (): void => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }
+
+  return { containerRef, splitPercent, setSplitPercent, handleSplitDrag };
+}

--- a/src/screens/compliance-review.screen.tsx
+++ b/src/screens/compliance-review.screen.tsx
@@ -1,6 +1,6 @@
 import { useKyc } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ComplianceReviewHeader } from 'src/components/compliance/compliance-review-header';
 import {
@@ -18,6 +18,7 @@ import { ErrorHint } from 'src/components/error-hint';
 import { ComplianceUserData, KycFile, KycStepInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useSplitPane } from 'src/hooks/split-pane.hook';
 
 function findLatestStep(kycSteps: KycStepInfo[], stepName: string): KycStepInfo | undefined {
   return kycSteps.filter((s) => s.name === stepName).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
@@ -54,32 +55,7 @@ export default function ComplianceReviewScreen(): JSX.Element {
   const [activeTab, setActiveTab] = useState<ReviewCheckTab | undefined>();
   const [isSaving, setIsSaving] = useState(false);
   const [preview, setPreview] = useState<{ url: string; contentType: string; name: string }>();
-  const [splitPercent, setSplitPercent] = useState(66);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  function handleSplitDrag(e: React.MouseEvent): void {
-    e.preventDefault();
-    const container = containerRef.current;
-    if (!container) return;
-
-    const onMouseMove = (moveEvent: MouseEvent): void => {
-      const rect = container.getBoundingClientRect();
-      const percent = ((moveEvent.clientX - rect.left) / rect.width) * 100;
-      setSplitPercent(Math.min(80, Math.max(30, percent)));
-    };
-
-    const onMouseUp = (): void => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }
+  const { containerRef, splitPercent, handleSplitDrag } = useSplitPane();
 
   const loadData = useCallback(() => {
     if (!userDataId) {

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -132,6 +132,7 @@ export default function ComplianceUserScreen(): JSX.Element {
 
   const numericUserDataId = +userDataId;
   const isSupport = role === UserRole.SUPPORT;
+  const canCopyKycLinks = role === UserRole.ADMIN || role === UserRole.COMPLIANCE;
   const showRightPanel = data.permissions.viewKycFiles || isSupport;
 
   const tabs: TabConfig[] = [
@@ -159,6 +160,7 @@ export default function ComplianceUserScreen(): JSX.Element {
             userData={data.userData}
             userDataId={numericUserDataId}
             canRequestLimit={data.permissions.canRequestLimit}
+            canCopyKycLinks={canCopyKycLinks}
             wide={isSupport}
             onLimitRequestCreated={loadData}
           />

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -1,4 +1,4 @@
-import { useKyc } from '@dfx.swiss/react';
+import { useAuthContext, UserRole, useKyc } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -19,6 +19,7 @@ import { IpLogsPanel } from 'src/components/compliance/ip-logs-panel';
 import { KycFilesPanel } from 'src/components/compliance/kyc-files-panel';
 import { RecommendationPanel } from 'src/components/compliance/recommendation-panel';
 import { SupportIssuesPanel } from 'src/components/compliance/support-issues-panel';
+import { SupportUserOverviewPanel } from 'src/components/compliance/support-user-overview-panel';
 import { TransactionsTable } from 'src/components/compliance/transactions-tab';
 import { UserDataPanel } from 'src/components/compliance/user-data-panel';
 import { ErrorHint } from 'src/components/error-hint';
@@ -26,6 +27,7 @@ import { useSettingsContext } from 'src/contexts/settings.context';
 import { ComplianceUserData, KycFile, useCompliance } from 'src/hooks/compliance.hook';
 import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useSplitPane } from 'src/hooks/split-pane.hook';
 
 type TabType =
   | 'transactions'
@@ -48,6 +50,8 @@ interface TabConfig {
 
 export default function ComplianceUserScreen(): JSX.Element {
   useSupportDashboardGuard();
+  const { session } = useAuthContext();
+  const role = session?.role;
 
   const { translate } = useSettingsContext();
   const { id: userDataId } = useParams();
@@ -62,6 +66,7 @@ export default function ComplianceUserScreen(): JSX.Element {
   const [expandedBankTxId, setExpandedBankTxId] = useState<number>();
   const [expandedCryptoInputId, setExpandedCryptoInputId] = useState<number>();
   const [expandedTxUid, setExpandedTxUid] = useState<string>();
+  const { containerRef, splitPercent, setSplitPercent, handleSplitDrag } = useSplitPane();
 
   function handleExpandBankTx(id: number | undefined): void {
     setExpandedBankTxId(id);
@@ -116,49 +121,52 @@ export default function ComplianceUserScreen(): JSX.Element {
     return () => preview && URL.revokeObjectURL(preview.url);
   }, [preview]);
 
+  useEffect(() => {
+    if (role === UserRole.SUPPORT) setSplitPercent(50);
+  }, [role]);
+
   useLayoutOptions({ title: translate('screens/compliance', 'User Data'), backButton: true, noMaxWidth: true });
 
-  const tabs: TabConfig[] = data
-    ? [
-        { id: 'transactions', label: 'Transactions', count: data.transactions?.length || 0 },
-        { id: 'users', label: 'Users', count: data.users?.length || 0 },
-        { id: 'kycSteps', label: 'KYC Steps', count: data.kycSteps?.length || 0 },
-        ...(data.permissions.viewKycLogs
-          ? [{ id: 'kycLogs' as TabType, label: 'KYC Log', count: data.kycLogs?.length ?? 0 }]
-          : []),
-        { id: 'bankDatas', label: 'Bank Data', count: data.bankDatas?.length || 0 },
-        { id: 'virtualIbans', label: 'Virtual IBANs', count: data.virtualIbans?.length || 0 },
-        { id: 'buyRoutes', label: 'Buy Routes', count: data.buyRoutes?.length || 0 },
-        { id: 'sellRoutes', label: 'Sell Routes', count: data.sellRoutes?.length || 0 },
-        { id: 'swapRoutes', label: 'Swap Routes', count: data.swapRoutes?.length || 0 },
-        { id: 'refRewards', label: 'Ref Rewards', count: data.refRewards?.length || 0 },
-        { id: 'notifications', label: 'Notifications', count: data.notifications?.length || 0 },
-      ]
-    : [];
+  if (error && !data) return <ErrorHint message={error} />;
+  if (!data || !userDataId) return <StyledLoadingSpinner size={SpinnerSize.LG} />;
+
+  const numericUserDataId = +userDataId;
+  const isSupport = role === UserRole.SUPPORT;
+  const showRightPanel = data.permissions.viewKycFiles || isSupport;
+
+  const tabs: TabConfig[] = [
+    { id: 'transactions', label: 'Transactions', count: data.transactions?.length || 0 },
+    { id: 'users', label: 'Users', count: data.users?.length || 0 },
+    { id: 'kycSteps', label: 'KYC Steps', count: data.kycSteps?.length || 0 },
+    ...(data.permissions.viewKycLogs
+      ? [{ id: 'kycLogs' as TabType, label: 'KYC Log', count: data.kycLogs?.length ?? 0 }]
+      : []),
+    { id: 'bankDatas', label: 'Bank Data', count: data.bankDatas?.length || 0 },
+    { id: 'virtualIbans', label: 'Virtual IBANs', count: data.virtualIbans?.length || 0 },
+    { id: 'buyRoutes', label: 'Buy Routes', count: data.buyRoutes?.length || 0 },
+    { id: 'sellRoutes', label: 'Sell Routes', count: data.sellRoutes?.length || 0 },
+    { id: 'swapRoutes', label: 'Swap Routes', count: data.swapRoutes?.length || 0 },
+    { id: 'refRewards', label: 'Ref Rewards', count: data.refRewards?.length || 0 },
+    { id: 'notifications', label: 'Notifications', count: data.notifications?.length || 0 },
+  ];
 
   return (
-    <>
-      {error && !data ? (
-        <ErrorHint message={error} />
-      ) : !data ? (
-        <StyledLoadingSpinner size={SpinnerSize.LG} />
-      ) : (
-        <div className="w-full flex flex-col gap-4">
-          {/* Top Section: User Data | Middle Panels | File Preview */}
-          <div className="flex gap-4 min-h-[400px]">
-            <UserDataPanel
-              userData={data.userData}
-              keyLabel={translate('screens/compliance', 'Key')}
-              valueLabel={translate('screens/compliance', 'Value')}
-              titleLabel={translate('screens/compliance', 'User Data')}
-              userDataId={userDataId ? +userDataId : undefined}
-              canRequestLimit={data.permissions.canRequestLimit}
-              onLimitRequestCreated={loadData}
-            />
+    <div className="w-full flex flex-col gap-4">
+      {/* Top Section: (User Data | Middle Panels) | Splitter | (File Preview | Support Overview) */}
+      <div ref={containerRef} className="flex min-h-[400px]">
+        <div style={{ width: `${showRightPanel ? splitPercent : 100}%` }} className="flex gap-4 min-w-0 pr-2">
+          <UserDataPanel
+            userData={data.userData}
+            userDataId={numericUserDataId}
+            canRequestLimit={data.permissions.canRequestLimit}
+            wide={isSupport}
+            onLimitRequestCreated={loadData}
+          />
 
-            <div className="w-1/3 min-w-[300px] flex flex-col gap-4">
+          {!isSupport && (
+            <div className="flex-1 min-w-[300px] flex flex-col gap-4">
               {data.permissions.viewRecommendation && (
-                <RecommendationPanel kycSteps={data.kycSteps} userDataId={userDataId ?? ''} navigate={navigate} />
+                <RecommendationPanel kycSteps={data.kycSteps} userDataId={userDataId} navigate={navigate} />
               )}
               {data.permissions.viewKycFiles && (
                 <KycFilesPanel
@@ -167,79 +175,89 @@ export default function ComplianceUserScreen(): JSX.Element {
                   onOpenFile={openFile}
                 />
               )}
-              {data.permissions.viewIpLogs && (
-                <IpLogsPanel ipLogs={data.ipLogs ?? []} userDataId={+(userDataId ?? '0')} />
-              )}
+              {data.permissions.viewIpLogs && <IpLogsPanel ipLogs={data.ipLogs ?? []} userDataId={numericUserDataId} />}
               {data.permissions.viewSupportIssues && (
                 <SupportIssuesPanel
                   supportIssues={data.supportIssues ?? []}
-                  userDataId={userDataId ?? ''}
+                  userDataId={userDataId}
                   navigate={navigate}
                 />
               )}
             </div>
+          )}
+        </div>
 
-            {data.permissions.viewKycFiles && (
-              <div className="sticky top-4 self-start">
+        {showRightPanel && (
+          <>
+            <div
+              className="w-1.5 cursor-col-resize flex-shrink-0 group flex items-stretch"
+              onMouseDown={handleSplitDrag}
+            >
+              <div className="w-0.5 mx-auto bg-dfxGray-400 group-hover:bg-dfxBlue-400 transition-colors rounded-full" />
+            </div>
+            <div style={{ width: `${100 - splitPercent}%` }} className="min-w-0 sticky top-4 self-start pl-2">
+              {isSupport ? (
+                <SupportUserOverviewPanel data={data} />
+              ) : (
                 <FilePreviewPanel
                   preview={preview}
                   label={translate('screens/compliance', 'File Preview')}
                   onClose={() => setPreview(undefined)}
                 />
-              </div>
-            )}
-          </div>
-
-          {/* Bottom Section: Tabs */}
-          <div className="w-full">
-            <div className="flex border-b border-dfxGray-300">
-              {tabs.map((tab) => (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`px-4 py-2 text-sm font-medium transition-colors ${
-                    activeTab === tab.id
-                      ? 'text-dfxBlue-800 border-b-2 border-dfxBlue-800 bg-white'
-                      : 'text-dfxGray-700 hover:text-dfxBlue-800 hover:bg-dfxGray-300'
-                  }`}
-                >
-                  {tab.label} ({tab.count})
-                </button>
-              ))}
-            </div>
-
-            <div className="bg-white rounded-b-lg shadow-sm p-4">
-              {activeTab === 'transactions' && (
-                <TransactionsTable
-                  transactions={data.transactions}
-                  bankTxs={data.bankTxs}
-                  cryptoInputs={data.cryptoInputs}
-                  userDataId={+(userDataId ?? '0')}
-                  expandedBankTxId={expandedBankTxId}
-                  expandedCryptoInputId={expandedCryptoInputId}
-                  expandedTxUid={expandedTxUid}
-                  canPerformActions={data.permissions.canPerformTransactionActions}
-                  onExpandBankTx={handleExpandBankTx}
-                  onExpandCryptoInput={handleExpandCryptoInput}
-                  onExpandTxUid={handleExpandTxUid}
-                  onStopped={loadData}
-                />
               )}
-
-              {activeTab === 'users' && <UsersTable users={data.users} />}
-              {activeTab === 'kycSteps' && <KycStepsTable kycSteps={data.kycSteps} />}
-              {activeTab === 'kycLogs' && <KycLogsTable kycLogs={data.kycLogs ?? []} />}
-              {activeTab === 'bankDatas' && <BankDatasTable bankDatas={data.bankDatas} />}
-              {activeTab === 'buyRoutes' && <BuyRoutesTable buyRoutes={data.buyRoutes} />}
-              {activeTab === 'sellRoutes' && <SellRoutesTable sellRoutes={data.sellRoutes} />}
-              {activeTab === 'swapRoutes' && <SwapRoutesTable swapRoutes={data.swapRoutes} />}
-              {activeTab === 'virtualIbans' && <VirtualIbansTable virtualIbans={data.virtualIbans} />}
-              {activeTab === 'refRewards' && <RefRewardsTable refRewards={data.refRewards} />}
-              {activeTab === 'notifications' && <NotificationsTable notifications={data.notifications} />}
             </div>
-          </div>
+          </>
+        )}
+      </div>
+
+      {/* Bottom Section: Tabs */}
+      <div className="w-full">
+        <div className="flex border-b border-dfxGray-300">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2 text-sm font-medium transition-colors ${
+                activeTab === tab.id
+                  ? 'text-dfxBlue-800 border-b-2 border-dfxBlue-800 bg-white'
+                  : 'text-dfxGray-700 hover:text-dfxBlue-800 hover:bg-dfxGray-300'
+              }`}
+            >
+              {tab.label} ({tab.count})
+            </button>
+          ))}
         </div>
-      )}
-    </>
+
+        <div className="bg-white rounded-b-lg shadow-sm p-4">
+          {activeTab === 'transactions' && (
+            <TransactionsTable
+              transactions={data.transactions}
+              bankTxs={data.bankTxs}
+              cryptoInputs={data.cryptoInputs}
+              userDataId={numericUserDataId}
+              expandedBankTxId={expandedBankTxId}
+              expandedCryptoInputId={expandedCryptoInputId}
+              expandedTxUid={expandedTxUid}
+              canPerformActions={data.permissions.canPerformTransactionActions}
+              onExpandBankTx={handleExpandBankTx}
+              onExpandCryptoInput={handleExpandCryptoInput}
+              onExpandTxUid={handleExpandTxUid}
+              onStopped={loadData}
+            />
+          )}
+
+          {activeTab === 'users' && <UsersTable users={data.users} />}
+          {activeTab === 'kycSteps' && <KycStepsTable kycSteps={data.kycSteps} />}
+          {activeTab === 'kycLogs' && <KycLogsTable kycLogs={data.kycLogs ?? []} />}
+          {activeTab === 'bankDatas' && <BankDatasTable bankDatas={data.bankDatas} />}
+          {activeTab === 'buyRoutes' && <BuyRoutesTable buyRoutes={data.buyRoutes} />}
+          {activeTab === 'sellRoutes' && <SellRoutesTable sellRoutes={data.sellRoutes} />}
+          {activeTab === 'swapRoutes' && <SwapRoutesTable swapRoutes={data.swapRoutes} />}
+          {activeTab === 'virtualIbans' && <VirtualIbansTable virtualIbans={data.virtualIbans} />}
+          {activeTab === 'refRewards' && <RefRewardsTable refRewards={data.refRewards} />}
+          {activeTab === 'notifications' && <NotificationsTable notifications={data.notifications} />}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -8,6 +8,7 @@ import { useSettingsContext } from 'src/contexts/settings.context';
 import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
+import { useSplitPane } from 'src/hooks/split-pane.hook';
 import {
   ASSIGNABLE_DEPARTMENTS,
   CustomerAuthor,
@@ -54,8 +55,7 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
 
   // File preview state
   const [filePreview, setFilePreview] = useState<{ url: string; contentType: string; name: string }>();
-  const [splitPercent, setSplitPercent] = useState(66);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const { containerRef, splitPercent, handleSplitDrag } = useSplitPane();
 
   const isComplianceDept = issueData?.department === Department.COMPLIANCE;
 
@@ -207,30 +207,6 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
 
   if (loadError) return <ErrorHint message={loadError} />;
   if (isLoading || !issueData) return <StyledLoadingSpinner size={SpinnerSize.LG} />;
-
-  function handleSplitDrag(e: React.MouseEvent): void {
-    e.preventDefault();
-    const container = containerRef.current;
-    if (!container) return;
-
-    const onMouseMove = (moveEvent: MouseEvent): void => {
-      const rect = container.getBoundingClientRect();
-      const percent = ((moveEvent.clientX - rect.left) / rect.width) * 100;
-      setSplitPercent(Math.min(80, Math.max(30, percent)));
-    };
-
-    const onMouseUp = (): void => {
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-  }
 
   return (
     <div ref={containerRef} className="w-full flex text-left">

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -274,24 +274,19 @@ export default function SupportDashboardScreen(): JSX.Element {
                       <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800 break-all">
                         {translate('screens/compliance', 'Email')}
                       </th>
-                      <th className="px-3 py-2"></th>
                     </tr>
                   </thead>
                   <tbody>
                     {customerSearchResults.map((u) => (
-                      <tr key={u.id} className="border-b border-dfxGray-300 hover:bg-dfxGray-300">
-                        <td className="px-3 py-2 text-dfxBlue-800">{u.id}</td>
-                        <td className="px-3 py-2 text-dfxBlue-800">{u.accountType ?? '-'}</td>
-                        <td className="px-3 py-2 text-dfxBlue-800">{u.name ?? '-'}</td>
-                        <td className="px-3 py-2 text-dfxBlue-800 break-all">{u.mail ?? '-'}</td>
-                        <td className="px-3 py-2 text-right">
-                          <button
-                            className="px-2 py-1 text-xs font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors"
-                            onClick={() => navigate(`/support/user/${u.id}`)}
-                          >
-                            {translate('screens/compliance', 'Details')}
-                          </button>
-                        </td>
+                      <tr
+                        key={u.id}
+                        className="border-b border-dfxGray-300 transition-colors hover:bg-dfxBlue-400 cursor-pointer group"
+                        onClick={() => navigate(`/support/user/${u.id}`)}
+                      >
+                        <td className="px-3 py-2 text-dfxBlue-800 group-hover:text-white">{u.id}</td>
+                        <td className="px-3 py-2 text-dfxBlue-800 group-hover:text-white">{u.accountType ?? '-'}</td>
+                        <td className="px-3 py-2 text-dfxBlue-800 group-hover:text-white">{u.name ?? '-'}</td>
+                        <td className="px-3 py-2 text-dfxBlue-800 group-hover:text-white break-all">{u.mail ?? '-'}</td>
                       </tr>
                     ))}
                   </tbody>

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -171,3 +171,35 @@ export function formatValue(value: unknown): string {
     return 'Fehler: Wert kann nicht ermittelt werden';
   }
 }
+
+export type Primitive = string | number | boolean | null | undefined;
+
+// Display a typed primitive UI value: null/undefined/'' → '-'.
+// For unknown / dynamic values (e.g. JSON-parsed result fields), use formatValue() instead.
+export function display(value: Primitive): string {
+  if (value == null || value === '') return '-';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
+// Resolve a reference type ({ name?, symbol? }) to its display name.
+export function refName(ref?: { name?: string; symbol?: string }): string {
+  return ref?.name ?? ref?.symbol ?? '-';
+}
+
+// Build a comma-separated address line. Works for UserData and Organization (structural typing).
+export function buildAddress(parts?: {
+  street?: string;
+  houseNumber?: string;
+  zip?: string;
+  location?: string;
+  country?: { name?: string };
+}): string {
+  if (!parts) return '-';
+  const lines = [
+    [parts.street, parts.houseNumber].filter(Boolean).join(' '),
+    [parts.zip, parts.location].filter(Boolean).join(' '),
+    parts.country?.name,
+  ].filter((l): l is string => Boolean(l && l.length));
+  return lines.length > 0 ? lines.join(', ') : '-';
+}


### PR DESCRIPTION
## Summary

Follow-up cleanup on top of the compliance user-detail-tabs feature.

- Extract `display()`, `refName()` and `buildAddress()` into `compliance-helpers.tsx` and migrate `freigabe-panel`, `compliance-review-header`, `user-data-panel` and `ident-panel` to use them. Removes duplicated formatters and the legacy `Record<string, unknown>`-based `extractField` / `extractString` helpers.
- New `useSplitPane` hook; `compliance-user`, `compliance-review` and `support-dashboard-issue` screens now share a single drag implementation.
- `SupportUserOverviewPanel` now goes through `useSettingsContext.translate(...)` instead of hardcoded German strings.
- `ComplianceUserScreen` switched to early-return pattern; removes the inconsistent `?.permissions` chains and the `+(userDataId ?? '0')` fallback in favor of a guarded numeric id.

## Test plan

- [ ] Compliance user detail screen with all roles (Admin / Compliance / Support)
- [ ] Personal and Organization accounts (header / freigabe-panel addresses)
- [ ] Limit Request modal (still reachable from `UserDataPanel` for non-onboarding flows)
- [ ] Split-pane drag works on `compliance-user`, `compliance-review` and `support-dashboard-issue`
- [ ] Support overview cards and transaction lookup render in EN/DE