### PR TITLE
fix(deps): override shell-quote to ^1.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31403,9 +31403,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     },
     "@coinbase/wallet-sdk": "3.9.3",
     "axios": "^1.15.0",
-    "protobufjs": "^7.5.5"
+    "protobufjs": "^7.5.5",
+    "shell-quote": "^1.8.4"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary

Resolves the critical advisory **GHSA-w7jw-789q-3m8p** (`shell-quote` `quote()` does not escape newlines) flagged by the PR review bot.

- `shell-quote@1.8.1` is pulled in transitively (not a direct dependency) via the `react-scripts` build toolchain (react-dev-utils, webpack-dev-server) and trezor dev tooling (react-native → react-devtools-core). It is a dev/build-time dependency and does not ship in the production bundle.
- Pinned to `^1.8.4` (first patched version) through the existing `overrides` block — no `react-scripts` major upgrade needed.
- `npm audit` critical count: **1 → 0**.

## Test plan

- [x] `npm ci` clean with regenerated lockfile
- [x] `shell-quote@1.8.4` resolved across all transitive paths (`npm ls shell-quote`)
- [x] `npm audit` reports 0 critical
- [x] `npm run lint` clean, `npm run test` green (26 suites / 283 tests)
- [x] production build succeeds