### PR TITLE
feat(compliance): AML check refinements and KYC log integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.3.2-beta.2",
-        "@dfx.swiss/react-components": "^1.3.1",
+        "@dfx.swiss/react": "^1.4.0-beta.0",
+        "@dfx.swiss/react-components": "^1.3.2",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
         "@ledgerhq/hw-transport-webhid": "^6.27.19",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@dfx.swiss/core": {
-      "version": "0.2.2-beta.2",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.2.2-beta.2.tgz",
-      "integrity": "sha512-/WTwOg2uzyxTpeiRbIIhTNiRDFOshHWXrDAOG/AwCp5X+sxkEto2DzLg1UFgKHB0kADzWaTIyJgeWcZg5+NVYw==",
+      "version": "0.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.0-beta.0.tgz",
+      "integrity": "sha512-HGG+gMQCCvGMh2hkXqYP+LTSpz//iq5Jovz4pByFPId+n5srgTitYFFYic0uDZamsPSjEcRyDKL1VRqojnQIYw==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2642,21 +2642,21 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.3.2-beta.2",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.3.2-beta.2.tgz",
-      "integrity": "sha512-aN3Vg6uMHS+UgafU4+3fbT97Etbfa+kXuOdOPA49g2qjhMu/5c2vC2OwcXrcshSTDALmIFyDpbe5QgBWWizpkA==",
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.0-beta.0.tgz",
+      "integrity": "sha512-R3S2l4DgCXB5scpFNCTm6dpy+uPNnUoOHmHuFViP4PrrbuwEKugSvr3K4XTYCuQrUBhTi/0UsxPmYzT45CS1KQ==",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/core": "^0.2.2-beta.2",
+        "@dfx.swiss/core": "^0.3.0-beta.0",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "typescript": "^4.9.3"
       }
     },
     "node_modules/@dfx.swiss/react-components": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react-components/-/react-components-1.3.1.tgz",
-      "integrity": "sha512-04EoQ6iLssQTXET+ijUgDvCBeiGMpU/JDRga+vJziNDO9H5lFzkX+q6PAjNZkuFsToye430Piiy6BFPsnM0G0w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react-components/-/react-components-1.3.2.tgz",
+      "integrity": "sha512-oY7nT4fawW/sqFP/utosCBeCwKPgstxF8Un9fQGAiiU/HrBi1b/ytyCP6+tULDcJZDC2FtNPclpPg1P+f3e70A==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.18.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.3.2-beta.2",
-    "@dfx.swiss/react-components": "^1.3.1",
+    "@dfx.swiss/react": "^1.4.0-beta.0",
+    "@dfx.swiss/react-components": "^1.3.2",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",
     "@ledgerhq/hw-transport-webhid": "^6.27.19",

--- a/src/components/compliance/aml-check-panel.tsx
+++ b/src/components/compliance/aml-check-panel.tsx
@@ -8,20 +8,19 @@ function callQueueForReason(reason: string | undefined): CallQueue | undefined {
   return reason && (Object.values(CallQueue) as string[]).includes(reason) ? (reason as CallQueue) : undefined;
 }
 
+export interface AmlCheckUpdate {
+  amlCheck?: string;
+  amlReason?: string;
+  comment?: string;
+  priceDefinitionAllowedDate?: string;
+}
+
 interface AmlCheckPendingPanelProps {
   data: ComplianceUserData;
-  onUpdateBuyCrypto: (
-    id: number,
-    data: { amlCheck?: string; amlReason?: string; comment?: string; priceDefinitionAllowedDate?: string },
-  ) => Promise<void>;
-  onUpdateBuyFiat: (
-    id: number,
-    data: { amlCheck?: string; amlReason?: string; comment?: string; priceDefinitionAllowedDate?: string },
-  ) => Promise<void>;
-  onResetBuyCryptoAml: (id: number) => Promise<void>;
-  onResetBuyFiatAml: (id: number) => Promise<void>;
+  clerks: string[];
   isSaving: boolean;
-  onReload: () => void;
+  onUpdate: (tx: TransactionInfo, update: AmlCheckUpdate, clerk: string) => Promise<void>;
+  onReset: (tx: TransactionInfo, clerk: string) => Promise<void>;
 }
 
 const AML_CHECK_OPTIONS = [CheckStatus.PASS, CheckStatus.FAIL, CheckStatus.PENDING, 'Reset'] as const;
@@ -31,43 +30,40 @@ const AML_REASON_OPTIONS: AmlReason[] = [
   ...(Object.values(AmlReason) as AmlReason[]).filter((r) => r !== AmlReason.NA).sort((a, b) => a.localeCompare(b)),
 ];
 
-function isBuyCrypto(tx: TransactionInfo): boolean {
-  return tx.buyCryptoId != null;
-}
-
 function TransactionEntry({
   tx,
+  clerks,
   onUpdate,
   onReset,
   isSaving,
 }: {
   tx: TransactionInfo;
-  onUpdate: (data: {
-    amlCheck?: string;
-    amlReason?: string;
-    comment?: string;
-    priceDefinitionAllowedDate?: string;
-  }) => Promise<void>;
-  onReset: () => Promise<void>;
+  clerks: string[];
+  onUpdate: (data: AmlCheckUpdate, clerk: string) => Promise<void>;
+  onReset: (clerk: string) => Promise<void>;
   isSaving: boolean;
 }): JSX.Element {
   const [amlCheck, setAmlCheck] = useState(tx.amlCheck ?? '');
   const [amlReason, setAmlReason] = useState<AmlReason>((tx.amlReason as AmlReason) ?? AmlReason.NA);
   const [setPriceDate, setSetPriceDate] = useState(false);
+  const [clerk, setClerk] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
 
   async function handleSave(): Promise<void> {
-    if (!amlCheck) return;
+    if (!amlCheck || !clerk) return;
     setIsProcessing(true);
     try {
       if (amlCheck === 'Reset') {
-        await onReset();
+        await onReset(clerk);
       } else {
-        await onUpdate({
-          amlCheck,
-          amlReason,
-          priceDefinitionAllowedDate: setPriceDate ? new Date().toISOString() : undefined,
-        });
+        await onUpdate(
+          {
+            amlCheck,
+            amlReason,
+            priceDefinitionAllowedDate: setPriceDate ? new Date().toISOString() : undefined,
+          },
+          clerk,
+        );
       }
     } finally {
       setIsProcessing(false);
@@ -179,11 +175,30 @@ function TransactionEntry({
         </div>
       </div>
 
+      {/* Clerk */}
+      <div className="bg-white rounded-lg shadow-sm px-3 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-dfxBlue-800 font-medium">Editor:</span>
+          <select
+            className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={clerk}
+            onChange={(e) => setClerk(e.target.value)}
+          >
+            <option value="">—</option>
+            {clerks.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
       <div>
         <button
           className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
           onClick={handleSave}
-          disabled={isSaving || isProcessing || !amlCheck}
+          disabled={isSaving || isProcessing || !amlCheck || !clerk}
         >
           {isProcessing ? 'Speichern...' : 'Speichern'}
         </button>
@@ -194,12 +209,10 @@ function TransactionEntry({
 
 export function AmlCheckPendingPanel({
   data,
-  onUpdateBuyCrypto,
-  onUpdateBuyFiat,
-  onResetBuyCryptoAml,
-  onResetBuyFiatAml,
+  clerks,
   isSaving,
-  onReload,
+  onUpdate,
+  onReset,
 }: AmlCheckPendingPanelProps): JSX.Element {
   const { navigate } = useNavigation();
 
@@ -335,22 +348,9 @@ export function AmlCheckPendingPanel({
         <div key={tx.id} className="border-b border-dfxGray-300 pb-6 last:border-0">
           <TransactionEntry
             tx={tx}
-            onUpdate={async (updateData) => {
-              if (isBuyCrypto(tx) && tx.buyCryptoId != null) {
-                await onUpdateBuyCrypto(tx.buyCryptoId, updateData);
-              } else if (tx.buyFiatId != null) {
-                await onUpdateBuyFiat(tx.buyFiatId, updateData);
-              }
-              onReload();
-            }}
-            onReset={async () => {
-              if (isBuyCrypto(tx) && tx.buyCryptoId != null) {
-                await onResetBuyCryptoAml(tx.buyCryptoId);
-              } else if (tx.buyFiatId != null) {
-                await onResetBuyFiatAml(tx.buyFiatId);
-              }
-              onReload();
-            }}
+            clerks={clerks}
+            onUpdate={(updateData, clerk) => onUpdate(tx, updateData, clerk)}
+            onReset={(clerk) => onReset(tx, clerk)}
             isSaving={isSaving}
           />
         </div>

--- a/src/components/compliance/bank-data-panel.tsx
+++ b/src/components/compliance/bank-data-panel.tsx
@@ -5,8 +5,9 @@ import { statusBadge } from 'src/util/compliance-helpers';
 interface BankDataReviewPanelProps {
   bankDatas: BankDataInfo[];
   userData: UserDataDetail;
-  onApprove: (bankDataId: number) => Promise<void>;
-  onReject: (bankDataId: number) => Promise<void>;
+  clerks: string[];
+  onApprove: (bankDataId: number, clerk: string) => Promise<void>;
+  onReject: (bankDataId: number, clerk: string) => Promise<void>;
   isSaving: boolean;
 }
 
@@ -79,30 +80,33 @@ function YesNoSelect({ value, onChange }: { value: YesNo; onChange: (v: YesNo) =
 function BankDataEntry({
   entry,
   verifiedName,
+  clerks,
   onApprove,
   onReject,
   isSaving,
 }: {
   entry: BankDataInfo;
   verifiedName: string;
-  onApprove: (id: number) => Promise<void>;
-  onReject: (id: number) => Promise<void>;
+  clerks: string[];
+  onApprove: (id: number, clerk: string) => Promise<void>;
+  onReject: (id: number, clerk: string) => Promise<void>;
   isSaving: boolean;
 }): JSX.Element {
   const [decision, setDecision] = useState<DecisionValue>(
     entry.status === 'Completed' ? 'Akzeptiert' : entry.status === 'Failed' ? 'Abgelehnt' : '',
   );
+  const [clerk, setClerk] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
   const nameMismatch = verifiedName && entry.name && verifiedName.toLowerCase() !== entry.name.toLowerCase();
 
   async function handleSave(): Promise<void> {
-    if (!decision) return;
+    if (!decision || !clerk) return;
     setIsProcessing(true);
     try {
       if (decision === 'Akzeptiert') {
-        await onApprove(entry.id);
+        await onApprove(entry.id, clerk);
       } else {
-        await onReject(entry.id);
+        await onReject(entry.id, clerk);
       }
     } finally {
       setIsProcessing(false);
@@ -195,12 +199,31 @@ function BankDataEntry({
             </div>
           </div>
 
+          {/* Clerk */}
+          <div className="bg-white rounded-lg shadow-sm px-3 py-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-dfxBlue-800 font-medium">Editor:</span>
+              <select
+                className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                value={clerk}
+                onChange={(e) => setClerk(e.target.value)}
+              >
+                <option value="">—</option>
+                {clerks.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
           {/* Save */}
           <div>
             <button
               className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
               onClick={handleSave}
-              disabled={isSaving || isProcessing || !decision}
+              disabled={isSaving || isProcessing || !decision || !clerk}
             >
               {isProcessing ? 'Speichern...' : 'Speichern'}
             </button>
@@ -219,6 +242,7 @@ function BankDataEntry({
 export function BankDataReviewPanel({
   bankDatas,
   userData,
+  clerks,
   onApprove,
   onReject,
   isSaving,
@@ -242,6 +266,7 @@ export function BankDataReviewPanel({
           <BankDataEntry
             entry={entry}
             verifiedName={verifiedName}
+            clerks={clerks}
             onApprove={onApprove}
             onReject={onReject}
             isSaving={isSaving}

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -1,8 +1,15 @@
+import { canManualPass } from '@dfx.swiss/react';
 import { StyledButton, StyledButtonWidth } from '@dfx.swiss/react-components';
 import { useEffect, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
-import { CallOutcome, CallOutcomeContext, CallOutcomeResult, useCompliance } from 'src/hooks/compliance.hook';
+import {
+  AmlAction,
+  CallOutcome,
+  CallOutcomeContext,
+  CallOutcomeResult,
+  useCompliance,
+} from 'src/hooks/compliance.hook';
 
 interface Props {
   context: CallOutcomeContext;
@@ -10,15 +17,24 @@ interface Props {
   clerks: string[];
   onSaved: () => void;
   title: string;
+  txComment?: string;
 }
 
-export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSaved, title }: Props): JSX.Element {
+export function CallQueueOutcomeForm({
+  context,
+  availableOutcomes,
+  clerks,
+  onSaved,
+  title,
+  txComment,
+}: Props): JSX.Element {
   const { translate } = useSettingsContext();
   const { saveCallOutcome } = useCompliance();
 
   const [signature, setSignature] = useState<string>('');
   const [comment, setComment] = useState<string>('');
   const [outcome, setOutcome] = useState<CallOutcome | ''>('');
+  const [amlAction, setAmlAction] = useState<AmlAction | ''>('');
   const [isSaving, setIsSaving] = useState(false);
   const [result, setResult] = useState<CallOutcomeResult>();
 
@@ -26,13 +42,20 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
     setSignature((prev) => prev || clerks[0] || '');
   }, [clerks]);
 
+  const hasTx = context.txId != null && context.sourceType != null;
+  const showAmlCheck = hasTx && outcome !== CallOutcome.COMPLETED;
+  const passAllowed = hasTx && canManualPass(txComment);
   const canSubmit = !!signature && !!outcome && !!comment.trim() && !isSaving;
 
   async function handleSubmit() {
     if (!outcome || !signature || !comment.trim()) return;
     setIsSaving(true);
     setResult(undefined);
-    const res = await saveCallOutcome(context, outcome, { signature, comment });
+    const res = await saveCallOutcome(context, outcome, {
+      signature,
+      comment,
+      amlAction: showAmlCheck && amlAction ? amlAction : undefined,
+    });
     setIsSaving(false);
     setResult(res);
     if (res.success) onSaved();
@@ -73,6 +96,33 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
           </select>
         </div>
       </div>
+      {showAmlCheck && (
+        <div className="mt-4">
+          <label className="block text-sm font-medium text-dfxBlue-800 mb-1">
+            {translate('screens/compliance', 'AmlCheck')}
+          </label>
+          <select
+            className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
+            value={amlAction}
+            onChange={(e) => setAmlAction(e.target.value as AmlAction | '')}
+          >
+            <option value="">— {translate('screens/compliance', 'No change')}</option>
+            <option
+              value="Pass"
+              disabled={!passAllowed}
+              title={
+                passAllowed
+                  ? undefined
+                  : translate('screens/compliance', 'Pass only allowed when all errors are phone-related')
+              }
+            >
+              Pass{passAllowed ? '' : ` (${translate('screens/compliance', 'blocked')})`}
+            </option>
+            <option value="Fail">Fail</option>
+            <option value="Reset">Reset</option>
+          </select>
+        </div>
+      )}
       <div className="mt-4">
         <label className="block text-sm font-medium text-dfxBlue-800 mb-1">
           {translate('screens/kyc', 'Comment')} *

--- a/src/components/compliance/compliance-review-panel.tsx
+++ b/src/components/compliance/compliance-review-panel.tsx
@@ -15,8 +15,16 @@ interface ComplianceReviewPanelProps {
   rejectionReasons: string[];
   userData: UserDataDetail;
   kycSteps: KycStepInfo[];
+  clerks: string[];
   onOpenFile: (file: KycFile) => void;
-  onSave: (stepId: number, status: string, comment?: string, result?: string) => Promise<void>;
+  onSave: (
+    stepId: number,
+    status: string,
+    clerk: string,
+    description: string,
+    comment?: string,
+    result?: string,
+  ) => Promise<void>;
   isSaving: boolean;
 }
 
@@ -122,6 +130,7 @@ export function ComplianceReviewPanel({
   rejectionReasons,
   userData,
   kycSteps,
+  clerks,
   onOpenFile,
   onSave,
   isSaving,
@@ -129,6 +138,7 @@ export function ComplianceReviewPanel({
   const [checks, setChecks] = useState<Record<string, string>>({});
   const [decision, setDecision] = useState<DecisionValue>('');
   const [rejectionComment, setRejectionComment] = useState('');
+  const [clerk, setClerk] = useState('');
 
   // Labels can reference fields that live outside UserData (e.g. {legalEntity}
   // is stored on the LegalEntity step result). Merge them into the resolver source.
@@ -192,7 +202,7 @@ export function ComplianceReviewPanel({
   }
 
   function handleSave(): void {
-    if (!step || !decision) return;
+    if (!step || !decision || !clerk) return;
     const status = decision === 'Akzeptiert' ? 'Completed' : 'Failed';
 
     // Comment: plain text for GS compatibility
@@ -220,7 +230,7 @@ export function ComplianceReviewPanel({
     existingResult.complianceReview = checksData;
     const result = JSON.stringify(existingResult);
 
-    onSave(step.id, status, comment, result);
+    onSave(step.id, status, clerk, step.name, comment, result);
   }
 
   return (
@@ -403,12 +413,31 @@ export function ComplianceReviewPanel({
             </div>
           )}
 
+          {/* Clerk */}
+          <div className="bg-white rounded-lg shadow-sm px-3 py-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-dfxBlue-800 font-medium">Editor:</span>
+              <select
+                className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                value={clerk}
+                onChange={(e) => setClerk(e.target.value)}
+              >
+                <option value="">—</option>
+                {clerks.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
           {/* Save */}
           <div>
             <button
               className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
               onClick={handleSave}
-              disabled={isSaving || !decision}
+              disabled={isSaving || !decision || !clerk}
             >
               {isSaving ? 'Speichern...' : 'Speichern'}
             </button>

--- a/src/components/compliance/ident-panel.tsx
+++ b/src/components/compliance/ident-panel.tsx
@@ -5,8 +5,16 @@ import { renderResultTable } from './compliance-review-panel';
 
 interface IdentPanelProps {
   data: ComplianceUserData;
+  clerks: string[];
   onOpenFile: (file: KycFile) => void;
-  onSave: (stepId: number, status: string, comment?: string, result?: string) => Promise<void>;
+  onSave: (
+    stepId: number,
+    status: string,
+    clerk: string,
+    description: string,
+    comment?: string,
+    result?: string,
+  ) => Promise<void>;
   isSaving: boolean;
 }
 
@@ -68,7 +76,7 @@ function InfoLine({ label, value }: { label: string; value: string }): JSX.Eleme
   );
 }
 
-export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelProps): JSX.Element {
+export function IdentPanel({ data, clerks, onOpenFile, onSave, isSaving }: IdentPanelProps): JSX.Element {
   const step = findLatestStep(data.kycSteps, 'Ident');
   const nationalityStep = findLatestStep(data.kycSteps, 'NationalityData');
 
@@ -76,6 +84,7 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
     step?.status === 'Completed' ? 'Akzeptiert' : step?.status === 'Failed' ? 'Abgelehnt' : '',
   );
   const [rejectionComment, setRejectionComment] = useState(step?.comment ?? '');
+  const [clerk, setClerk] = useState('');
 
   if (!step) {
     return (
@@ -102,9 +111,15 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
   }
 
   function handleSave(): void {
-    if (!step || !decision) return;
+    if (!step || !decision || !clerk) return;
     const status = decision === 'Akzeptiert' ? 'Completed' : 'Failed';
-    onSave(step.id, status, decision === 'Abgelehnt' && rejectionComment ? rejectionComment : undefined);
+    onSave(
+      step.id,
+      status,
+      clerk,
+      'Ident',
+      decision === 'Abgelehnt' && rejectionComment ? rejectionComment : undefined,
+    );
   }
 
   const rejectionReasons = ['Identification failed', 'Document expired', 'Name mismatch', 'Photo quality insufficient'];
@@ -287,12 +302,31 @@ export function IdentPanel({ data, onOpenFile, onSave, isSaving }: IdentPanelPro
             </div>
           )}
 
+          {/* Clerk */}
+          <div className="bg-white rounded-lg shadow-sm px-3 py-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-dfxBlue-800 font-medium">Editor:</span>
+              <select
+                className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                value={clerk}
+                onChange={(e) => setClerk(e.target.value)}
+              >
+                <option value="">—</option>
+                {clerks.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
           {/* Save */}
           <div>
             <button
               className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
               onClick={handleSave}
-              disabled={isSaving || !decision}
+              disabled={isSaving || !decision || !clerk}
             >
               {isSaving ? 'Speichern...' : 'Speichern'}
             </button>

--- a/src/components/compliance/stammdaten-panel.tsx
+++ b/src/components/compliance/stammdaten-panel.tsx
@@ -6,8 +6,16 @@ import { statusBadge, formatDateTime } from 'src/util/compliance-helpers';
 
 interface StammdatenPanelProps {
   data: ComplianceUserData;
+  clerks: string[];
   onOpenFile: (file: KycFile) => void;
-  onSave: (stepId: number, status: string, comment?: string, result?: string) => Promise<void>;
+  onSave: (
+    stepId: number,
+    status: string,
+    clerk: string,
+    description: string,
+    comment?: string,
+    result?: string,
+  ) => Promise<void>;
   isSaving: boolean;
 }
 
@@ -178,6 +186,7 @@ function ChangeSectionPanel({
   files,
   userData,
   checkItems,
+  clerks,
   onOpenFile,
   onSave,
   isSaving,
@@ -187,8 +196,16 @@ function ChangeSectionPanel({
   files: KycFile[];
   userData: UserDataDetail;
   checkItems: DocumentCheckItem[];
+  clerks: string[];
   onOpenFile: (file: KycFile) => void;
-  onSave: (stepId: number, status: string, comment?: string, result?: string) => Promise<void>;
+  onSave: (
+    stepId: number,
+    status: string,
+    clerk: string,
+    description: string,
+    comment?: string,
+    result?: string,
+  ) => Promise<void>;
   isSaving: boolean;
 }): JSX.Element {
   const [decision, setDecision] = useState<DecisionValue>(
@@ -196,6 +213,7 @@ function ChangeSectionPanel({
   );
   const [comment, setComment] = useState(step.comment ?? '');
   const [checks, setChecks] = useState<Record<string, string>>({});
+  const [clerk, setClerk] = useState('');
 
   useEffect(() => {
     const initial: Record<string, string> = {};
@@ -227,7 +245,7 @@ function ChangeSectionPanel({
   const comparisonRows = step.result ? buildComparisonRows(section.stepName, step.result, userData, countries) : [];
 
   function handleSave(): void {
-    if (!decision) return;
+    if (!decision || !clerk) return;
     const status = decision === 'Akzeptiert' ? 'Completed' : 'Failed';
     const comment_ = decision === 'Abgelehnt' && comment ? comment : undefined;
 
@@ -250,7 +268,7 @@ function ChangeSectionPanel({
     existingResult.complianceReview = checksData;
     const result = JSON.stringify(existingResult);
 
-    onSave(step.id, status, comment_, result);
+    onSave(step.id, status, clerk, section.stepName, comment_, result);
   }
 
   return (
@@ -358,12 +376,31 @@ function ChangeSectionPanel({
             </div>
           )}
 
+          {/* Clerk */}
+          <div className="bg-white rounded-lg shadow-sm px-3 py-3">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-dfxBlue-800 font-medium">Editor:</span>
+              <select
+                className="ml-4 shrink-0 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                value={clerk}
+                onChange={(e) => setClerk(e.target.value)}
+              >
+                <option value="">—</option>
+                {clerks.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
           {/* Save */}
           <div>
             <button
               className="px-4 py-2 text-sm text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded-lg transition-colors disabled:opacity-50"
               onClick={handleSave}
-              disabled={isSaving || !decision}
+              disabled={isSaving || !decision || !clerk}
             >
               {isSaving ? 'Speichern...' : 'Speichern'}
             </button>
@@ -374,7 +411,7 @@ function ChangeSectionPanel({
   );
 }
 
-export function StammdatenPanel({ data, onOpenFile, onSave, isSaving }: StammdatenPanelProps): JSX.Element {
+export function StammdatenPanel({ data, clerks, onOpenFile, onSave, isSaving }: StammdatenPanelProps): JSX.Element {
   const accountType = String(data.userData.accountType ?? '');
 
   const activeSections = changeSections
@@ -402,6 +439,7 @@ export function StammdatenPanel({ data, onOpenFile, onSave, isSaving }: Stammdat
             files={data.kycFiles ?? []}
             userData={data.userData}
             checkItems={getCheckItems(section.stepName, accountType)}
+            clerks={clerks}
             onOpenFile={onOpenFile}
             onSave={onSave}
             isSaving={isSaving}

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -1090,17 +1090,17 @@ export function useCompliance() {
 
   async function manualPassBuyCrypto(id: number, responsible: string): Promise<void> {
     return call<void>({
-      url: `buyCrypto/${id}/amlCheck/pass`,
+      url: `buyCrypto/${id}/amlCheck`,
       method: 'PUT',
-      data: { responsible },
+      data: { amlCheck: CheckStatus.PASS, responsible },
     });
   }
 
   async function manualPassBuyFiat(id: number, responsible: string): Promise<void> {
     return call<void>({
-      url: `buyFiat/${id}/amlCheck/pass`,
+      url: `buyFiat/${id}/amlCheck`,
       method: 'PUT',
-      data: { responsible },
+      data: { amlCheck: CheckStatus.PASS, responsible },
     });
   }
 

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -24,6 +24,7 @@ import { CustodyOrderListEntry } from 'src/dto/order.dto';
 import { CreateRecallDto, RecallListEntry } from 'src/dto/recall.dto';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
 import { useMemo } from 'react';
+import { buildKycLogMessage, KycLogResult } from 'src/util/compliance-helpers';
 import { downloadFile, downloadPdfFromString, filenameDateFormat } from 'src/util/utils';
 
 export interface RefundFeeData {
@@ -647,17 +648,7 @@ function checkDateFieldForQueue(queue: CallQueue): string {
   return checkDateFieldByQueue[queue];
 }
 
-function buildTxUpdatePayload(outcome: CallOutcome): { amlCheck?: string; amlReason?: string } | null {
-  switch (outcome) {
-    case CallOutcome.COMPLETED:
-      return { amlCheck: CheckStatus.PASS };
-    case CallOutcome.USER_REJECTED:
-    case CallOutcome.SUSPICIOUS:
-      return { amlCheck: CheckStatus.FAIL, amlReason: AmlReason.MANUAL_CHECK_PHONE_FAILED };
-    default:
-      return null;
-  }
-}
+export type AmlAction = 'Pass' | 'Fail' | 'Reset';
 
 export function useCompliance() {
   const { call } = useApi();
@@ -899,7 +890,7 @@ export function useCompliance() {
   async function saveCallOutcome(
     context: CallOutcomeContext,
     outcome: CallOutcome,
-    options: { signature: string; comment?: string },
+    options: { signature: string; comment?: string; amlAction?: AmlAction },
   ): Promise<CallOutcomeResult> {
     const completedSteps: CallOutcomeStep[] = [];
     const fail = (step: CallOutcomeStep, err: unknown): CallOutcomeResult => ({
@@ -910,16 +901,29 @@ export function useCompliance() {
     });
 
     const tx = context.txId != null && context.sourceType ? { id: context.txId, sourceType: context.sourceType } : null;
+    const results: KycLogResult[] = [];
 
     // 1) Transaction update (if applicable)
     try {
-      if (tx) {
-        const txData = buildTxUpdatePayload(outcome);
-        if (txData) {
-          if (tx.sourceType === 'BuyCrypto') await updateBuyCrypto(tx.id, txData);
-          else await updateBuyFiat(tx.id, txData);
-          completedSteps.push('transaction');
+      if (tx && options.amlAction) {
+        const signature = options.signature.trim();
+        const txTable = tx.sourceType === 'BuyCrypto' ? 'buyCrypto' : 'buyFiat';
+        if (options.amlAction === 'Pass') {
+          if (tx.sourceType === 'BuyCrypto') await manualPassBuyCrypto(tx.id, signature);
+          else await manualPassBuyFiat(tx.id, signature);
+          results.push({ table: txTable, column: 'amlCheck', value: CheckStatus.PASS });
+        } else if (options.amlAction === 'Fail') {
+          const failData = { amlCheck: CheckStatus.FAIL, amlReason: AmlReason.MANUAL_CHECK_PHONE_FAILED };
+          if (tx.sourceType === 'BuyCrypto') await updateBuyCrypto(tx.id, failData);
+          else await updateBuyFiat(tx.id, failData);
+          results.push({ table: txTable, column: 'amlCheck', value: CheckStatus.FAIL });
+          results.push({ table: txTable, column: 'amlReason', value: AmlReason.MANUAL_CHECK_PHONE_FAILED });
+        } else {
+          if (tx.sourceType === 'BuyCrypto') await resetBuyCryptoAml(tx.id);
+          else await resetBuyFiatAml(tx.id);
+          results.push({ table: txTable, column: 'amlCheck', value: 'Reset' });
         }
+        completedSteps.push('transaction');
       }
     } catch (e) {
       return fail('transaction', e);
@@ -931,8 +935,12 @@ export function useCompliance() {
     if (phoneStatus && !skipUserData) {
       try {
         const udData: Record<string, unknown> = { phoneCallStatus: phoneStatus };
+        results.push({ table: 'userData', column: 'phoneCallStatus', value: phoneStatus });
         if (outcome === CallOutcome.COMPLETED) {
-          udData[checkDateFieldForQueue(context.queue)] = new Date().toISOString();
+          const checkDateField = checkDateFieldForQueue(context.queue);
+          const checkDateValue = new Date().toISOString();
+          udData[checkDateField] = checkDateValue;
+          results.push({ table: 'userData', column: checkDateField, value: checkDateValue });
         }
         await updateUserData(context.userDataId, udData);
         completedSteps.push('userData');
@@ -943,8 +951,12 @@ export function useCompliance() {
 
     // 3) KYC log entry (always)
     try {
-      const comment = options.comment?.trim();
-      const logMessage = [options.signature.trim(), outcome, comment].filter(Boolean).join(' – ');
+      const logMessage = buildKycLogMessage({
+        description: context.queue,
+        clerk: options.signature,
+        results,
+        comment: options.comment,
+      });
       await createKycLog(context.userDataId, logMessage);
       completedSteps.push('log');
     } catch (e) {
@@ -1073,6 +1085,22 @@ export function useCompliance() {
     return call<void>({
       url: `buyFiat/${id}/amlCheck`,
       method: 'DELETE',
+    });
+  }
+
+  async function manualPassBuyCrypto(id: number, responsible: string): Promise<void> {
+    return call<void>({
+      url: `buyCrypto/${id}/amlCheck/pass`,
+      method: 'PUT',
+      data: { responsible },
+    });
+  }
+
+  async function manualPassBuyFiat(id: number, responsible: string): Promise<void> {
+    return call<void>({
+      url: `buyFiat/${id}/amlCheck/pass`,
+      method: 'PUT',
+      data: { responsible },
     });
   }
 

--- a/src/screens/compliance-call-queue-detail.screen.tsx
+++ b/src/screens/compliance-call-queue-detail.screen.tsx
@@ -181,8 +181,11 @@ export default function ComplianceCallQueueDetailScreen(): JSX.Element {
         context={context}
         availableOutcomes={config.outcomes}
         clerks={clerks}
-        onSaved={() => navigate(`compliance/call-queues/${queue}`)}
+        onSaved={() =>
+          navigate({ pathname: `/compliance/call-queues/${queue}` }, { replace: true, clearParams: ['txId'] })
+        }
         title={translate('screens/compliance', 'Save Outcome')}
+        txComment={transaction?.comment}
       />
     </StyledVerticalStack>
   );

--- a/src/screens/compliance-review.screen.tsx
+++ b/src/screens/compliance-review.screen.tsx
@@ -12,13 +12,15 @@ import { ReviewCheckTab, ReviewTabConfig, reviewTabs } from 'src/components/comp
 import { FilePreviewPanel } from 'src/components/compliance/file-preview-panel';
 import { StammdatenPanel } from 'src/components/compliance/stammdaten-panel';
 import { BankDataReviewPanel } from 'src/components/compliance/bank-data-panel';
-import { AmlCheckPendingPanel } from 'src/components/compliance/aml-check-panel';
+import { AmlCheckPendingPanel, AmlCheckUpdate } from 'src/components/compliance/aml-check-panel';
 import { IdentPanel } from 'src/components/compliance/ident-panel';
 import { ErrorHint } from 'src/components/error-hint';
-import { ComplianceUserData, KycFile, KycStepInfo, useCompliance } from 'src/hooks/compliance.hook';
+import { useCallQueueClerks } from 'src/hooks/call-queue-clerks.hook';
+import { ComplianceUserData, KycFile, KycStepInfo, TransactionInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useSplitPane } from 'src/hooks/split-pane.hook';
+import { buildKycLogMessage, KycLogResult } from 'src/util/compliance-helpers';
 
 function findLatestStep(kycSteps: KycStepInfo[], stepName: string): KycStepInfo | undefined {
   return kycSteps.filter((s) => s.name === stepName).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
@@ -48,8 +50,10 @@ export default function ComplianceReviewScreen(): JSX.Element {
     resetBuyCryptoAml,
     resetBuyFiatAml,
     generateOnboardingPdf,
+    createKycLog,
   } = useCompliance();
   const { getFile } = useKyc();
+  const { clerks } = useCallQueueClerks();
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -121,12 +125,24 @@ export default function ComplianceReviewScreen(): JSX.Element {
         comment: params.comment,
       });
 
+      const results: KycLogResult[] = [{ table: 'kycStep', column: 'status', value: params.status }];
+
       // 2. Update UserData if needed
       if (params.userDataUpdate && userDataId) {
         await updateUserData(+userDataId, params.userDataUpdate);
+        for (const [col, val] of Object.entries(params.userDataUpdate)) {
+          if (val == null) continue;
+          results.push({ table: 'userData', column: col, value: String(val) });
+        }
       }
 
-      // 3. Generate PDF if data provided
+      // 3. KycLog (Editor = processedBy aus den params, single source of truth)
+      const clerk = params.pdfData?.processedBy;
+      if (userDataId && clerk) {
+        await createKycLog(+userDataId, buildKycLogMessage({ description: 'DfxApproval', clerk, results }));
+      }
+
+      // 4. Generate PDF if data provided
       if (params.pdfData && userDataId) {
         try {
           const { pdfData, fileName } = await generateOnboardingPdf(+userDataId, params.pdfData);
@@ -146,7 +162,7 @@ export default function ComplianceReviewScreen(): JSX.Element {
         }
       }
 
-      // 4. Reload data (now includes the new PDF)
+      // 5. Reload data (now includes the new PDF)
       loadData();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Error saving');
@@ -155,18 +171,32 @@ export default function ComplianceReviewScreen(): JSX.Element {
     }
   }
 
-  async function handleSave(stepId: number, status: string, comment?: string, result?: string): Promise<void> {
+  async function handleSave(
+    stepId: number,
+    status: string,
+    clerk: string,
+    description: string,
+    comment?: string,
+    result?: string,
+  ): Promise<void> {
     setIsSaving(true);
     setError(undefined);
     try {
       await updateKycStep(stepId, { status, comment, result });
+
+      const results: KycLogResult[] = [{ table: 'kycStep', column: 'status', value: status }];
 
       if (effectiveTab === 'operationalActivity' && userDataId) {
         const step = findLatestStep(data?.kycSteps ?? [], 'OperationalActivity');
         const amlAccountType = deriveAmlAccountType(step);
         if (amlAccountType) {
           await updateUserData(+userDataId, { amlAccountType });
+          results.push({ table: 'userData', column: 'amlAccountType', value: amlAccountType });
         }
+      }
+
+      if (userDataId) {
+        await createKycLog(+userDataId, buildKycLogMessage({ description, clerk, results }));
       }
 
       loadData();
@@ -177,11 +207,25 @@ export default function ComplianceReviewScreen(): JSX.Element {
     }
   }
 
-  async function handleBankDataApprove(bankDataId: number): Promise<void> {
+  async function handleBankDataApprove(bankDataId: number, clerk: string): Promise<void> {
     setIsSaving(true);
     setError(undefined);
     try {
       await updateBankData(bankDataId, { manualApproved: true, approved: true, status: 'Completed' });
+      if (userDataId) {
+        await createKycLog(
+          +userDataId,
+          buildKycLogMessage({
+            description: 'BankData',
+            clerk,
+            results: [
+              { table: 'bankData', column: 'approved', value: 'true' },
+              { table: 'bankData', column: 'manualApproved', value: 'true' },
+              { table: 'bankData', column: 'status', value: 'Completed' },
+            ],
+          }),
+        );
+      }
       loadData();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Error approving');
@@ -190,14 +234,78 @@ export default function ComplianceReviewScreen(): JSX.Element {
     }
   }
 
-  async function handleBankDataReject(bankDataId: number): Promise<void> {
+  async function handleBankDataReject(bankDataId: number, clerk: string): Promise<void> {
     setIsSaving(true);
     setError(undefined);
     try {
       await updateBankData(bankDataId, { manualApproved: false, approved: false, status: 'Failed' });
+      if (userDataId) {
+        await createKycLog(
+          +userDataId,
+          buildKycLogMessage({
+            description: 'BankData',
+            clerk,
+            results: [
+              { table: 'bankData', column: 'approved', value: 'false' },
+              { table: 'bankData', column: 'manualApproved', value: 'false' },
+              { table: 'bankData', column: 'status', value: 'Failed' },
+            ],
+          }),
+        );
+      }
       loadData();
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Error rejecting');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleAmlUpdate(tx: TransactionInfo, update: AmlCheckUpdate, clerk: string): Promise<void> {
+    setIsSaving(true);
+    setError(undefined);
+    try {
+      const isBc = tx.buyCryptoId != null;
+      const table = isBc ? 'buyCrypto' : 'buyFiat';
+      if (isBc) await updateBuyCrypto(tx.buyCryptoId as number, update);
+      else if (tx.buyFiatId != null) await updateBuyFiat(tx.buyFiatId, update);
+      if (userDataId) {
+        const results: KycLogResult[] = [];
+        if (update.amlCheck) results.push({ table, column: 'amlCheck', value: update.amlCheck });
+        if (update.amlReason) results.push({ table, column: 'amlReason', value: update.amlReason });
+        if (update.priceDefinitionAllowedDate)
+          results.push({ table, column: 'priceDefinitionAllowedDate', value: update.priceDefinitionAllowedDate });
+        await createKycLog(+userDataId, buildKycLogMessage({ description: 'AmlCheck', clerk, results }));
+      }
+      loadData();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Error saving');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleAmlReset(tx: TransactionInfo, clerk: string): Promise<void> {
+    setIsSaving(true);
+    setError(undefined);
+    try {
+      const isBc = tx.buyCryptoId != null;
+      const table = isBc ? 'buyCrypto' : 'buyFiat';
+      if (isBc) await resetBuyCryptoAml(tx.buyCryptoId as number);
+      else if (tx.buyFiatId != null) await resetBuyFiatAml(tx.buyFiatId);
+      if (userDataId) {
+        await createKycLog(
+          +userDataId,
+          buildKycLogMessage({
+            description: 'AmlCheck',
+            clerk,
+            results: [{ table, column: 'amlCheck', value: 'Reset' }],
+          }),
+        );
+      }
+      loadData();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Error resetting');
     } finally {
       setIsSaving(false);
     }
@@ -338,13 +446,20 @@ export default function ComplianceReviewScreen(): JSX.Element {
               isSaving={isSaving}
             />
           ) : effectiveTab === 'stammdaten' ? (
-            <StammdatenPanel data={data} onOpenFile={openFile} onSave={handleSave} isSaving={isSaving} />
+            <StammdatenPanel
+              data={data}
+              clerks={clerks}
+              onOpenFile={openFile}
+              onSave={handleSave}
+              isSaving={isSaving}
+            />
           ) : effectiveTab === 'ident' ? (
-            <IdentPanel data={data} onOpenFile={openFile} onSave={handleSave} isSaving={isSaving} />
+            <IdentPanel data={data} clerks={clerks} onOpenFile={openFile} onSave={handleSave} isSaving={isSaving} />
           ) : effectiveTab === 'bankDataReview' ? (
             <BankDataReviewPanel
               bankDatas={data.bankDatas}
               userData={data.userData}
+              clerks={clerks}
               onApprove={handleBankDataApprove}
               onReject={handleBankDataReject}
               isSaving={isSaving}
@@ -352,12 +467,10 @@ export default function ComplianceReviewScreen(): JSX.Element {
           ) : effectiveTab === 'amlPending' ? (
             <AmlCheckPendingPanel
               data={data}
-              onUpdateBuyCrypto={updateBuyCrypto}
-              onUpdateBuyFiat={updateBuyFiat}
-              onResetBuyCryptoAml={resetBuyCryptoAml}
-              onResetBuyFiatAml={resetBuyFiatAml}
+              clerks={clerks}
               isSaving={isSaving}
-              onReload={loadData}
+              onUpdate={handleAmlUpdate}
+              onReset={handleAmlReset}
             />
           ) : (
             <ComplianceReviewPanel
@@ -370,6 +483,7 @@ export default function ComplianceReviewScreen(): JSX.Element {
               rejectionReasons={activeConfig.rejectionReasons}
               userData={data.userData}
               kycSteps={data.kycSteps}
+              clerks={clerks}
               onOpenFile={openFile}
               onSave={handleSave}
               isSaving={isSaving}

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -396,7 +396,11 @@
     "No entries found": "Keine Einträge gefunden",
     "found by {{type}}": "gefunden per {{type}}",
     "Customers": "Kunden",
-    "Bank Transactions": "Banktransaktionen"
+    "Bank Transactions": "Banktransaktionen",
+    "AmlCheck": "AmlCheck",
+    "No change": "keine Änderung",
+    "blocked": "gesperrt",
+    "Pass only allowed when all errors are phone-related": "Pass nur erlaubt, wenn alle Errors Phone-bezogen sind"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -396,7 +396,11 @@
     "No entries found": "Aucune entrée trouvée",
     "found by {{type}}": "trouvés par {{type}}",
     "Customers": "Clients",
-    "Bank Transactions": "Transactions bancaires"
+    "Bank Transactions": "Transactions bancaires",
+    "AmlCheck": "AmlCheck",
+    "No change": "aucun changement",
+    "blocked": "bloqué",
+    "Pass only allowed when all errors are phone-related": "Pass autorisé uniquement si toutes les erreurs sont liées au téléphone"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -396,7 +396,11 @@
     "No entries found": "Nessuna voce trovata",
     "found by {{type}}": "trovati tramite {{type}}",
     "Customers": "Clienti",
-    "Bank Transactions": "Transazioni bancarie"
+    "Bank Transactions": "Transazioni bancarie",
+    "AmlCheck": "AmlCheck",
+    "No change": "nessuna modifica",
+    "blocked": "bloccato",
+    "Pass only allowed when all errors are phone-related": "Pass consentito solo se tutti gli errori sono relativi al telefono"
   },
   "screens/2fa": {
     "2FA": "2FA",

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -225,3 +225,22 @@ export function buildAddress(parts?: {
   ].filter((l): l is string => Boolean(l && l.length));
   return lines.length > 0 ? lines.join(', ') : '-';
 }
+
+export interface KycLogResult {
+  table: string;
+  column: string;
+  value: string;
+}
+
+export function buildKycLogMessage(parts: {
+  description: string;
+  clerk: string;
+  results: KycLogResult[];
+  comment?: string;
+}): string {
+  const resultStr = parts.results.map((r) => `${r.table}-${r.column}-${r.value}`).join(', ');
+  const sections = [`Services - ${parts.description}`, `Editor: ${parts.clerk.trim()}`, `result: ${resultStr}`];
+  const comment = parts.comment?.trim();
+  if (comment) sections.push(`comment: ${comment}`);
+  return sections.join('; ');
+}


### PR DESCRIPTION
## Summary
- Add clerk selection to AML check and call queue outcome panels
- Write KYC log entries for AML checks, compliance review and bank data updates (single source of truth via `buildKycLogMessage`)
- Restrict manual pass to phone-related errors via the new `canManualPass` helper
- Bump `@dfx.swiss/react` to `^1.4.0-beta.0` and `@dfx.swiss/react-components` to `^1.3.2`

## Test plan
- [ ] Compliance review: approve a KYC step and verify a KYC log entry is created with the selected clerk
- [ ] AML check panel: PASS / FAIL / PENDING / Reset on Buy-Crypto and Buy-Fiat transactions
- [ ] Call queue outcome: manual pass disabled unless all errors are phone-related
- [ ] Compliance review on bank data update: KYC log entry written
- [ ] Lint, typecheck, tests, build all green