### PR TITLE
feat: rename Telegram support page title to Telegram Group

### DIFF
--- a/src/screens/telegram-support.screen.tsx
+++ b/src/screens/telegram-support.screen.tsx
@@ -60,7 +60,7 @@ export default function TelegramSupportScreen(): JSX.Element {
     answer2: Validations.Required,
   });
 
-  useLayoutOptions({ title: translate('screens/support', 'Telegram Support') });
+  useLayoutOptions({ title: translate('screens/support', 'Telegram Group') });
 
   return (
     <Form control={control} rules={rules} errors={errors}>

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -966,6 +966,7 @@
     "Show completed tickets": "Abgeschlossene Tickets anzeigen",
 
     "Telegram Support": "Telegram Support",
+    "Telegram Group": "Telegram-Gruppe",
     "If someone offers you help in a private message, EVEN IF THEY APPEAR IDENTICAL TO A REAL GROUP ADMIN, should you ever respond to them?": "Wenn Dir jemand in einer privaten Nachricht Hilfe anbietet, AUCH WENN SIE IDENTISCH ZU EINEM ECHTEN GRUPPENADMIN AUSSEHEN, solltest Du jemals auf sie antworten?",
     "True or false: Scammers who want to steal your funds will message you pretending to be admins and official support accounts.": "Richtig oder falsch: Betrüger, die Deine Gelder stehlen wollen, werden Dir Nachrichten senden und sich als Administratoren und offizielle Support-Konten ausgeben.",
     "Admins will NEVER give help by asking for your seed phrase or requiring you to follow any links. If anyone claims they need your seed phrase to help you with a problem, should you give it to them?": "Admins werden NIEMALS Hilfe anbieten, indem sie nach Deiner Seed-Phrase fragen oder Dich auffordern, Links zu folgen. Wenn jemand behauptet, er benötige Deine Seed-Phrase, um Dir bei einem Problem zu helfen, solltest Du sie ihm geben?",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -965,6 +965,7 @@
     "Show completed tickets": "Afficher les tickets terminés",
 
     "Telegram Support": "Support Telegram",
+    "Telegram Group": "Groupe Telegram",
     "If someone offers you help in a private message, EVEN IF THEY APPEAR IDENTICAL TO A REAL GROUP ADMIN, should you ever respond to them?": "Si quelqu'un vous propose de l'aide dans un message privé, MÊME S'IL SEMBLE IDENTIQUE À UN VRAI ADMINISTRATEUR DU GROUPE, devriez-vous jamais lui répondre?",
     "True or false: Scammers who want to steal your funds will message you pretending to be admins and official support accounts.": "Vrai ou faux: Les escrocs qui veulent voler vos fonds vous enverront des messages en se faisant passer pour des administrateurs et des comptes de support officiels.",
     "Admins will NEVER give help by asking for your seed phrase or requiring you to follow any links. If anyone claims they need your seed phrase to help you with a problem, should you give it to them?": "Les administrateurs ne donneront JAMAIS d'aide en demandant votre phrase de récupération ou en vous demandant de suivre des liens. Si quelqu'un prétend avoir besoin de votre phrase de récupération pour vous aider avec un problème, devriez-vous la lui donner?",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -965,6 +965,7 @@
     "Show completed tickets": "Mostra i ticket completati",
 
     "Telegram Support": "Supporto Telegram",
+    "Telegram Group": "Gruppo Telegram",
     "If someone offers you help in a private message, EVEN IF THEY APPEAR IDENTICAL TO A REAL GROUP ADMIN, should you ever respond to them?": "Se qualcuno ti offre aiuto in un messaggio privato, ANCHE SE SEMBRA IDENTICO A UN VERO AMMINISTRATORE DEL GRUPPO, dovresti mai rispondere?",
     "True or false: Scammers who want to steal your funds will message you pretending to be admins and official support accounts.": "Vero o falso: I truffatori che vogliono rubare i tuoi fondi ti invieranno messaggi fingendosi amministratori e account di supporto ufficiali.",
     "Admins will NEVER give help by asking for your seed phrase or requiring you to follow any links. If anyone claims they need your seed phrase to help you with a problem, should you give it to them?": "Gli amministratori non daranno MAI aiuto chiedendo la tua frase di recupero o richiedendo di seguire link. Se qualcuno afferma di aver bisogno della tua frase di recupero per aiutarti con un problema, dovresti dargliela?",


### PR DESCRIPTION
## What

Renames the page title at `/support/telegram` from **Telegram Support** to **Telegram Group**.

## Why

The page is the gateway/quiz to join the Telegram group, not a support channel — "Telegram Group" describes it accurately.

## Changes

- `telegram-support.screen.tsx`: page title key `Telegram Support` → `Telegram Group`
- Added `Telegram Group` translations (de: Telegram-Gruppe, fr: Groupe Telegram, it: Gruppo Telegram)

Scope kept to the page header only; the support-overview card and sitemap label still use the existing `Telegram Support` key.