### PR TITLE
feat(compliance): show ref-code referrer in recommendation panel and network graph

### DIFF
--- a/src/components/compliance/recommendation-panel.tsx
+++ b/src/components/compliance/recommendation-panel.tsx
@@ -1,15 +1,23 @@
 import { NavigateFunction } from 'react-router-dom';
-import { KycStepInfo } from 'src/hooks/compliance.hook';
+import { KycStepInfo, UserInfo } from 'src/hooks/compliance.hook';
 import { formatDate, statusBadge } from 'src/util/compliance-helpers';
 
 interface RecommendationPanelProps {
   kycSteps: KycStepInfo[];
+  users: UserInfo[];
   userDataId: string;
   navigate: NavigateFunction;
 }
 
-export function RecommendationPanel({ kycSteps, userDataId, navigate }: RecommendationPanelProps): JSX.Element {
+export function RecommendationPanel({ kycSteps, users, userDataId, navigate }: RecommendationPanelProps): JSX.Element {
   const recommendations = kycSteps?.filter((s) => s.name === 'Recommendation') || [];
+
+  // classic ref-code referrers (user.usedRef), deduplicated by code
+  const referrers = Array.from(
+    new Map(
+      (users ?? []).filter((u) => u.usedRef && u.usedRef !== '000-000').map((u) => [u.usedRef, u]),
+    ).values(),
+  );
 
   return (
     <div>
@@ -22,6 +30,21 @@ export function RecommendationPanel({ kycSteps, userDataId, navigate }: Recommen
           View Network
         </button>
       </div>
+      {referrers.length > 0 && (
+        <div className="bg-white rounded-lg shadow-sm mb-2 p-3 text-sm">
+          <div className="text-dfxGray-700 mb-1">Referrer (Ref-Code)</div>
+          {referrers.map((u) => (
+            <button
+              key={u.usedRef}
+              className="block text-dfxBlue-800 hover:underline disabled:cursor-default disabled:no-underline"
+              disabled={!u.refUserDataId}
+              onClick={() => u.refUserDataId && navigate(`/compliance/user/${u.refUserDataId}`)}
+            >
+              {u.refUserName ?? '-'} {u.refUserDataId ? `#${u.refUserDataId}` : ''} ({u.usedRef})
+            </button>
+          ))}
+        </div>
+      )}
       <div className="bg-white rounded-lg shadow-sm max-h-[35vh] overflow-auto scroll-shadow">
         {recommendations.length > 0 ? (
           <table className="w-full border-collapse">

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -391,15 +391,22 @@ export interface RecommendationGraphNode {
   tradeApprovalDate?: string;
 }
 
+export enum RecommendationGraphEdgeKind {
+  RECOMMENDATION = 'Recommendation',
+  USED_REF = 'UsedRef',
+}
+
 export interface RecommendationGraphEdge {
   id: number;
+  kind: RecommendationGraphEdgeKind;
   recommenderId: number;
   recommendedId: number;
-  method: string;
-  type: string;
+  method?: string;
+  type?: string;
   isConfirmed?: boolean;
   confirmationDate?: string;
-  created: string;
+  refCode?: string;
+  created?: string;
 }
 
 export interface RecommendationGraph {
@@ -450,6 +457,7 @@ export interface UserInfo {
   ref?: string;
   usedRef?: string;
   refUserName?: string;
+  refUserDataId?: number;
   role: string;
   status: string;
   walletName?: string;

--- a/src/screens/compliance-recommendation-graph.screen.tsx
+++ b/src/screens/compliance-recommendation-graph.screen.tsx
@@ -17,7 +17,12 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
-import { RecommendationGraph, RecommendationGraphNode, useCompliance } from 'src/hooks/compliance.hook';
+import {
+  RecommendationGraph,
+  RecommendationGraphEdgeKind,
+  RecommendationGraphNode,
+  useCompliance,
+} from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 
@@ -48,9 +53,7 @@ function UserNode({ data }: { data: RecommendationGraphNode & { isRoot: boolean;
           <span className="text-xs px-1.5 py-0.5 rounded bg-dfxGray-300 text-dfxBlue-800">L{data.kycLevel}</span>
         )}
       </div>
-      {data.childCount > 0 && (
-        <div className="text-xs text-dfxGray-700 mt-1">{data.childCount} recommendations</div>
-      )}
+      {data.childCount > 0 && <div className="text-xs text-dfxGray-700 mt-1">{data.childCount} referrals</div>}
       <Handle type="source" position={Position.Bottom} className="!bg-dfxGray-700" />
     </div>
   );
@@ -147,15 +150,21 @@ function layoutGraph(graph: RecommendationGraph): { nodes: Node[]; edges: Edge[]
     });
   }
 
-  const edges: Edge[] = graph.edges.map((e) => ({
-    id: `e-${e.id}`,
-    source: String(e.recommenderId),
-    target: String(e.recommendedId),
-    markerEnd: { type: MarkerType.ArrowClosed },
-    style: { stroke: e.isConfirmed ? '#22c55e' : e.isConfirmed === false ? '#ef4444' : '#9ca3af' },
-    label: e.method,
-    labelStyle: { fontSize: 10, fill: '#6b7280' },
-  }));
+  const edges: Edge[] = graph.edges.map((e) => {
+    const isRef = e.kind === RecommendationGraphEdgeKind.USED_REF;
+    return {
+      id: `e-${e.id}`,
+      source: String(e.recommenderId),
+      target: String(e.recommendedId),
+      markerEnd: { type: MarkerType.ArrowClosed },
+      animated: isRef,
+      style: isRef
+        ? { stroke: '#3b82f6', strokeDasharray: '6 4' }
+        : { stroke: e.isConfirmed ? '#22c55e' : e.isConfirmed === false ? '#ef4444' : '#9ca3af' },
+      label: isRef ? `Ref-Code${e.refCode ? ` ${e.refCode}` : ''}` : e.method,
+      labelStyle: { fontSize: 10, fill: isRef ? '#3b82f6' : '#6b7280' },
+    };
+  });
 
   return { nodes, edges };
 }
@@ -217,6 +226,9 @@ export default function ComplianceRecommendationGraphScreen(): JSX.Element {
         </span>
         <span className="flex items-center gap-1">
           <span className="w-3 h-3 rounded border-2 border-dfxGray-300 bg-white inline-block" /> No approval
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-6 border-t-2 border-dashed border-blue-500 inline-block" /> Ref-Code
         </span>
       </div>
 

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -188,7 +188,12 @@ export default function ComplianceUserScreen(): JSX.Element {
           {!isSupport && (
             <div className="flex-1 min-w-[300px] flex flex-col gap-4">
               {data.permissions.viewRecommendation && (
-                <RecommendationPanel kycSteps={data.kycSteps} userDataId={userDataId} navigate={navigate} />
+                <RecommendationPanel
+                  kycSteps={data.kycSteps}
+                  users={data.users}
+                  userDataId={userDataId}
+                  navigate={navigate}
+                />
               )}
               {data.permissions.viewKycFiles && (
                 <KycFilesPanel


### PR DESCRIPTION
## Problem

A user onboarded via a classic ref code (`user.usedRef`) appeared **isolated** in the compliance recommendation network and showed **"No recommendation"** in the panel — even when AML flagged the referral (`InvalidKycStatusRefUser`) — because both views only rendered `Recommendation`-table data.

Example: userData **330009** used ref code `171-364` (referrer **321067**) but had no edge to its referrer anywhere in the UI.

## Change

Consumes the new API fields (see paired PR **DFXswiss/api#3897**):

- **Network graph**: render `kind: UsedRef` edges distinctly (dashed blue, `Ref-Code <code>` label) with a legend entry; node child-count relabeled "referrals".
- **Recommendation panel**: new **Referrer (Ref-Code)** section derived from `usedRef`/`refUserName`, linking to the referrer's user (`refUserDataId`).

## Notes

- Requires the paired API PR (`kind`, `refCode`, `refUserDataId`).
- Type-checked/linted locally (the repo-wide tsc noise is pre-existing dependency drift, unrelated to these files).
