### PR TITLE
chore(deps): pin shell-quote to >=1.8.4 to clear critical advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31403,9 +31403,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     },
     "@coinbase/wallet-sdk": "3.9.3",
     "axios": "^1.15.0",
-    "protobufjs": "^7.5.5"
+    "protobufjs": "^7.5.5",
+    "shell-quote": "^1.8.4"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Was

Hebt `shell-quote` per `overrides` auf `^1.8.4` (gepatcht). Der PR-Review-Bot meldet auf jedem PR `1 critical vulnerability` — das ist `shell-quote@1.8.1` (`quote()` escaped keine Newlines, GHSA critical).

## Kontext

`shell-quote` ist eine **transitive Dev-Only-Dependency**:
- `react-scripts` → webpack-dev-server / react-dev-utils / launch-editor
- `@trezor/connect-web` → react-native → react-devtools-core

Nichts davon landet im Production-Bundle des Widgets — die Lücke ist nicht in der Runtime-Angriffsfläche. Der Bot zählt aber den repo-weiten `npm audit`-Critical-Count, unabhängig vom Diff. Vorbestehend auf develop, nicht von einem Feature-PR eingeführt.

## Änderung

Chirurgisch: nur `shell-quote` 1.8.1 → 1.8.4 im Lockfile + ein `overrides`-Eintrag. `npm audit` critical: **1 → 0** (die 62 high bleiben bewusst unangetastet — separater Scope). Production-Build lokal grün.

Klärt die kritische Bot-Meldung für diesen und alle künftigen PRs.