### PR TITLE
fix(compliance): increase vertical spacing between recommendation graph levels

### DIFF
--- a/src/screens/compliance-recommendation-graph.screen.tsx
+++ b/src/screens/compliance-recommendation-graph.screen.tsx
@@ -124,6 +124,8 @@ function layoutGraph(graph: RecommendationGraph): { nodes: Node[]; edges: Edge[]
 
   const NODE_WIDTH = 220;
   const NODE_HEIGHT = 120;
+  // vertical pitch between BFS levels: a full empty level between rows so the hierarchy is readable
+  const LEVEL_HEIGHT = NODE_HEIGHT * 2;
   const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]));
 
   const nodes: Node[] = [];
@@ -137,7 +139,7 @@ function layoutGraph(graph: RecommendationGraph): { nodes: Node[]; edges: Edge[]
       nodes.push({
         id: String(id),
         type: 'user',
-        position: { x: startX + index * NODE_WIDTH, y: level * NODE_HEIGHT },
+        position: { x: startX + index * NODE_WIDTH, y: level * LEVEL_HEIGHT },
         data: {
           ...nodeData,
           isRoot: id === graph.rootId,


### PR DESCRIPTION
## Problem
The recommendation network graph stacks BFS levels at `y = level * NODE_HEIGHT` (120px) — exactly one node height apart — so consecutive levels touch and edge labels overlap the node boxes, making the hierarchy hard to read.

## Fix
Introduce a dedicated vertical pitch `LEVEL_HEIGHT = NODE_HEIGHT * 2`, leaving a full empty level between rows. Layout-only; no behaviour or data change.
