### PR TITLE
Guard Lightning deep link builder against nullish deepLink

### DIFF
--- a/src/hooks/payment-link-wallets.hook.ts
+++ b/src/hooks/payment-link-wallets.hook.ts
@@ -49,7 +49,7 @@ export const usePaymentLinkWallets = (): PaymentLinkWalletsProps => {
     if (wallet.supportedMethods?.includes(Blockchain.LIGHTNING)) {
       const lightning = new URL(paymentIdentifier).searchParams.get('lightning');
       const suffix = 'lightning:';
-      const prefix = wallet.deepLink !== suffix ? `${wallet.deepLink}` : '';
+      const prefix = wallet.deepLink && wallet.deepLink !== suffix ? wallet.deepLink : '';
       return `${prefix}${suffix}${lightning}`;
     }
 


### PR DESCRIPTION
## Summary

Fixes `getDeeplinkByCategory` in `src/hooks/payment-link-wallets.hook.ts`: a nullish `wallet.deepLink` was coerced via template literal into the string `"null"`, producing a broken `"nulllightning:<lnurl>"` link.

## Change

```diff
-      const prefix = wallet.deepLink !== suffix ? `${wallet.deepLink}` : '';
+      const prefix = wallet.deepLink && wallet.deepLink !== suffix ? wallet.deepLink : '';
```

A missing prefix now yields the plain `lightning:<lnurl>` link, regardless of the backing data.

## Notes

- Defensive frontend hardening. The immediate AQUA-wallet data symptom was already fixed in DFXswiss/api#3909.
- `eslint` + `prettier --check` pass on the changed file.

Closes #1124