### PR TITLE
feat(compliance): customer search improvements (DEV-4570)

### DIFF
--- a/src/components/compliance/detail-tabs.tsx
+++ b/src/components/compliance/detail-tabs.tsx
@@ -72,6 +72,7 @@ function DataTable<T extends { id: number }>({
 const usersColumns: ColumnDef<UserInfo>[] = [
   { header: 'ID', render: (u) => u.id },
   { header: 'Address', align: 'left', render: (u) => u.address, className: 'font-mono' },
+  { header: 'Wallet', align: 'left', render: (u) => u.walletName || '-' },
   { header: 'Ref', render: (u) => u.ref || '-' },
   { header: 'Role', render: (u) => u.role },
   { header: 'Status', render: (u) => u.status },
@@ -203,6 +204,30 @@ const sellRoutesColumns: ColumnDef<SellRouteInfo>[] = [
   { header: 'ID', render: (s) => s.id },
   { header: 'IBAN', align: 'left', render: (s) => s.iban, className: 'font-mono' },
   { header: 'Fiat', render: (s) => s.fiatName || '-' },
+  {
+    header: 'Deposit Address',
+    align: 'left',
+    render: (s) =>
+      s.depositAddress ? (
+        s.depositAddressExplorerUrl ? (
+          <a
+            href={s.depositAddressExplorerUrl}
+            target="_blank"
+            rel="noreferrer"
+            title={s.depositAddress}
+            className="text-dfxBlue-800 hover:underline"
+          >
+            {s.depositAddress}
+          </a>
+        ) : (
+          <span title={s.depositAddress}>{s.depositAddress}</span>
+        )
+      ) : (
+        '-'
+      ),
+    className: 'font-mono',
+  },
+  { header: 'Blockchain', align: 'left', render: (s) => s.depositBlockchains?.join(', ') || '-' },
   { header: 'Volume', align: 'right', render: (s) => s.volume?.toFixed(2) },
   { header: 'Active', render: (s) => boolBadge(s.active) },
   { header: 'Created', render: (s) => formatDate(s.created) },

--- a/src/components/compliance/user-data-panel.tsx
+++ b/src/components/compliance/user-data-panel.tsx
@@ -3,7 +3,7 @@ import { CollapsibleSection } from 'src/components/compliance/collapsible-sectio
 import { LimitRequestModal } from 'src/components/compliance/limit-request-modal';
 import { useClipboard } from 'src/hooks/clipboard.hook';
 import { OrganizationDetail, UserDataDetail } from 'src/hooks/compliance.hook';
-import { display, formatDate, formatDateTime, Primitive, refName } from 'src/util/compliance-helpers';
+import { calculateAge, display, formatDate, formatDateTime, Primitive, refName } from 'src/util/compliance-helpers';
 
 interface UserDataPanelProps {
   userData: UserDataDetail;
@@ -124,7 +124,7 @@ function personalDataRows(d: UserDataDetail): Row[] {
     { key: 'country', value: refName(d.country) },
     { key: 'nationality', value: refName(d.nationality) },
     { key: 'language', value: refName(d.language) },
-    { key: 'birthday', value: fmtDate(d.birthday) },
+    { key: 'birthday', value: d.birthday ? `${formatDate(d.birthday)} (Alter: ${calculateAge(d.birthday)})` : '-' },
     { key: 'phone', value: display(d.phone) },
   ];
 }

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -500,6 +500,9 @@ export interface SellRouteInfo {
   id: number;
   iban: string;
   fiatName?: string;
+  depositAddress?: string;
+  depositBlockchains?: string[];
+  depositAddressExplorerUrl?: string;
   volume: number;
   active: boolean;
   created: string;

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -429,7 +429,7 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
                         <span className="text-xs font-medium">{msg.author}</span>
                         <span className="text-xs opacity-70">{formatDateTime(msg.created)}</span>
                       </div>
-                      <div className="text-sm">{msg.message || '-'}</div>
+                      <div className="text-sm whitespace-pre-wrap">{msg.message || '-'}</div>
                       {msg.fileName && (
                         <button
                           className="text-xs mt-1 text-dfxBlue-400 underline hover:text-dfxBlue-800"

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -144,6 +144,15 @@ export function formatDate(value: string): string {
   return new Date(value).toLocaleDateString();
 }
 
+export function calculateAge(birthday: string): number {
+  const birth = new Date(birthday);
+  const now = new Date();
+  let age = now.getFullYear() - birth.getFullYear();
+  const m = now.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < birth.getDate())) age--;
+  return age;
+}
+
 export function formatDateTime(value: string): string {
   return new Date(value).toLocaleString();
 }


### PR DESCRIPTION
## Summary
- Users tab: show wallet name column
- Sell routes tab: show deposit address (with explorer link) and blockchain
- Support issue chat: preserve newlines in messages (`whitespace-pre-wrap`)
- User data panel: show current age next to birthday (e.g. `14.3.1987 (Alter: 39)`)

Depends on the matching API change (DFXswiss/api: `feature/DEV-4570-customer-search-improvements`).

Ticket: DEV-4570

## Test plan
- [ ] Customer search → Users tab shows the wallet name
- [ ] Customer search → Sell Routes tab shows deposit address and blockchain
- [ ] Support issue chat renders multi-line messages with line breaks
- [ ] Birthday row in user data panel shows the calculated age