### PR TITLE
test: harden Modal visual regression — realistic content + stable topOffset

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,15 +3,27 @@ import type { Preview } from '@storybook/react';
 import { LayoutContextProvider } from '../src/contexts/layout.context';
 import '../src/index.css';
 
+// The Modal component reads `topOffset` from `modalRootRef.getBoundingClientRect().top`
+// to leave room for the app's layout header. To make stories render the same way
+// the deployed app does, the decorator provides:
+//   - a visible header surrogate (scrollRef-tagged div, 64 px tall) at the top of
+//     the host so screenshots include the blue band the app shows above any modal,
+//   - a measurable modalRootRef anchor placed immediately below the header so its
+//     bounding rect resolves to y = 64 in time for Modal's useEffect.
 function StorybookLayoutHost({ children }: { children: ReactNode }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const modalRootRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   return (
-    <div ref={rootRef} className="min-h-screen w-full">
-      <div ref={scrollRef} className="h-16 w-full bg-dfxBlue-800" />
-      <div ref={modalRootRef} />
+    <div ref={rootRef} className="min-h-screen w-full bg-white">
+      <div
+        ref={scrollRef}
+        className="h-16 w-full bg-dfxBlue-800 flex items-center px-4 text-sm font-medium text-white"
+      >
+        DFX Services
+      </div>
+      <div ref={modalRootRef} className="relative" data-testid="modal-root-anchor" />
       <LayoutContextProvider rootRef={rootRef} modalRootRef={modalRootRef} scrollRef={scrollRef}>
         {children}
       </LayoutContextProvider>

--- a/e2e/storybook/modal-visual.spec.ts
+++ b/e2e/storybook/modal-visual.spec.ts
@@ -30,10 +30,27 @@ for (const story of STORIES) {
       await page.setViewportSize(viewport);
       await page.goto(`/iframe.html?id=${story.id}&viewMode=story`);
 
-      // Wait for Storybook's story root to confirm the component is mounted,
-      // then for fonts to settle so subpixel differences don't flake the diff.
-      await page.locator('#storybook-root').waitFor({ state: 'attached' });
+      // Story root must be mounted before we look for the modal portal.
+      await page.locator('#storybook-root').waitFor({ state: 'visible' });
+
+      // The Modal portal lands on document.body; wait for its outer wrapper
+      // (`z-50` is on both variants) to ensure the component has reached
+      // its second render after `mounted` and refs have been set.
+      await page.locator('div.z-50').waitFor({ state: 'visible' });
+
+      // Fonts must be ready or text rendering shifts subpixels between runs.
       await page.evaluate(() => document.fonts.ready);
+
+      // Modal's fullscreen variant computes `topOffset` from a ResizeObserver
+      // on documentElement which fires asynchronously after the initial paint.
+      // Wait two animation frames so the re-render with the final `top` style
+      // has been committed before the snapshot is taken.
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+          ),
+      );
 
       await expect(page).toHaveScreenshot(`${story.name}-${viewportName}.png`, {
         fullPage: true,

--- a/src/components/modal.stories.tsx
+++ b/src/components/modal.stories.tsx
@@ -3,39 +3,88 @@ import { Modal } from './modal';
 
 function SampleFullscreenContent(): JSX.Element {
   return (
-    <div className="flex flex-col gap-4 text-dfxBlue-800">
-      <h1 className="text-2xl font-semibold">Fullscreen modal</h1>
-      <p className="text-sm">
-        The fullscreen variant fills the viewport below the layout header. It is used for primary content flows such as
-        KYC, Safe Deposit, and Buy / Sell.
-      </p>
-      <div className="rounded-md bg-dfxGray-300 p-4 text-sm">
-        Body content area — fills the available viewport width up to <code>max-w-screen-md</code>.
+    <div className="flex flex-col gap-6 text-dfxBlue-800">
+      <header className="flex flex-col gap-2">
+        <span className="text-xs uppercase tracking-wider text-dfxGray-800">Step 2 of 4</span>
+        <h1 className="text-2xl font-semibold">Identity verification</h1>
+        <p className="text-sm text-dfxGray-800">
+          Confirm the information on your government-issued ID. All fields are required.
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">First name</span>
+          <input
+            type="text"
+            defaultValue="Jane"
+            readOnly
+            className="rounded-md border border-dfxGray-500 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Last name</span>
+          <input
+            type="text"
+            defaultValue="Müller"
+            readOnly
+            className="rounded-md border border-dfxGray-500 px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-sm font-medium">Date of birth</span>
+          <input
+            type="text"
+            defaultValue="1985-04-12"
+            readOnly
+            className="rounded-md border border-dfxGray-500 px-3 py-2 text-sm"
+          />
+        </label>
       </div>
-      <button
-        type="button"
-        className="self-start rounded-md bg-dfxRed-100 px-4 py-2 text-sm font-semibold text-white"
-      >
-        Continue
-      </button>
+
+      <p className="rounded-md bg-dfxGray-300 p-3 text-xs text-dfxGray-800">
+        We share these details with our regulated KYC partner. Your data is never sold and is deleted on request.
+      </p>
+
+      <div className="flex flex-row gap-2 self-start">
+        <button
+          type="button"
+          className="rounded-md border border-dfxGray-500 px-4 py-2 text-sm font-medium text-dfxBlue-800"
+        >
+          Cancel
+        </button>
+        <button type="button" className="rounded-md bg-dfxRed-100 px-4 py-2 text-sm font-semibold text-white">
+          Continue
+        </button>
+      </div>
     </div>
   );
 }
 
 function SampleDialogContent(): JSX.Element {
   return (
-    <div className="bg-white rounded-lg shadow-xl p-6 max-w-md mx-auto w-full">
-      <h2 className="text-lg font-semibold text-dfxBlue-800 mb-3 text-left">Confirm action</h2>
-      <p className="text-sm text-dfxBlue-800 mb-6 text-left">
-        The dialog variant is used for confirmations and short compliance flows. The card sits centered on a translucent
-        backdrop.
+    <div className="bg-white rounded-lg shadow-xl p-6 max-w-md mx-auto w-full text-dfxBlue-800">
+      <h2 className="text-lg font-semibold mb-3 text-left">Refund transaction</h2>
+      <p className="text-sm mb-4 text-left">
+        This will return the full amount to the sender via SEPA. The transaction cannot be undone.
       </p>
+      <dl className="grid grid-cols-2 gap-y-1 text-sm mb-6 rounded-md bg-dfxGray-300 p-3">
+        <dt className="text-dfxGray-800">Amount</dt>
+        <dd className="text-right font-medium">CHF 1,250.00</dd>
+        <dt className="text-dfxGray-800">Recipient IBAN</dt>
+        <dd className="text-right font-mono text-xs">CH00 0000 0000 0000 0000 0</dd>
+        <dt className="text-dfxGray-800">Reference</dt>
+        <dd className="text-right text-xs">TX-2026-04-1893</dd>
+      </dl>
       <div className="flex justify-end gap-2">
-        <button type="button" className="rounded-md border border-dfxGray-500 px-4 py-2 text-sm text-dfxBlue-800">
+        <button
+          type="button"
+          className="rounded-md border border-dfxGray-500 px-4 py-2 text-sm font-medium text-dfxBlue-800"
+        >
           Cancel
         </button>
         <button type="button" className="rounded-md bg-dfxRed-100 px-4 py-2 text-sm font-semibold text-white">
-          Confirm
+          Confirm refund
         </button>
       </div>
     </div>


### PR DESCRIPTION
Stacked on top of #1093. Follow-up after inspecting the first CI baseline run from #1095 (now closed): the captured snapshots were technically valid but visually weak — the simulated layout header was hidden, the fullscreen modal covered the full viewport (because the screenshot was taken before \`ResizeObserver\` updated \`topOffset\`), and the story content was generic placeholder text.

## Three hardening changes

### 1. Stable \`topOffset\` in the decorator + visible header

\`.storybook/preview.tsx\` now renders a real "DFX Services" header band, and the \`modalRootRef\` anchor is a positioned \`<div>\` (not an empty zero-size element). The fullscreen modal sits cleanly below the header in every baseline — matches how the real app composes the layout.

### 2. Deterministic wait in the spec

The spec now:
- waits for the \`.z-50\` portal element to become visible (Modal has reached its second render after \`mounted\` flips),
- awaits \`document.fonts.ready\`,
- yields two animation frames so the \`ResizeObserver\`-driven \`top\` style update is committed before the snapshot.

This removes the race that caused the previous baselines to show \`top: 0\` instead of the stabilised \`top: 64px\`.

### 3. Realistic story content

\`src/components/modal.stories.tsx\` swaps the placeholder text for content that mirrors what the deployed app actually renders:

- **Fullscreen**: KYC-style identity-verification step with step-indicator, three labelled inputs, privacy notice, Cancel + Continue. Mirrors KYC, Safe Deposit, Buy/Sell flows.
- **Dialog**: transaction-refund confirmation card with a detail table (Amount, Recipient IBAN, Reference) and Cancel + Confirm refund buttons. Mirrors the chargeback / limit-request / recall modals shipped in #1048.

The Default story still renders \`<Modal isOpen>\` with no \`variant\`, so the **byte-equality between Default and Fullscreen** remains the load-bearing regression signal for the #1048 bug class.

## Visual sanity check (local, --update-snapshots)

| Property | Result |
|---|---|
| Default == Fullscreen byte-identical at both viewports | ✅ |
| Dialog distinct (different SHA-1) at both viewports | ✅ |
| Layout header visible above the fullscreen modal | ✅ — blue \"DFX Services\" band, modal starts at y=64 |
| Dialog backdrop covers the header (matches app behaviour) | ✅ |
| Inter font applied (no system fallback) | ✅ |
| Realistic content readable (form fields, detail table) | ✅ |

## Next steps after merge

1. This PR merges into \`test/modal-visual-regression\`.
2. The parent #1093 CI re-runs, \`Storybook visual regression\` produces a fresh, more meaningful set of baseline candidates in \`visual-regression-diff.zip\`.
3. A final stacked PR commits those baselines into \`e2e/storybook/__snapshots__/modal-visual.spec.ts/\`.
4. Subsequent #1093 runs are green → gate is live.