### PR TITLE
fix(compliance, support): reviewer feedback

### DIFF
--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -26,10 +26,10 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
     setSignature((prev) => prev || clerks[0] || '');
   }, [clerks]);
 
-  const canSubmit = !!signature && !!outcome && !isSaving;
+  const canSubmit = !!signature && !!outcome && !!comment.trim() && !isSaving;
 
   async function handleSubmit() {
-    if (!outcome || !signature) return;
+    if (!outcome || !signature || !comment.trim()) return;
     setIsSaving(true);
     setResult(undefined);
     const res = await saveCallOutcome(context, outcome, { signature, comment });
@@ -74,14 +74,17 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
         </div>
       </div>
       <div className="mt-4">
-        <label className="block text-sm font-medium text-dfxBlue-800 mb-1">{translate('screens/kyc', 'Comment')}</label>
+        <label className="block text-sm font-medium text-dfxBlue-800 mb-1">
+          {translate('screens/kyc', 'Comment')} *
+        </label>
         <textarea
           className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
           rows={4}
           maxLength={500}
           value={comment}
           onChange={(e) => setComment(e.target.value)}
-          placeholder="Optional: Notes from the call"
+          placeholder="Notes from the call"
+          required
         />
       </div>
       {result && !result.success && (

--- a/src/components/compliance/call-queue/call-queue-user-info.tsx
+++ b/src/components/compliance/call-queue/call-queue-user-info.tsx
@@ -58,7 +58,7 @@ export function CallQueueUserInfo({ userData, users, kycSteps, highlightCheckDat
   const fullName = [userData.firstname, userData.surname, userData.organization?.name].filter(Boolean).join(' ');
 
   const leftRows: Row[] = [
-    { label: 'User ID', value: userData.id != null ? String(userData.id) : undefined },
+    { label: 'User ID', value: userData.id == null ? undefined : String(userData.id) },
     { label: 'Account Type', value: userData.accountType },
     { label: 'Name', value: fullName || undefined },
     { label: 'Verified Name', value: userData.verifiedName },
@@ -72,7 +72,7 @@ export function CallQueueUserInfo({ userData, users, kycSteps, highlightCheckDat
 
   const rightRows: Row[] = [
     { label: 'Status', value: userData.status },
-    { label: 'KYC Level', value: userData.kycLevel != null ? String(userData.kycLevel) : undefined },
+    { label: 'KYC Level', value: userData.kycLevel == null ? undefined : String(userData.kycLevel) },
     { label: 'KYC Status', value: userData.kycStatus },
     { label: 'Wallet', value: primaryUser?.walletName ?? userData.wallet?.name },
     { label: 'User Ref', value: primaryUser?.ref },
@@ -80,6 +80,10 @@ export function CallQueueUserInfo({ userData, users, kycSteps, highlightCheckDat
     { label: 'Referrer (Ref Werber)', value: refUserName },
     { label: 'Recommendation Step Result', value: recommendationStepResult },
     { label: 'Phone Call Status', value: userData.phoneCallStatus },
+    {
+      label: 'Phone Call Accepted',
+      value: userData.phoneCallAccepted == null ? undefined : String(userData.phoneCallAccepted),
+    },
   ];
 
   const checkDateRows: [CheckDateField, string][] = [

--- a/src/components/compliance/stammdaten-panel.tsx
+++ b/src/components/compliance/stammdaten-panel.tsx
@@ -1,4 +1,6 @@
+import { Country } from '@dfx.swiss/react';
 import { useEffect, useState } from 'react';
+import { useSettingsContext } from 'src/contexts/settings.context';
 import { ComplianceUserData, KycFile, KycStepInfo, UserDataDetail } from 'src/hooks/compliance.hook';
 import { statusBadge, formatDateTime } from 'src/util/compliance-helpers';
 
@@ -76,6 +78,19 @@ function safeString(value: unknown): string {
   return String(value);
 }
 
+// AddressChange step results store country as `{ id }` only (see kyc-data.dto.ts).
+// Resolve via the loaded countries list so the new country is displayed by name.
+function countryString(value: unknown, countries: Country[]): string {
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    if (obj.name == null && obj.symbol == null && typeof obj.id === 'number') {
+      const match = countries.find((c) => c.id === obj.id);
+      if (match) return match.name ?? match.symbol ?? '-';
+    }
+  }
+  return safeString(value);
+}
+
 function getCheckItems(stepName: string, accountType: string): DocumentCheckItem[] {
   const isCompany = accountType === 'Organization' || accountType === 'SoleProprietorship';
 
@@ -89,7 +104,12 @@ function getCheckItems(stepName: string, accountType: string): DocumentCheckItem
   }
 }
 
-function buildComparisonRows(stepName: string, result: string, userData: UserDataDetail): ComparisonRow[] {
+function buildComparisonRows(
+  stepName: string,
+  result: string,
+  userData: UserDataDetail,
+  countries: Country[],
+): ComparisonRow[] {
   let parsed: Record<string, unknown>;
   try {
     parsed = JSON.parse(result) as Record<string, unknown>;
@@ -111,7 +131,11 @@ function buildComparisonRows(stepName: string, result: string, userData: UserDat
         { label: 'Hausnummer', oldValue: safeString(userData.houseNumber), newValue: safeString(addr.houseNumber) },
         { label: 'PLZ', oldValue: safeString(userData.zip), newValue: safeString(addr.zip) },
         { label: 'Ort', oldValue: safeString(userData.location), newValue: safeString(addr.city) },
-        { label: 'Land', oldValue: safeString(userData.country), newValue: safeString(addr.country) },
+        {
+          label: 'Land',
+          oldValue: countryString(userData.country, countries),
+          newValue: countryString(addr.country, countries),
+        },
       ];
     }
 
@@ -198,8 +222,9 @@ function ChangeSectionPanel({
     setChecks(initial);
   }, [step, checkItems]);
 
+  const { countries } = useSettingsContext();
   const relatedFiles = section.fileType ? files.filter((f) => f.type === section.fileType) : [];
-  const comparisonRows = step.result ? buildComparisonRows(section.stepName, step.result, userData) : [];
+  const comparisonRows = step.result ? buildComparisonRows(section.stepName, step.result, userData, countries) : [];
 
   function handleSave(): void {
     if (!decision) return;

--- a/src/contexts/settings.context.tsx
+++ b/src/contexts/settings.context.tsx
@@ -46,6 +46,7 @@ const stickerLanguages = ['DE', 'EN', 'FR', 'IT', 'SQ'];
 interface SettingsInterface {
   availableLanguages: Language[];
   availableStickerLanguages: Language[];
+  countries: Country[];
   allowedCountries: Country[];
   nationalityCountries: Country[];
   allowedOrganizationCountries: Country[];
@@ -267,6 +268,7 @@ export function SettingsContextProvider(props: PropsWithChildren): JSX.Element {
     () => ({
       availableLanguages,
       availableStickerLanguages,
+      countries,
       allowedCountries: countries.filter((c) => c.kycAllowed),
       allowedOrganizationCountries: countries.filter((c) => c.kycOrganizationAllowed),
       nationalityCountries: countries.filter((c) => c.nationalityAllowed),

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -228,16 +228,14 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
             <InfoRow
               label="UserData ID"
               value={
-                canAccessCompliance ? (
-                  <button
-                    className="text-dfxBlue-400 underline hover:text-dfxBlue-800"
-                    onClick={() => navigate(`/compliance/user/${issueData.account.id}`)}
-                  >
-                    {issueData.account.id}
-                  </button>
-                ) : (
-                  String(issueData.account.id)
-                )
+                <button
+                  className="text-dfxBlue-400 underline hover:text-dfxBlue-800"
+                  onClick={() =>
+                    navigate(`${canAccessCompliance ? '/compliance' : '/support'}/user/${issueData.account.id}`)
+                  }
+                >
+                  {issueData.account.id}
+                </button>
               }
             />
             <InfoRow label="Status" value={statusBadge(issueData.account.status)} />


### PR DESCRIPTION
## Summary
Ongoing fix branch addressing reviewer feedback for the Compliance and Support tools. New fixes will land as additional commits on this branch.

### Current changes
- **Support dashboard issue**: UserData ID is now a clickable link for all roles. Compliance/Admin → `/compliance/user/:id`, others → `/support/user/:id`. (`support-dashboard-issue.screen.tsx`)
- **Call queue user info**: Added missing **Phone Call Accepted** row right under Phone Call Status — applies to all call queue overviews. (`call-queue-user-info.tsx`)
- **Call queue outcome form**: **Comment** is now required. Label marked with `*`, placeholder updated, Save button stays disabled until a non-empty comment is entered. (`call-queue-outcome-form.tsx`)
- **Stammdaten AddressChange**: Resolve country name via the loaded `countries` list. The AddressChange step result only stores `{ id }` (see `kyc-data.dto.ts`), so the new country was always rendered as `-`. (`stammdaten-panel.tsx`)
- **Settings context**: Expose the full `countries` list so consumers can resolve country references by id. (`settings.context.tsx`)

### Reviewer feedback items already verified as fixed in develop (no code changes)
- "Entity Bug" — `Germany (undefined)` in user data overview → fixed by refactor #1083 (`refName()`).
- URL malformation on Pending Reviews search → the standalone `compliance/pending-reviews/:type/:name` route was removed in #1076; reviews are now inline rows on the compliance screen.
- DfxApproval "Bearbeitet von" empty dropdown → fixed by #1081 (clerks now from `support/call-queues/clerks`).

## Test plan
- [ ] Open a support issue as a SUPPORT user → UserData ID navigates to `/support/user/:id`
- [ ] Open a support issue as ADMIN/COMPLIANCE → UserData ID still navigates to `/compliance/user/:id`
- [ ] Open any Call Queue detail → "Phone Call Accepted" appears under "Phone Call Status"
- [ ] Try to save a call outcome with empty comment → Save button is disabled
- [ ] Compliance user with AddressChange step (where the persisted country is `{ id: N }`) → "Land" right column shows the resolved country name
- [ ] Tests (`npm test`), lint and typecheck remain green