### PR TITLE
feat(compliance): sort notifications and link bankData in transactions (DEV-4573)

### DIFF
--- a/src/components/compliance/detail-tabs.tsx
+++ b/src/components/compliance/detail-tabs.tsx
@@ -383,5 +383,6 @@ const notificationsColumns: ColumnDef<NotificationInfo>[] = [
 ];
 
 export function NotificationsTable({ notifications }: { notifications: NotificationInfo[] }): JSX.Element {
-  return <DataTable data={notifications} columns={notificationsColumns} emptyLabel="No notifications" />;
+  const sorted = [...notifications].sort((a, b) => b.id - a.id);
+  return <DataTable data={sorted} columns={notificationsColumns} emptyLabel="No notifications" />;
 }

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -5,20 +5,30 @@ import { ChargebackModal } from 'src/components/compliance/chargeback-modal';
 import { RecallDetailsModal } from 'src/components/compliance/recall-details-modal';
 import { RecallModal } from 'src/components/compliance/recall-modal';
 import { ConfirmDialog } from 'src/components/confirm-dialog';
-import { BankTxInfo, CryptoInputInfo, RecallInfo, TransactionInfo, useCompliance } from 'src/hooks/compliance.hook';
-import { DetailRow, TransactionDetailRows, formatDate, statusBadge } from 'src/util/compliance-helpers';
+import {
+  BankDataInfo,
+  BankTxInfo,
+  CryptoInputInfo,
+  RecallInfo,
+  TransactionInfo,
+  useCompliance,
+} from 'src/hooks/compliance.hook';
+import { boolBadge, DetailRow, statusBadge, TransactionDetailRows, formatDate } from 'src/util/compliance-helpers';
 
 interface TransactionsTableProps {
   transactions: TransactionInfo[];
   bankTxs: BankTxInfo[];
   cryptoInputs: CryptoInputInfo[];
+  bankDatas: BankDataInfo[];
   userDataId: number;
   expandedBankTxId?: number;
   expandedCryptoInputId?: number;
+  expandedBankDataId?: number;
   expandedTxUid?: string;
   canPerformActions?: boolean;
   onExpandBankTx: (id: number | undefined) => void;
   onExpandCryptoInput: (id: number | undefined) => void;
+  onExpandBankData: (id: number | undefined) => void;
   onExpandTxUid: (uid: string | undefined) => void;
   onStopped?: () => void;
 }
@@ -27,13 +37,16 @@ export function TransactionsTable({
   transactions,
   bankTxs,
   cryptoInputs,
+  bankDatas,
   userDataId,
   expandedBankTxId,
   expandedCryptoInputId,
+  expandedBankDataId,
   expandedTxUid,
   canPerformActions = true,
   onExpandBankTx,
   onExpandCryptoInput,
+  onExpandBankData,
   onExpandTxUid,
   onStopped,
 }: TransactionsTableProps): JSX.Element {
@@ -115,6 +128,7 @@ export function TransactionsTable({
       ?.filter((c): c is CryptoInputInfo & { transactionId: number } => c.transactionId != null)
       .map((c) => [c.transactionId, c]),
   );
+  const bankDataById = new Map(bankDatas?.map((b) => [b.id, b]));
 
   return (
     <div>
@@ -145,6 +159,7 @@ export function TransactionsTable({
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">AML Check</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Chargeback</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Bank TX</th>
+            <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Bank Data</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Crypto In</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Created</th>
             <th className="px-3 py-2 text-center text-sm font-semibold text-dfxBlue-800">Completed</th>
@@ -155,8 +170,10 @@ export function TransactionsTable({
             transactions.map((tx) => {
               const bankTx = bankTxByTxId.get(tx.id);
               const cryptoInput = cryptoInputByTxId.get(tx.id);
+              const bankData = tx.bankDataId != null ? bankDataById.get(tx.bankDataId) : undefined;
               const isBankTxExpanded = expandedBankTxId === bankTx?.id;
               const isCryptoExpanded = expandedCryptoInputId === cryptoInput?.id;
+              const isBankDataExpanded = expandedBankDataId === bankData?.id;
 
               return (
                 <Fragment key={tx.id}>
@@ -215,6 +232,18 @@ export function TransactionsTable({
                       )}
                     </td>
                     <td className="px-3 py-2 text-sm text-dfxBlue-800 text-center">
+                      {bankData ? (
+                        <button
+                          className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
+                          onClick={() => onExpandBankData(isBankDataExpanded ? undefined : bankData.id)}
+                        >
+                          {bankData.id}
+                        </button>
+                      ) : (
+                        (tx.bankDataId ?? '-')
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-sm text-dfxBlue-800 text-center">
                       {cryptoInput ? (
                         <button
                           className="text-dfxBlue-300 underline hover:text-dfxBlue-800"
@@ -238,7 +267,7 @@ export function TransactionsTable({
 
                   {isBankTxExpanded && bankTx && (
                     <tr key={`bankTx-${bankTx.id}`} className="bg-dfxGray-300/50">
-                      <td colSpan={14} className="px-6 py-3">
+                      <td colSpan={15} className="px-6 py-3">
                         <table className="text-sm text-dfxBlue-800 text-left">
                           <tbody>
                             <DetailRow label="Account Service Ref" value={bankTx.accountServiceRef} />
@@ -251,9 +280,45 @@ export function TransactionsTable({
                     </tr>
                   )}
 
+                  {isBankDataExpanded && bankData && (
+                    <tr key={`bankData-${bankData.id}`} className="bg-dfxGray-300/50">
+                      <td colSpan={15} className="px-6 py-3">
+                        <table className="text-sm text-dfxBlue-800 text-left">
+                          <tbody>
+                            <DetailRow label="IBAN" value={bankData.iban} mono />
+                            <DetailRow label="Name" value={bankData.name} />
+                            <DetailRow label="Type" value={bankData.type} />
+                            {bankData.status && (
+                              <tr>
+                                <td className="pr-3 py-0.5 font-medium whitespace-nowrap">Status:</td>
+                                <td className="py-0.5">{statusBadge(bankData.status)}</td>
+                              </tr>
+                            )}
+                            <tr>
+                              <td className="pr-3 py-0.5 font-medium whitespace-nowrap">Approved:</td>
+                              <td className="py-0.5">{boolBadge(bankData.approved)}</td>
+                            </tr>
+                            {bankData.manualApproved != null && (
+                              <tr>
+                                <td className="pr-3 py-0.5 font-medium whitespace-nowrap">Manual Approved:</td>
+                                <td className="py-0.5">{boolBadge(bankData.manualApproved)}</td>
+                              </tr>
+                            )}
+                            <tr>
+                              <td className="pr-3 py-0.5 font-medium whitespace-nowrap">Active:</td>
+                              <td className="py-0.5">{boolBadge(bankData.active)}</td>
+                            </tr>
+                            <DetailRow label="Comment" value={bankData.comment} />
+                            <DetailRow label="Created" value={formatDate(bankData.created)} />
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  )}
+
                   {isCryptoExpanded && cryptoInput && (
                     <tr key={`ci-${cryptoInput.id}`} className="bg-dfxGray-300/50">
-                      <td colSpan={14} className="px-6 py-3">
+                      <td colSpan={15} className="px-6 py-3">
                         <table className="text-sm text-dfxBlue-800 text-left">
                           <tbody>
                             <DetailRow
@@ -288,7 +353,7 @@ export function TransactionsTable({
 
                   {expandedTxUid === tx.uid && (
                     <tr key={`txDetail-${tx.uid}`} className="bg-dfxGray-300/50">
-                      <td colSpan={14} className="px-6 py-3">
+                      <td colSpan={15} className="px-6 py-3">
                         {txDetailLoading === tx.uid ? (
                           <StyledLoadingSpinner size={SpinnerSize.SM} />
                         ) : txDetailError && !txDetailCache.has(tx.uid) ? (
@@ -366,7 +431,7 @@ export function TransactionsTable({
             })
           ) : (
             <tr>
-              <td colSpan={14} className="px-3 py-4 text-center text-dfxGray-700">
+              <td colSpan={15} className="px-3 py-4 text-center text-dfxGray-700">
                 No transactions
               </td>
             </tr>

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -444,6 +444,7 @@ export interface TransactionInfo {
   uid: string;
   buyCryptoId?: number;
   buyFiatId?: number;
+  bankDataId?: number;
   type?: string;
   sourceType: string;
   inputAmount?: number;

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -65,18 +65,28 @@ export default function ComplianceUserScreen(): JSX.Element {
   const [activeTab, setActiveTab] = useState<TabType>('transactions');
   const [expandedBankTxId, setExpandedBankTxId] = useState<number>();
   const [expandedCryptoInputId, setExpandedCryptoInputId] = useState<number>();
+  const [expandedBankDataId, setExpandedBankDataId] = useState<number>();
   const [expandedTxUid, setExpandedTxUid] = useState<string>();
   const { containerRef, splitPercent, setSplitPercent, handleSplitDrag } = useSplitPane();
 
   function handleExpandBankTx(id: number | undefined): void {
     setExpandedBankTxId(id);
     setExpandedCryptoInputId(undefined);
+    setExpandedBankDataId(undefined);
     setExpandedTxUid(undefined);
   }
 
   function handleExpandCryptoInput(id: number | undefined): void {
     setExpandedCryptoInputId(id);
     setExpandedBankTxId(undefined);
+    setExpandedBankDataId(undefined);
+    setExpandedTxUid(undefined);
+  }
+
+  function handleExpandBankData(id: number | undefined): void {
+    setExpandedBankDataId(id);
+    setExpandedBankTxId(undefined);
+    setExpandedCryptoInputId(undefined);
     setExpandedTxUid(undefined);
   }
 
@@ -84,6 +94,7 @@ export default function ComplianceUserScreen(): JSX.Element {
     setExpandedTxUid(uid);
     setExpandedBankTxId(undefined);
     setExpandedCryptoInputId(undefined);
+    setExpandedBankDataId(undefined);
   }
 
   async function openFile(file: KycFile): Promise<void> {
@@ -241,13 +252,16 @@ export default function ComplianceUserScreen(): JSX.Element {
               transactions={data.transactions}
               bankTxs={data.bankTxs}
               cryptoInputs={data.cryptoInputs}
+              bankDatas={data.bankDatas}
               userDataId={numericUserDataId}
               expandedBankTxId={expandedBankTxId}
               expandedCryptoInputId={expandedCryptoInputId}
+              expandedBankDataId={expandedBankDataId}
               expandedTxUid={expandedTxUid}
               canPerformActions={data.permissions.canPerformTransactionActions}
               onExpandBankTx={handleExpandBankTx}
               onExpandCryptoInput={handleExpandCryptoInput}
+              onExpandBankData={handleExpandBankData}
               onExpandTxUid={handleExpandTxUid}
               onStopped={loadData}
             />


### PR DESCRIPTION
## Summary
- Notifications tab: sort entries by `id` descending (newest first)
- Transactions tab: new `Bank Data` column showing `bankDataId` from BuyCrypto/BuyFiat
- Bank Data id is clickable (like Bank TX / Crypto In) and expands an inline detail row with IBAN, Name, Type, Status, Approved/Manual/Active badges, Comment and Created

Depends on the matching API change (DFXswiss/api: `feature/DEV-4573-tx-bankdata`).

Ticket: DEV-4573

## Test plan
- [ ] Compliance user detail → Notifications tab is sorted by id descending
- [ ] Compliance user detail → Transactions tab shows the new `Bank Data` column
- [ ] Clicking a `Bank Data` id expands the detail row with the bank data fields
- [ ] Clicking the same id again collapses it
- [ ] Expanding Bank Data collapses Bank TX / Crypto In / Tx details (and vice versa)