### PR TITLE
feat(sitemap): add financial overview entry

### DIFF
--- a/src/screens/sitemap.screen.tsx
+++ b/src/screens/sitemap.screen.tsx
@@ -118,6 +118,7 @@ const sections: PageSection[] = [
     pages: [
       { path: '/dashboard', label: 'Dashboard' },
       { path: '/dashboard/financial', label: 'Financial' },
+      { path: '/dashboard/financial/overview', label: 'Financial Overview' },
       { path: '/dashboard/financial/live', label: 'Financial Live' },
       { path: '/dashboard/financial/history', label: 'Financial History' },
       { path: '/dashboard/financial/history/expenses', label: 'Expenses' },


### PR DESCRIPTION
## Summary
- Add `/dashboard/financial/overview` to the Financial Dashboard section of the sitemap. The route exists (`App.tsx:526-527`, screen added in #1106) but was missing from the sitemap listing.

## Test plan
- [ ] Visit `/sitemap` and confirm "Financial Overview" appears in the Financial Dashboard block, between "Financial" and "Financial Live"
- [ ] Click the entry and verify it navigates to the overview screen