### PR TITLE
feat(support): add support notes tab and screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ const ComplianceCallQueueDetailScreen = lazy(() => import('./screens/compliance-
 const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
 const SupportDashboardIssueScreen = lazy(() => import('./screens/support-dashboard-issue.screen'));
 const SupportDashboardCreateScreen = lazy(() => import('./screens/support-dashboard-create.screen'));
+const NotesScreen = lazy(() => import('./screens/notes.screen'));
 const RealunitScreen = lazy(() => import('./screens/realunit.screen'));
 const RealunitHoldersScreen = lazy(() => import('./screens/realunit-holders.screen'));
 const RealunitQuotesScreen = lazy(() => import('./screens/realunit-quotes.screen'));
@@ -457,6 +458,10 @@ export const Routes = [
       {
         path: 'support/dashboard/create',
         element: withSuspense(<SupportDashboardCreateScreen />),
+      },
+      {
+        path: 'notes',
+        element: withSuspense(<NotesScreen />),
       },
       {
         path: 'realunit',

--- a/src/components/compliance/note-composer.tsx
+++ b/src/components/compliance/note-composer.tsx
@@ -1,0 +1,137 @@
+import { Department, useAuthContext, UserRole } from '@dfx.swiss/react';
+import { useState } from 'react';
+import { useCompliance } from 'src/hooks/compliance.hook';
+import { adminDeptOptions } from './note-utils';
+
+interface Props {
+  // Fixed user data id (NotesTab). Ignored when allowUserDataIdInput is true.
+  userDataId?: number;
+  allowUserDataIdInput?: boolean;
+  // Pre-fills the user data id input when allowUserDataIdInput is true (e.g. deep link from a user).
+  initialUserDataId?: string;
+  submitLabel?: string;
+  contentPlaceholder?: string;
+  onCreated: () => void;
+}
+
+export function NoteComposer({
+  userDataId,
+  allowUserDataIdInput,
+  initialUserDataId,
+  submitLabel,
+  contentPlaceholder,
+  onCreated,
+}: Readonly<Props>): JSX.Element {
+  const { session } = useAuthContext();
+  const role = session?.role;
+  const isAdmin = role === UserRole.ADMIN;
+  const adminOptions = adminDeptOptions(role);
+
+  const { createSupportNote } = useCompliance();
+
+  const [subject, setSubject] = useState('');
+  const [content, setContent] = useState('');
+  const [department, setDepartment] = useState<Department | ''>('');
+  const [userDataIdInput, setUserDataIdInput] = useState(initialUserDataId ?? '');
+  const [error, setError] = useState<string>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function resolveUserDataId(): { value?: number; error?: string } {
+    if (!allowUserDataIdInput) return { value: userDataId };
+    const trimmed = userDataIdInput.trim();
+    if (!trimmed) return { value: undefined };
+    const n = Number(trimmed);
+    if (Number.isNaN(n) || n < 1) return { error: 'Invalid user data id' };
+    return { value: n };
+  }
+
+  async function handleSubmit(): Promise<void> {
+    if (!content.trim()) return;
+    if (isAdmin && !department) {
+      setError('Please select a department');
+      return;
+    }
+    const resolved = resolveUserDataId();
+    if (resolved.error) {
+      setError(resolved.error);
+      return;
+    }
+
+    setError(undefined);
+    setIsSubmitting(true);
+    try {
+      await createSupportNote(content.trim(), {
+        userDataId: resolved.value,
+        subject: subject.trim() || undefined,
+        department: department || undefined,
+      });
+      setSubject('');
+      setContent('');
+      setDepartment('');
+      setUserDataIdInput('');
+      onCreated();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to save note');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {isAdmin && (
+        <select
+          className="px-2 py-1 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800 self-start"
+          value={department}
+          onChange={(e) => setDepartment(e.target.value as Department | '')}
+          disabled={isSubmitting}
+        >
+          <option value="">— Department —</option>
+          {adminOptions.map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+        </select>
+      )}
+      {allowUserDataIdInput && (
+        <input
+          type="text"
+          className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+          value={userDataIdInput}
+          onChange={(e) => setUserDataIdInput(e.target.value)}
+          placeholder="User Data ID (optional)"
+          inputMode="numeric"
+          disabled={isSubmitting}
+        />
+      )}
+      <input
+        type="text"
+        className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+        value={subject}
+        onChange={(e) => setSubject(e.target.value)}
+        placeholder="Betreff (optional)"
+        maxLength={256}
+        disabled={isSubmitting}
+      />
+      <textarea
+        className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-h-[80px]"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder={contentPlaceholder ?? 'Neue Notiz...'}
+        disabled={isSubmitting}
+      />
+      {error && <p className="text-sm text-dfxRed-100">{error}</p>}
+      <div className="flex justify-end">
+        <button
+          type="button"
+          className="px-4 py-1.5 text-sm font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors disabled:opacity-50"
+          onClick={handleSubmit}
+          disabled={isSubmitting || !content.trim() || (isAdmin && !department)}
+        >
+          {isSubmitting ? 'Speichern...' : (submitLabel ?? 'Notiz hinzufügen')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/compliance/note-list.tsx
+++ b/src/components/compliance/note-list.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ConfirmDialog } from 'src/components/confirm-dialog';
+import { SupportNoteInfo, useCompliance } from 'src/hooks/compliance.hook';
+import { formatDateTime } from 'src/util/compliance-helpers';
+import { deptBadge } from './note-utils';
+
+interface Props {
+  notes: SupportNoteInfo[];
+  showUserDataIdLink?: boolean;
+  emptyMessage?: string;
+  onChange: () => void;
+}
+
+export function NoteList({ notes, showUserDataIdLink, emptyMessage, onChange }: Readonly<Props>): JSX.Element {
+  const navigate = useNavigate();
+  const { updateSupportNote, deleteSupportNote } = useCompliance();
+
+  const [editingId, setEditingId] = useState<number>();
+  const [editSubject, setEditSubject] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const [error, setError] = useState<string>();
+
+  const [deleteId, setDeleteId] = useState<number>();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  function startEdit(note: SupportNoteInfo): void {
+    setEditingId(note.id);
+    setEditSubject(note.subject ?? '');
+    setEditContent(note.content);
+  }
+
+  async function handleUpdate(id: number): Promise<void> {
+    if (!editContent.trim()) return;
+    try {
+      await updateSupportNote(id, editContent.trim(), { subject: editSubject.trim() || undefined });
+      setEditingId(undefined);
+      onChange();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to update note');
+    }
+  }
+
+  async function confirmDelete(): Promise<void> {
+    if (deleteId == null) return;
+    setIsDeleting(true);
+    try {
+      await deleteSupportNote(deleteId);
+      setDeleteId(undefined);
+      onChange();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to delete note');
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  if (notes.length === 0) {
+    return (
+      <div className="bg-white rounded-lg shadow-sm p-4 text-center text-dfxGray-700 text-sm">
+        {emptyMessage ?? 'Keine Notizen vorhanden.'}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {error && <p className="text-sm text-dfxRed-100">{error}</p>}
+      {notes.map((note) => {
+        const canModify = note.isOwn || note.isAdmin;
+        const isEditing = editingId === note.id;
+        return (
+          <div key={note.id} className="bg-white rounded-lg shadow-sm p-3 flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2 flex-wrap">
+              <div className="flex items-center gap-2 text-xs text-dfxGray-700 flex-wrap">
+                {deptBadge(note.department)}
+                <span>{note.authorMail}</span>
+                <span>·</span>
+                <span>{formatDateTime(note.created)}</span>
+                {note.updated && note.updated !== note.created && (
+                  <>
+                    <span>·</span>
+                    <span title={`Updated: ${formatDateTime(note.updated)}`}>(bearbeitet)</span>
+                  </>
+                )}
+                {showUserDataIdLink && note.userDataId != null && (
+                  <>
+                    <span>·</span>
+                    <button
+                      type="button"
+                      className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
+                      onClick={() => navigate(`/support/user/${note.userDataId}`)}
+                    >
+                      UserData #{note.userDataId}
+                    </button>
+                    {note.userName && <span>({note.userName})</span>}
+                  </>
+                )}
+              </div>
+              {canModify && !isEditing && (
+                <div className="flex gap-1">
+                  <button
+                    type="button"
+                    className="px-2 py-0.5 text-xs text-dfxBlue-800 hover:bg-dfxGray-300 rounded transition-colors"
+                    onClick={() => startEdit(note)}
+                    title="Edit"
+                  >
+                    ✏️
+                  </button>
+                  <button
+                    type="button"
+                    className="px-2 py-0.5 text-xs text-dfxBlue-800 hover:bg-dfxRed-100/20 rounded transition-colors"
+                    onClick={() => setDeleteId(note.id)}
+                    title="Delete"
+                  >
+                    🗑️
+                  </button>
+                </div>
+              )}
+            </div>
+            {isEditing ? (
+              <>
+                <input
+                  type="text"
+                  className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                  value={editSubject}
+                  onChange={(e) => setEditSubject(e.target.value)}
+                  placeholder="Betreff (optional)"
+                  maxLength={256}
+                />
+                <textarea
+                  className="w-full px-3 py-2 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-h-[80px]"
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                />
+                <div className="flex gap-2 justify-end">
+                  <button
+                    type="button"
+                    className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 rounded hover:bg-dfxGray-400 transition-colors"
+                    onClick={() => setEditingId(undefined)}
+                  >
+                    Abbrechen
+                  </button>
+                  <button
+                    type="button"
+                    className="px-3 py-1 text-xs font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors disabled:opacity-50"
+                    onClick={() => handleUpdate(note.id)}
+                    disabled={!editContent.trim()}
+                  >
+                    Speichern
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                {note.subject && <p className="text-sm font-semibold text-dfxBlue-800 text-left">{note.subject}</p>}
+                <p className="text-sm text-dfxBlue-800 whitespace-pre-wrap text-left">{note.content}</p>
+              </>
+            )}
+          </div>
+        );
+      })}
+      <ConfirmDialog
+        isOpen={deleteId != null}
+        title="Notiz löschen"
+        message="Möchtest du diese Notiz wirklich löschen?"
+        confirmLabel="Löschen"
+        cancelLabel="Abbrechen"
+        destructive
+        isLoading={isDeleting}
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteId(undefined)}
+      />
+    </>
+  );
+}

--- a/src/components/compliance/note-utils.tsx
+++ b/src/components/compliance/note-utils.tsx
@@ -1,0 +1,17 @@
+import { Department, UserRole } from '@dfx.swiss/react';
+
+const DEPT_BADGE: Record<Department, string> = {
+  [Department.SUPPORT]: 'bg-dfxGray-300 text-dfxBlue-800',
+  [Department.COMPLIANCE]: 'bg-dfxBlue-300/20 text-dfxBlue-400',
+  [Department.MARKETING]: 'bg-dfxGreen-100/20 text-dfxGreen-300',
+  [Department.COOPERATION]: 'bg-dfxGray-400 text-dfxBlue-800',
+};
+
+export function deptBadge(dept: Department): JSX.Element {
+  const classes = DEPT_BADGE[dept] ?? 'bg-dfxGray-300 text-dfxBlue-800';
+  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${classes}`}>{dept}</span>;
+}
+
+export function adminDeptOptions(role: UserRole | undefined): Department[] {
+  return role === UserRole.ADMIN ? [Department.SUPPORT, Department.COMPLIANCE, Department.MARKETING] : [];
+}

--- a/src/components/compliance/notes-tab.tsx
+++ b/src/components/compliance/notes-tab.tsx
@@ -1,0 +1,20 @@
+import { SupportNoteInfo } from 'src/hooks/compliance.hook';
+import { NoteComposer } from './note-composer';
+import { NoteList } from './note-list';
+
+interface Props {
+  notes: SupportNoteInfo[];
+  userDataId: number;
+  onChange: () => void;
+}
+
+export function NotesTab({ notes, userDataId, onChange }: Readonly<Props>): JSX.Element {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="bg-white rounded-lg shadow-sm p-3">
+        <NoteComposer userDataId={userDataId} onCreated={onChange} />
+      </div>
+      <NoteList notes={notes} onChange={onChange} />
+    </div>
+  );
+}

--- a/src/components/compliance/user-data-panel.tsx
+++ b/src/components/compliance/user-data-panel.tsx
@@ -12,6 +12,7 @@ interface UserDataPanelProps {
   canCopyKycLinks?: boolean;
   wide?: boolean;
   onLimitRequestCreated?: () => void;
+  onCreateNote?: () => void;
 }
 
 function kycServicesBaseUrl(): string {
@@ -99,9 +100,9 @@ function SectionTable({
   );
 }
 
-function userDataRows(d: UserDataDetail, depositLimitNode: ReactNode): Row[] {
+function userDataRows(d: UserDataDetail, depositLimitNode: ReactNode, idNode: ReactNode): Row[] {
   return [
-    { key: 'id', value: display(d.id) },
+    { key: 'id', value: idNode },
     { key: 'created', value: fmtDateTime(d.created) },
     { key: 'status', value: display(d.status) },
     { key: 'riskStatus', value: display(d.riskStatus) },
@@ -210,6 +211,7 @@ export function UserDataPanel({
   canCopyKycLinks = false,
   wide = false,
   onLimitRequestCreated,
+  onCreateNote,
 }: Readonly<UserDataPanelProps>): JSX.Element {
   const [showLimitRequestModal, setShowLimitRequestModal] = useState(false);
 
@@ -228,12 +230,26 @@ export function UserDataPanel({
       display(userData.depositLimit)
     );
 
+  const idNode: ReactNode = onCreateNote ? (
+    <div className="flex items-center justify-between gap-2">
+      <span>{display(userData.id)}</span>
+      <button
+        className="px-3 py-1 text-xs text-white bg-dfxBlue-800 hover:bg-dfxBlue-800/80 rounded transition-colors whitespace-nowrap"
+        onClick={onCreateNote}
+      >
+        Notiz erstellen
+      </button>
+    </div>
+  ) : (
+    display(userData.id)
+  );
+
   return (
     <>
       <div className={`${wide ? 'w-full' : 'w-1/2'} min-w-0`}>
         <div className="bg-white rounded-lg shadow-sm divide-y divide-dfxGray-300">
           <CollapsibleSection title="UserData" initiallyOpen>
-            <SectionTable rows={userDataRows(userData, depositLimitNode)} />
+            <SectionTable rows={userDataRows(userData, depositLimitNode, idNode)} />
           </CollapsibleSection>
 
           <CollapsibleSection title="Personal Data" initiallyOpen>

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -7,6 +7,7 @@ import {
   CallQueueSourceType,
   CallQueueSummaryEntry,
   CheckStatus,
+  Department,
   Fiat,
   FundOrigin,
   InvestmentDate,
@@ -343,6 +344,28 @@ export interface SupportPermissions {
   viewRecommendation: boolean;
 }
 
+export interface SupportNoteInfo {
+  id: number;
+  department: Department;
+  authorMail: string;
+  subject?: string;
+  content: string;
+  userDataId?: number;
+  userName?: string;
+  isOwn: boolean;
+  isAdmin: boolean;
+  created: string;
+  updated: string;
+}
+
+export type SupportNoteScope = 'all' | 'free' | 'bound';
+
+export interface SupportNoteUser {
+  userDataId: number;
+  name: string;
+  count: number;
+}
+
 export interface ComplianceUserData {
   userData: UserDataDetail;
   kycFiles?: KycFile[];
@@ -361,6 +384,7 @@ export interface ComplianceUserData {
   virtualIbans: VirtualIbanInfo[];
   refRewards: RefRewardInfo[];
   notifications: NotificationInfo[];
+  notes: SupportNoteInfo[];
   permissions: SupportPermissions;
 }
 
@@ -1076,6 +1100,71 @@ export function useCompliance() {
     });
   }
 
+  async function getSupportNotes(userDataId: number): Promise<SupportNoteInfo[]> {
+    return call<SupportNoteInfo[]>({
+      url: `support/note?userDataId=${userDataId}`,
+      method: 'GET',
+    });
+  }
+
+  async function listSupportNotes(params: {
+    search?: string;
+    scope?: SupportNoteScope;
+    userDataId?: number;
+  }): Promise<SupportNoteInfo[]> {
+    const qs = new URLSearchParams();
+    if (params.search) qs.set('search', params.search);
+    if (params.scope) qs.set('scope', params.scope);
+    if (params.userDataId != null) qs.set('userDataId', String(params.userDataId));
+    const query = qs.toString();
+    return call<SupportNoteInfo[]>({
+      url: `support/note/list${query ? `?${query}` : ''}`,
+      method: 'GET',
+    });
+  }
+
+  async function listSupportNoteUsers(): Promise<SupportNoteUser[]> {
+    return call<SupportNoteUser[]>({
+      url: 'support/note/users',
+      method: 'GET',
+    });
+  }
+
+  async function createSupportNote(
+    content: string,
+    options?: { userDataId?: number; subject?: string; department?: Department },
+  ): Promise<SupportNoteInfo> {
+    return call<SupportNoteInfo>({
+      url: 'support/note',
+      method: 'POST',
+      data: {
+        userDataId: options?.userDataId,
+        subject: options?.subject,
+        content,
+        department: options?.department,
+      },
+    });
+  }
+
+  async function updateSupportNote(
+    id: number,
+    content: string,
+    options?: { subject?: string },
+  ): Promise<SupportNoteInfo> {
+    return call<SupportNoteInfo>({
+      url: `support/note/${id}`,
+      method: 'PUT',
+      data: { content, subject: options?.subject },
+    });
+  }
+
+  async function deleteSupportNote(id: number): Promise<void> {
+    return call<void>({
+      url: `support/note/${id}`,
+      method: 'DELETE',
+    });
+  }
+
   return useMemo(
     () => ({
       search,
@@ -1117,6 +1206,12 @@ export function useCompliance() {
       updateBuyFiat,
       resetBuyCryptoAml,
       resetBuyFiatAml,
+      getSupportNotes,
+      listSupportNotes,
+      listSupportNoteUsers,
+      createSupportNote,
+      updateSupportNote,
+      deleteSupportNote,
     }),
     [call],
   );

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -358,7 +358,7 @@ export interface SupportNoteInfo {
   updated: string;
 }
 
-export type SupportNoteScope = 'all' | 'free' | 'bound';
+export type SupportNoteScope = 'All' | 'Free' | 'Bound';
 
 export interface SupportNoteUser {
   userDataId: number;
@@ -1100,13 +1100,6 @@ export function useCompliance() {
     });
   }
 
-  async function getSupportNotes(userDataId: number): Promise<SupportNoteInfo[]> {
-    return call<SupportNoteInfo[]>({
-      url: `support/note?userDataId=${userDataId}`,
-      method: 'GET',
-    });
-  }
-
   async function listSupportNotes(params: {
     search?: string;
     scope?: SupportNoteScope;
@@ -1117,8 +1110,9 @@ export function useCompliance() {
     if (params.scope) qs.set('scope', params.scope);
     if (params.userDataId != null) qs.set('userDataId', String(params.userDataId));
     const query = qs.toString();
+    const suffix = query ? `?${query}` : '';
     return call<SupportNoteInfo[]>({
-      url: `support/note/list${query ? `?${query}` : ''}`,
+      url: `support/note${suffix}`,
       method: 'GET',
     });
   }
@@ -1206,7 +1200,6 @@ export function useCompliance() {
       updateBuyFiat,
       resetBuyCryptoAml,
       resetBuyFiatAml,
-      getSupportNotes,
       listSupportNotes,
       listSupportNoteUsers,
       createSupportNote,

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -17,6 +17,7 @@ import {
 import { FilePreviewPanel } from 'src/components/compliance/file-preview-panel';
 import { IpLogsPanel } from 'src/components/compliance/ip-logs-panel';
 import { KycFilesPanel } from 'src/components/compliance/kyc-files-panel';
+import { NotesTab } from 'src/components/compliance/notes-tab';
 import { RecommendationPanel } from 'src/components/compliance/recommendation-panel';
 import { SupportIssuesPanel } from 'src/components/compliance/support-issues-panel';
 import { SupportUserOverviewPanel } from 'src/components/compliance/support-user-overview-panel';
@@ -40,7 +41,8 @@ type TabType =
   | 'swapRoutes'
   | 'virtualIbans'
   | 'refRewards'
-  | 'notifications';
+  | 'notifications'
+  | 'notes';
 
 interface TabConfig {
   id: TabType;
@@ -154,6 +156,7 @@ export default function ComplianceUserScreen(): JSX.Element {
     { id: 'swapRoutes', label: 'Swap Routes', count: data.swapRoutes?.length || 0 },
     { id: 'refRewards', label: 'Ref Rewards', count: data.refRewards?.length || 0 },
     { id: 'notifications', label: 'Notifications', count: data.notifications?.length || 0 },
+    { id: 'notes', label: 'Notes', count: data.notes?.length ?? 0 },
   ];
 
   return (
@@ -168,6 +171,7 @@ export default function ComplianceUserScreen(): JSX.Element {
             canCopyKycLinks={canCopyKycLinks}
             wide={isSupport}
             onLimitRequestCreated={loadData}
+            onCreateNote={() => navigate(`/notes?userDataId=${numericUserDataId}&compose=1`)}
           />
 
           {!isSupport && (
@@ -263,6 +267,9 @@ export default function ComplianceUserScreen(): JSX.Element {
           {activeTab === 'virtualIbans' && <VirtualIbansTable virtualIbans={data.virtualIbans} />}
           {activeTab === 'refRewards' && <RefRewardsTable refRewards={data.refRewards} />}
           {activeTab === 'notifications' && <NotificationsTable notifications={data.notifications} />}
+          {activeTab === 'notes' && (
+            <NotesTab notes={data.notes ?? []} userDataId={numericUserDataId} onChange={loadData} />
+          )}
         </div>
       </div>
     </div>

--- a/src/screens/notes.screen.tsx
+++ b/src/screens/notes.screen.tsx
@@ -8,7 +8,7 @@ import { SupportNoteInfo, SupportNoteScope, SupportNoteUser, useCompliance } fro
 import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 
-type Scope = Extract<SupportNoteScope, 'all' | 'free'>;
+type Scope = Extract<SupportNoteScope, 'All' | 'Free'>;
 
 export default function NotesScreen(): JSX.Element {
   useSupportDashboardGuard();
@@ -20,7 +20,7 @@ export default function NotesScreen(): JSX.Element {
   const [notes, setNotes] = useState<SupportNoteInfo[]>([]);
   const [search, setSearch] = useState('');
   const [submittedSearch, setSubmittedSearch] = useState('');
-  const [scope, setScope] = useState<Scope>('all');
+  const [scope, setScope] = useState<Scope>('All');
   const [error, setError] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -39,9 +39,10 @@ export default function NotesScreen(): JSX.Element {
   const loadNotes = useCallback(() => {
     setIsLoading(true);
     setError(undefined);
+    const effectiveScope = selectedUser || scope === 'All' ? undefined : scope;
     listSupportNotes({
       search: submittedSearch || undefined,
-      scope: selectedUser ? undefined : scope === 'all' ? undefined : scope,
+      scope: effectiveScope,
       userDataId: selectedUser?.userDataId,
     })
       .then(setNotes)
@@ -116,7 +117,7 @@ export default function NotesScreen(): JSX.Element {
     setSelectedUser(user);
     setCustomerQuery('');
     setShowSuggestions(false);
-    if (scope === 'free') setScope('all');
+    if (scope === 'Free') setScope('All');
   }
 
   function clearUser(): void {
@@ -126,7 +127,7 @@ export default function NotesScreen(): JSX.Element {
 
   function handleScopeChange(next: Scope): void {
     setScope(next);
-    if (next === 'free' && selectedUser) clearUser();
+    if (next === 'Free' && selectedUser) clearUser();
   }
 
   return (
@@ -164,8 +165,8 @@ export default function NotesScreen(): JSX.Element {
             disabled={selectedUser != null}
             title={selectedUser ? 'Filter ist auf einen Kunden eingeschränkt' : undefined}
           >
-            <option value="all">Alle</option>
-            <option value="free">Ohne Kundenbezug</option>
+            <option value="All">Alle</option>
+            <option value="Free">Ohne Kundenbezug</option>
           </select>
 
           <div ref={customerBoxRef} className="relative min-w-[220px]">

--- a/src/screens/notes.screen.tsx
+++ b/src/screens/notes.screen.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { NoteComposer } from 'src/components/compliance/note-composer';
+import { NoteList } from 'src/components/compliance/note-list';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { SupportNoteInfo, SupportNoteScope, SupportNoteUser, useCompliance } from 'src/hooks/compliance.hook';
+import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+type Scope = Extract<SupportNoteScope, 'all' | 'free'>;
+
+export default function NotesScreen(): JSX.Element {
+  useSupportDashboardGuard();
+  const { translate } = useSettingsContext();
+
+  const { listSupportNotes, listSupportNoteUsers } = useCompliance();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [notes, setNotes] = useState<SupportNoteInfo[]>([]);
+  const [search, setSearch] = useState('');
+  const [submittedSearch, setSubmittedSearch] = useState('');
+  const [scope, setScope] = useState<Scope>('all');
+  const [error, setError] = useState<string>();
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Customer filter (autocomplete)
+  const [users, setUsers] = useState<SupportNoteUser[]>([]);
+  const [selectedUser, setSelectedUser] = useState<SupportNoteUser>();
+  const [customerQuery, setCustomerQuery] = useState('');
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const customerBoxRef = useRef<HTMLDivElement>(null);
+
+  const [showCompose, setShowCompose] = useState(searchParams.get('compose') === '1');
+  const [initialUserDataId] = useState(searchParams.get('userDataId') ?? '');
+
+  useLayoutOptions({ title: translate('screens/compliance', 'Notes'), backButton: true, noMaxWidth: true });
+
+  const loadNotes = useCallback(() => {
+    setIsLoading(true);
+    setError(undefined);
+    listSupportNotes({
+      search: submittedSearch || undefined,
+      scope: selectedUser ? undefined : scope === 'all' ? undefined : scope,
+      userDataId: selectedUser?.userDataId,
+    })
+      .then(setNotes)
+      .catch((e: unknown) => setError(e instanceof Error ? e.message : 'Failed to load notes'))
+      .finally(() => setIsLoading(false));
+  }, [listSupportNotes, submittedSearch, scope, selectedUser]);
+
+  useEffect(() => {
+    loadNotes();
+  }, [loadNotes]);
+
+  const loadUsers = useCallback(() => {
+    listSupportNoteUsers()
+      .then((fetched) => {
+        setUsers(fetched);
+        // Reset filter if selected user no longer has notes
+        setSelectedUser((prev) => (prev && fetched.some((u) => u.userDataId === prev.userDataId) ? prev : undefined));
+      })
+      .catch(() => undefined);
+  }, [listSupportNoteUsers]);
+
+  useEffect(() => {
+    loadUsers();
+  }, [loadUsers]);
+
+  const refreshAll = useCallback(() => {
+    loadNotes();
+    loadUsers();
+  }, [loadNotes, loadUsers]);
+
+  // Drop compose/userDataId params from the URL after they have been consumed
+  // so that a reload does not re-open the compose dialog. Only runs once on mount.
+  useEffect(() => {
+    if (searchParams.has('compose') || searchParams.has('userDataId')) {
+      const next = new URLSearchParams(searchParams);
+      next.delete('compose');
+      next.delete('userDataId');
+      setSearchParams(next, { replace: true });
+    }
+  }, []);
+
+  // Close suggestions on outside click
+  useEffect(() => {
+    function onDocClick(e: MouseEvent): void {
+      if (!customerBoxRef.current?.contains(e.target as Node)) setShowSuggestions(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, []);
+
+  const filteredUsers = useMemo(() => {
+    const q = customerQuery.trim().toLowerCase();
+    if (!q) return users.slice(0, 20);
+    return users.filter((u) => u.name.toLowerCase().includes(q)).slice(0, 20);
+  }, [users, customerQuery]);
+
+  function submitSearch(): void {
+    setSubmittedSearch(search.trim());
+  }
+
+  function resetSearch(): void {
+    setSearch('');
+    setSubmittedSearch('');
+  }
+
+  function handleCreated(): void {
+    setShowCompose(false);
+    refreshAll();
+  }
+
+  function selectUser(user: SupportNoteUser): void {
+    setSelectedUser(user);
+    setCustomerQuery('');
+    setShowSuggestions(false);
+    if (scope === 'free') setScope('all');
+  }
+
+  function clearUser(): void {
+    setSelectedUser(undefined);
+    setCustomerQuery('');
+  }
+
+  function handleScopeChange(next: Scope): void {
+    setScope(next);
+    if (next === 'free' && selectedUser) clearUser();
+  }
+
+  return (
+    <div className="w-full flex flex-col gap-4 text-left">
+      <div className="bg-white rounded-lg shadow-sm p-3 flex flex-col gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="text"
+            className="px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800 flex-1 min-w-[200px]"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && submitSearch()}
+            placeholder={translate('screens/compliance', 'Search subject, content or name')}
+          />
+          <button
+            type="button"
+            className="px-3 py-1.5 text-xs font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors"
+            onClick={submitSearch}
+          >
+            {translate('general/actions', 'Search')}
+          </button>
+          {submittedSearch && (
+            <button
+              type="button"
+              className="px-3 py-1.5 text-xs font-medium bg-dfxGray-300 text-dfxBlue-800 rounded hover:bg-dfxGray-400 transition-colors"
+              onClick={resetSearch}
+            >
+              ✕
+            </button>
+          )}
+          <select
+            className="px-2 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+            value={scope}
+            onChange={(e) => handleScopeChange(e.target.value as Scope)}
+            disabled={selectedUser != null}
+            title={selectedUser ? 'Filter ist auf einen Kunden eingeschränkt' : undefined}
+          >
+            <option value="all">Alle</option>
+            <option value="free">Ohne Kundenbezug</option>
+          </select>
+
+          <div ref={customerBoxRef} className="relative min-w-[220px]">
+            {selectedUser ? (
+              <div className="flex items-center gap-1 px-2 py-1 text-sm border border-dfxGray-400 rounded bg-dfxBlue-300/20 text-dfxBlue-800">
+                <span className="truncate">
+                  {selectedUser.name} <span className="text-dfxGray-700">({selectedUser.count})</span>
+                </span>
+                <button
+                  type="button"
+                  className="ml-auto px-1 text-xs hover:text-dfxRed-100"
+                  onClick={clearUser}
+                  title="Filter zurücksetzen"
+                >
+                  ✕
+                </button>
+              </div>
+            ) : (
+              <input
+                type="text"
+                className="w-full px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
+                value={customerQuery}
+                onChange={(e) => {
+                  setCustomerQuery(e.target.value);
+                  setShowSuggestions(true);
+                }}
+                onFocus={() => setShowSuggestions(true)}
+                placeholder="Kunden Notes filtern"
+              />
+            )}
+            {!selectedUser && showSuggestions && filteredUsers.length > 0 && (
+              <ul className="absolute z-10 left-0 right-0 mt-1 max-h-64 overflow-auto bg-white border border-dfxGray-400 rounded shadow-lg text-sm">
+                {filteredUsers.map((u) => (
+                  <li key={u.userDataId}>
+                    <button
+                      type="button"
+                      className="w-full text-left px-3 py-1.5 hover:bg-dfxGray-300 text-dfxBlue-800 flex justify-between items-center gap-2"
+                      onClick={() => selectUser(u)}
+                    >
+                      <span className="truncate">
+                        {u.name || `UserData #${u.userDataId}`}{' '}
+                        <span className="text-dfxGray-700">#{u.userDataId}</span>
+                      </span>
+                      <span className="text-xs text-dfxGray-700">{u.count}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {!selectedUser && showSuggestions && filteredUsers.length === 0 && (
+              <div className="absolute z-10 left-0 right-0 mt-1 bg-white border border-dfxGray-400 rounded shadow-lg p-2 text-sm text-dfxGray-700">
+                Keine Kunden Notes gefunden
+              </div>
+            )}
+          </div>
+
+          <button
+            type="button"
+            className="ml-auto px-3 py-1.5 text-sm font-medium bg-dfxBlue-800 text-white rounded hover:bg-dfxBlue-800/80 transition-colors"
+            onClick={() => setShowCompose((v) => !v)}
+          >
+            {showCompose ? '× Abbrechen' : '+ Neue Notiz'}
+          </button>
+        </div>
+
+        {showCompose && (
+          <div className="border-t border-dfxGray-300 pt-2">
+            <NoteComposer
+              allowUserDataIdInput
+              initialUserDataId={selectedUser ? String(selectedUser.userDataId) : initialUserDataId}
+              submitLabel="Notiz speichern"
+              contentPlaceholder="Neue Notiz..."
+              onCreated={handleCreated}
+            />
+          </div>
+        )}
+      </div>
+
+      {error && <ErrorHint message={error} />}
+
+      {isLoading ? (
+        <div className="bg-white rounded-lg shadow-sm p-4 text-center text-dfxGray-700 text-sm">
+          {translate('screens/compliance', 'Loading...')}
+        </div>
+      ) : (
+        <NoteList
+          notes={notes}
+          showUserDataIdLink
+          emptyMessage={translate('screens/compliance', 'No entries found')}
+          onChange={refreshAll}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -223,6 +223,12 @@ export default function SupportDashboardScreen(): JSX.Element {
             {showCustomerSearch ? '−' : '+'} {translate('screens/support', 'Customer Search')}
           </button>
           <button
+            className="px-3 py-2 bg-white border border-dfxGray-400 text-dfxBlue-800 rounded-lg text-sm hover:bg-dfxGray-300 transition-colors"
+            onClick={() => navigate('/notes')}
+          >
+            {translate('screens/compliance', 'Notes')}
+          </button>
+          <button
             className="px-4 py-2 bg-dfxBlue-400 text-white rounded-lg text-sm hover:bg-dfxBlue-800 transition-colors"
             onClick={() => navigate('/support/dashboard/create')}
           >


### PR DESCRIPTION
## Summary
- New compliance user-detail `NotesTab` with composer and list components
- Standalone `notes.screen` linked from the support dashboard for cross-user search/management
- Hooks for fetching, creating, updating, deleting notes and listing note users
- Routing entry in `App.tsx`

## Companion API
- DFXswiss/api: `feat/support-notes` — adds `/support/note` endpoints

## Test plan
- [ ] Open a user in compliance → Notes tab shows existing notes and allows create/edit/delete
- [ ] Visit support dashboard → "Notes" entry navigates to notes screen
- [ ] Filter / search by user on notes screen
- [ ] Verify role-based visibility (Support vs Compliance)