### PR TITLE
feat(validation): cap ZIP length at the source across all address forms

### DIFF
--- a/src/components/compliance/chargeback-modal.tsx
+++ b/src/components/compliance/chargeback-modal.tsx
@@ -19,6 +19,7 @@ import { RefundDataTable } from 'src/components/refund/refund-data-table';
 import { useLayoutContext } from 'src/contexts/layout.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { TransactionRefundData, useCompliance } from 'src/hooks/compliance.hook';
+import { ZipValidation } from 'src/util/validation-rules';
 
 interface ChargebackModalProps {
   readonly isOpen: boolean;
@@ -163,7 +164,7 @@ export function ChargebackModal({
     iban: Validations.Required,
     creditorName: Validations.Required,
     creditorAddress: Validations.Required,
-    creditorZip: [Validations.Required, Validations.Custom((v) => !v || v.length <= 8 || 'pattern')],
+    creditorZip: ZipValidation,
     creditorCity: Validations.Required,
     creditorCountry: Validations.Required,
   });

--- a/src/screens/compliance-bank-tx-return.screen.tsx
+++ b/src/screens/compliance-bank-tx-return.screen.tsx
@@ -20,6 +20,7 @@ import { TransactionRefundData, useCompliance } from 'src/hooks/compliance.hook'
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
+import { ZipValidation } from 'src/util/validation-rules';
 
 interface FormData {
   iban: string;
@@ -116,7 +117,7 @@ export default function ComplianceBankTxReturnScreen(): JSX.Element {
     iban: Validations.Required,
     creditorName: Validations.Required,
     creditorStreet: Validations.Required,
-    creditorZip: Validations.Required,
+    creditorZip: ZipValidation,
     creditorCity: Validations.Required,
     creditorCountry: Validations.Required,
   });

--- a/src/screens/kyc.screen.tsx
+++ b/src/screens/kyc.screen.tsx
@@ -91,6 +91,7 @@ import { useKycHelper } from '../hooks/kyc-helper.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
 import { useNavigation } from '../hooks/navigation.hook';
 import { delay, toBase64, url } from '../util/utils';
+import { ZipValidation } from '../util/validation-rules';
 import { IframeMessageType } from './kyc-redirect.screen';
 
 enum Mode {
@@ -728,14 +729,14 @@ function PersonalData({ rootRef, mode, code, isLoading, step, onDone, onBack }: 
     phone: [Validations.Required, Validations.Phone],
 
     ['address.street']: Validations.Required,
-    ['address.zip']: Validations.Required,
+    ['address.zip']: ZipValidation,
     ['address.city']: Validations.Required,
     ['address.country']: Validations.Required,
 
     organizationName: Validations.Required,
     ['organizationAddress.street']: Validations.Required,
     ['organizationAddress.city']: Validations.Required,
-    ['organizationAddress.zip']: Validations.Required,
+    ['organizationAddress.zip']: ZipValidation,
     ['organizationAddress.country']: Validations.Required,
   });
 
@@ -2390,7 +2391,7 @@ function AddressChangeData({ rootRef, code, isLoading, step, onDone, onCancel, i
 
   const rules = Utils.createRules({
     ['address.street']: Validations.Required,
-    ['address.zip']: Validations.Required,
+    ['address.zip']: ZipValidation,
     ['address.city']: Validations.Required,
     ['address.country']: Validations.Required,
     file: [

--- a/src/screens/transaction.screen.tsx
+++ b/src/screens/transaction.screen.tsx
@@ -65,6 +65,7 @@ import { useUserGuard } from '../hooks/guard.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
 import { useNavigation } from '../hooks/navigation.hook';
 import { blankedAddress, openPdfFromString } from '../util/utils';
+import { ZipValidation } from '../util/validation-rules';
 
 export enum ExportType {
   COMPACT = 'Compact',
@@ -440,7 +441,7 @@ function TransactionRefund({ setError }: TransactionRefundProps): JSX.Element {
         ? undefined
         : Validations.Required,
     creditorStreet: isBankRefund ? Validations.Required : undefined,
-    creditorZip: isBankRefund ? Validations.Required : undefined,
+    creditorZip: isBankRefund ? ZipValidation : undefined,
     creditorCity: isBankRefund ? Validations.Required : undefined,
     creditorCountry: isBankRefund ? Validations.Required : undefined,
   });

--- a/src/util/validation-rules.ts
+++ b/src/util/validation-rules.ts
@@ -1,0 +1,6 @@
+import { Validations } from '@dfx.swiss/react';
+
+// Postal codes never legitimately exceed 8 characters (longest real formats incl. spaces,
+// e.g. UK "EC1A 1BB"). Capping zip inputs at the source prevents a combined
+// "<postcode> <city>" value from entering the payout/KYC address path.
+export const ZipValidation = [Validations.Required, Validations.Custom((v) => !v || v.length <= 8 || 'pattern')];


### PR DESCRIPTION
## Context

Follow-up to #1136 (chargeback modal ZIP/City split). The backend mirror of OLKYPAY's `CLIENT_INVALID_ZIPCODE` check (DFXswiss/api#3985) was **closed** in favour of hardening the validation **at the source** — the malformed `"<postcode> <city>"` value only ever originated in frontend address inputs, and mirroring an external API's constraint in our own code is a drift/maintenance liability.

## What this does

Extends the ZIP length cap (≤ 8 chars) — already on the chargeback modal via #1136 — to **every** form that feeds an address into the payout / KYC path:

- `transaction.screen.tsx` — bank-refund creditor ZIP
- `compliance-bank-tx-return.screen.tsx` — creditor ZIP
- `kyc.screen.tsx` — personal `address.zip`, `organizationAddress.zip`, and address-change `address.zip`

To avoid the exact drift concern raised on #3985, the rule is defined **once** in `src/util/validation-rules.ts` and all sites reference it — including the chargeback modal, which is de-duplicated off its inline copy:

```ts
export const ZipValidation = [Validations.Required, Validations.Custom((v) => !v || v.length <= 8 || 'pattern')];
```

8 chars is a general postal-code bound (longest real formats incl. spaces, e.g. UK `EC1A 1BB`), not an OLKYPAY-specific value — so it's our own UX validation with a single source of truth.

## Not in scope

`sepa-manual.screen.tsx` and `payment-routes.screen.tsx` have ZIP inputs but no validation rules wired and are peripheral to the payout path — left as a follow-up.

## Testing

Local CI (Node 20) all green:
- `npm run lint` ✓
- `npm run test` ✓ (289 passed / 27 suites)
- `npm run build:dev` ✓
