### PR TITLE
fix(compliance): split combined ZIP/City field in chargeback modal

### DIFF
--- a/src/components/compliance/chargeback-modal.tsx
+++ b/src/components/compliance/chargeback-modal.tsx
@@ -163,7 +163,7 @@ export function ChargebackModal({
     iban: Validations.Required,
     creditorName: Validations.Required,
     creditorAddress: Validations.Required,
-    creditorZip: Validations.Required,
+    creditorZip: [Validations.Required, Validations.Custom((v) => !v || v.length <= 8 || 'pattern')],
     creditorCity: Validations.Required,
     creditorCountry: Validations.Required,
   });

--- a/src/components/compliance/chargeback-modal.tsx
+++ b/src/components/compliance/chargeback-modal.tsx
@@ -5,6 +5,7 @@ import {
   StyledButton,
   StyledButtonColor,
   StyledButtonWidth,
+  StyledHorizontalStack,
   StyledInput,
   StyledLoadingSpinner,
   StyledSearchDropdown,
@@ -33,7 +34,8 @@ interface ChargebackFormData {
   refundAddress: string;
   creditorName: string;
   creditorAddress: string;
-  creditorZipCity: string;
+  creditorZip: string;
+  creditorCity: string;
   creditorCountry: Country;
 }
 
@@ -100,8 +102,8 @@ export function ChargebackModal({
           if (data.bankDetails.name) setValue('creditorName', data.bankDetails.name);
           const address = [data.bankDetails.address, data.bankDetails.houseNumber].filter(Boolean).join(' ');
           if (address) setValue('creditorAddress', address);
-          const zipCity = [data.bankDetails.zip, data.bankDetails.city].filter(Boolean).join(' ');
-          if (zipCity) setValue('creditorZipCity', zipCity);
+          if (data.bankDetails.zip) setValue('creditorZip', data.bankDetails.zip);
+          if (data.bankDetails.city) setValue('creditorCity', data.bankDetails.city);
           if (data.bankDetails.country) {
             const country = allowedCountries.find((c) => c.symbol === data.bankDetails?.country);
             if (country) setValue('creditorCountry', country);
@@ -135,8 +137,8 @@ export function ChargebackModal({
             ? {
                 name: formData.creditorName,
                 address: formData.creditorAddress,
-                zip: formData.creditorZipCity,
-                city: formData.creditorZipCity,
+                zip: formData.creditorZip,
+                city: formData.creditorCity,
                 country: formData.creditorCountry.symbol,
               }
             : undefined,
@@ -161,7 +163,8 @@ export function ChargebackModal({
     iban: Validations.Required,
     creditorName: Validations.Required,
     creditorAddress: Validations.Required,
-    creditorZipCity: Validations.Required,
+    creditorZip: Validations.Required,
+    creditorCity: Validations.Required,
     creditorCountry: Validations.Required,
   });
 
@@ -235,15 +238,26 @@ export function ChargebackModal({
                       full
                       smallLabel
                     />
-                    <StyledInput
-                      control={control}
-                      rules={bankRules?.creditorZipCity}
-                      name="creditorZipCity"
-                      label={translate('screens/kyc', 'ZIP code') + ' / ' + translate('screens/kyc', 'City')}
-                      placeholder="10115 Berlin"
-                      full
-                      smallLabel
-                    />
+                    <StyledHorizontalStack gap={2}>
+                      <StyledInput
+                        control={control}
+                        rules={bankRules?.creditorZip}
+                        name="creditorZip"
+                        label={translate('screens/kyc', 'ZIP code')}
+                        placeholder="10115"
+                        small
+                        smallLabel
+                      />
+                      <StyledInput
+                        control={control}
+                        rules={bankRules?.creditorCity}
+                        name="creditorCity"
+                        label={translate('screens/kyc', 'City')}
+                        placeholder={translate('screens/kyc', 'City')}
+                        full
+                        smallLabel
+                      />
+                    </StyledHorizontalStack>
                     <StyledSearchDropdown<Country>
                       control={control}
                       rules={bankRules?.creditorCountry}


### PR DESCRIPTION
## Problem

The compliance chargeback modal (`src/components/compliance/chargeback-modal.tsx`) collapsed **ZIP** and **City** into a single `creditorZipCity` input, then wrote that combined string into **both** `creditorData.zip` **and** `creditorData.city`:

```ts
const zipCity = [data.bankDetails.zip, data.bankDetails.city].filter(Boolean).join(' ');
setValue('creditorZipCity', zipCity);
// ...
zip: formData.creditorZipCity,
city: formData.creditorZipCity,
```

OLKYPAY's payee/client creation rejects any `zip` longer than **8 characters** (`CLIENT_INVALID_ZIPCODE: 'Client.zip' is not a valid zip code (length > 8)`). So a bank refund whose recipient was entered through this modal gets a malformed zip like `"97283 Riedenheim"` and **can never be transmitted** — the payout job retries it indefinitely.

## Fix

Split the single field into separate **`creditorZip`** / **`creditorCity`** inputs — mirroring the existing, correct `refund-creditor-fields.tsx` form — and prefill / submit each independently.

- No API contract change: `creditorData` already expects distinct `zip` and `city`; only the values change.
- Field names (`creditorZip`, `creditorCity`) match the convention used by the other refund forms.
- Reuses existing `screens/kyc` translation keys (`ZIP code`, `City`) — no new i18n entries.

## Scope

Limited to ZIP/City — the confirmed root cause. The address line (`creditorAddress`) similarly combines street + house number into one field; that's a separate, lower-impact concern and is left for a follow-up to keep this diff focused.

## Testing

Local CI (Node 20) all green:
- `npm run lint` ✓
- `npm run build:dev` ✓
- `npm run test` ✓ (283 passed / 26 suites)
