### PR TITLE
fix(support): show issue ID, linkify URLs in messages, expand search hint

### DIFF
--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -284,6 +284,7 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
         {/* Info Panels - Row 1: Issue + Account */}
         <div className="flex gap-4 flex-wrap">
           <InfoPanel title="Issue Details">
+            <InfoRow label="ID" value={String(issueData.id)} mono />
             <InfoRow label="UID" value={issueData.uid} mono />
             <InfoRow label="Name" value={issueData.name} />
             <InfoRow label="Type" value={translate('screens/support', typeLabel(issueData.type))} />
@@ -501,7 +502,9 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
                         <span className="text-xs font-medium">{msg.author}</span>
                         <span className="text-xs opacity-70">{formatDateTime(msg.created)}</span>
                       </div>
-                      <div className="text-sm whitespace-pre-wrap">{msg.message || '-'}</div>
+                      <div className="text-sm whitespace-pre-wrap break-words">
+                        {msg.message ? <LinkedText text={msg.message} /> : '-'}
+                      </div>
                       {msg.fileName && (
                         <button
                           className="text-xs mt-1 text-dfxBlue-400 underline hover:text-dfxBlue-800"
@@ -691,5 +694,30 @@ function InfoRow({ label, value, mono }: { label: string; value: string | JSX.El
       <td className="pr-4 py-1 font-medium whitespace-nowrap text-sm">{label}:</td>
       <td className={`py-1 text-sm break-all ${mono ? 'font-mono' : ''}`}>{value}</td>
     </tr>
+  );
+}
+
+const URL_PATTERN = /https?:\/\/[^\s]+/;
+
+function LinkedText({ text }: { text: string }): JSX.Element {
+  const parts = text.split(new RegExp(`(${URL_PATTERN.source})`, 'g'));
+  return (
+    <>
+      {parts.map((part, i) =>
+        URL_PATTERN.test(part) ? (
+          <a
+            key={i}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-dfxBlue-400 underline hover:text-dfxBlue-800 break-all"
+          >
+            {part}
+          </a>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </>
   );
 }

--- a/src/screens/support-dashboard.screen.tsx
+++ b/src/screens/support-dashboard.screen.tsx
@@ -435,7 +435,7 @@ export default function SupportDashboardScreen(): JSX.Element {
           className="px-3 py-1.5 text-sm border border-dfxGray-400 rounded bg-white text-dfxBlue-800"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="Search by UID, name, clerk, message..."
+          placeholder="Search by ID, UID, name, clerk, message..."
         />
       </div>
 


### PR DESCRIPTION
## Problem

Three usability gaps in the Support Dashboard, reported in *Support Dashboard Refactoring 2*:

1. **Issue ID not shown** in the issue detail overview — only UID was displayed, even though support agents reference issues by their numeric ID.
2. **URLs in messages render as plain text** — a customer sending `https://...` in a chat message gets an unclickable string in the agent view.
3. **Search hint did not mention ID** — agents could not tell that searching by issue ID was meant to work.

The fourth original ask (preserve newlines in replies) is already fixed on develop via `whitespace-pre-wrap` on the message body.

## Fix

- **`support-dashboard-issue.screen.tsx`**:
  - Added `<InfoRow label=\"ID\" value={String(issueData.id)} mono />` at the top of the *Issue Details* panel.
  - Replaced the plain-text message render with a small `LinkedText` helper that splits the message on `https?://...` and wraps matches in `<a target=\"_blank\" rel=\"noopener noreferrer\">`. The `whitespace-pre-wrap` is kept, and `break-words` is added so long URLs don't overflow the bubble.
- **`support-dashboard.screen.tsx`**:
  - Updated the search placeholder to `\"Search by ID, UID, name, clerk, message...\"`.

## Backend follow-up

The placeholder now advertises ID search, but the backend `support/issue/list?query=…` only matches `name`, `uid`, `clerk`, userData fields, and message text — not `issue.id`. A companion PR in `DFXswiss/api` extends the existing OR-predicate with an `OR issue.id = :paramId` branch, gated on the term being fully numeric. Until that lands, typing a pure numeric ID into the search will not find the issue; this PR is intentionally frontend-only and consistent with the existing search pattern.

## Test plan

- [ ] Open any support issue → \"ID\" shows above \"UID\" in the Issue Details panel.
- [ ] Send a chat message containing `https://example.com/foo bar` → only the URL becomes a clickable link, the trailing `bar` stays plain.
- [ ] Send a message containing two URLs separated by text → both link, surrounding text unchanged.
- [ ] Confirm newlines are preserved in agent-side replies (already fixed on develop, regression check).
- [ ] Dashboard search field shows the updated placeholder.