### PR TITLE
Handle TFA_REQUIRED for staff (mail login + support dashboard)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.4.0-beta.2",
+        "@dfx.swiss/react": "^1.4.0",
         "@dfx.swiss/react-components": "^1.3.2",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@dfx.swiss/core": {
-      "version": "0.3.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.0-beta.2.tgz",
-      "integrity": "sha512-2TXeHysQNO/siq57mBEd1Ck8VRxCTHMdY5Y1Q5JzJBNcsou9cAuIoCCp8X6Pvol+2zX1UrfcyNa7Z2h4bo0vWA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.0.tgz",
+      "integrity": "sha512-+sbbO1B4xXePCV5uzzVG73VLxVwRz7CnDAw69pJNF5xOm7HjWj8FakJO47WPw5Ae8W6pcXbY0h2Ppg3dxgybEw==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2642,12 +2642,12 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.4.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.0-beta.2.tgz",
-      "integrity": "sha512-v7ju/gNPnW4jyxsEpDcJbZ7AL7GWkw1H4xHC4dWxUcI303YnNigiCI6kYv+1SPdlGA9vDni2KpHXzIrdQILJcg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.0.tgz",
+      "integrity": "sha512-7RRQo704YAeXsoOF73CsRTEQK/p1wQ0L4gIU2PD9y8tzi/mKkLfqKWkdmycRomNheUibEx5EV4fxIvh9TOkNFg==",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/core": "^0.3.0-beta.2",
+        "@dfx.swiss/core": "^0.3.0",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "typescript": "^4.9.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.4.0-beta.0",
+        "@dfx.swiss/react": "^1.4.0-beta.2",
         "@dfx.swiss/react-components": "^1.3.2",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@dfx.swiss/core": {
-      "version": "0.3.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.0-beta.0.tgz",
-      "integrity": "sha512-HGG+gMQCCvGMh2hkXqYP+LTSpz//iq5Jovz4pByFPId+n5srgTitYFFYic0uDZamsPSjEcRyDKL1VRqojnQIYw==",
+      "version": "0.3.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.0-beta.2.tgz",
+      "integrity": "sha512-2TXeHysQNO/siq57mBEd1Ck8VRxCTHMdY5Y1Q5JzJBNcsou9cAuIoCCp8X6Pvol+2zX1UrfcyNa7Z2h4bo0vWA==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2642,12 +2642,12 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.4.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.0-beta.0.tgz",
-      "integrity": "sha512-R3S2l4DgCXB5scpFNCTm6dpy+uPNnUoOHmHuFViP4PrrbuwEKugSvr3K4XTYCuQrUBhTi/0UsxPmYzT45CS1KQ==",
+      "version": "1.4.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.0-beta.2.tgz",
+      "integrity": "sha512-v7ju/gNPnW4jyxsEpDcJbZ7AL7GWkw1H4xHC4dWxUcI303YnNigiCI6kYv+1SPdlGA9vDni2KpHXzIrdQILJcg==",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/core": "^0.3.0-beta.0",
+        "@dfx.swiss/core": "^0.3.0-beta.2",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "typescript": "^4.9.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.4.0-beta.2",
+    "@dfx.swiss/react": "^1.4.0",
     "@dfx.swiss/react-components": "^1.3.2",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.4.0-beta.0",
+    "@dfx.swiss/react": "^1.4.0-beta.2",
     "@dfx.swiss/react-components": "^1.3.2",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -18,10 +18,10 @@ import {
   PendingReviewType,
   PhoneCallStatus,
   ResponseType,
-  useApi,
 } from '@dfx.swiss/react';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
 import { useMemo } from 'react';
+import { useGuardedApi } from './guarded-api.hook';
 import { CreateMrosDto, MrosListEntry, UpdateMrosDto } from 'src/dto/mros.dto';
 import { CustodyOrderListEntry } from 'src/dto/order.dto';
 import { CreateRecallDto, RecallListEntry } from 'src/dto/recall.dto';
@@ -672,7 +672,7 @@ function checkDateFieldForQueue(queue: CallQueue): string {
 export type AmlAction = 'Pass' | 'Fail' | 'Reset';
 
 export function useCompliance() {
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   async function search(key: string): Promise<ComplianceSearchResult> {
     const normalizedKey = normalizeSearchKey(key);

--- a/src/hooks/guarded-api.hook.ts
+++ b/src/hooks/guarded-api.hook.ts
@@ -1,0 +1,26 @@
+import { ApiError, CallConfig, TfaLevel, useApi } from '@dfx.swiss/react';
+import { useCallback } from 'react';
+import { useNavigation } from './navigation.hook';
+
+// Drop-in replacement for useApi() on staff hooks: staff endpoints answer HTTP 403 { code: 'TFA_REQUIRED' }
+// when a mail-origin session still needs 2FA. Instead of surfacing a raw error, route into the bearer-based
+// (session-mode) 2FA flow. Every staff dashboard hook must obtain its `call` from here, not from useApi(),
+// so the 2FA redirect works everywhere — not only on the support dashboard.
+export function useGuardedApi(): { call: <T>(config: CallConfig) => Promise<T> } {
+  const { call } = useApi();
+  const { navigate } = useNavigation();
+
+  const call2fa = useCallback(
+    <T>(config: CallConfig): Promise<T> =>
+      call<T>(config).catch((error: ApiError) => {
+        // staff 2FA is always STRICT/TOTP; route into the bearer-based (session-mode) 2FA flow
+        if (error.code === 'TFA_REQUIRED') {
+          navigate('/2fa', { state: { level: TfaLevel.STRICT, sessionMode: true }, setRedirect: true });
+        }
+        throw error;
+      }),
+    [call, navigate],
+  );
+
+  return { call: call2fa };
+}

--- a/src/hooks/log-tracing.hook.ts
+++ b/src/hooks/log-tracing.hook.ts
@@ -1,5 +1,5 @@
-import { useApi } from '@dfx.swiss/react';
 import { useMemo } from 'react';
+import { useGuardedApi } from './guarded-api.hook';
 
 export interface LogQueryColumn {
   name: string;
@@ -80,7 +80,7 @@ export function parseGenericTrace(
 }
 
 export function useLogTracing() {
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   async function getRealunitTraces(hours: number): Promise<LogQueryResult> {
     return call<LogQueryResult>({

--- a/src/hooks/realunit-api.hook.ts
+++ b/src/hooks/realunit-api.hook.ts
@@ -1,5 +1,5 @@
-import { useApi } from '@dfx.swiss/react';
 import { useMemo } from 'react';
+import { useGuardedApi } from './guarded-api.hook';
 import {
   AccountHistory,
   AccountSummary,
@@ -15,7 +15,7 @@ import { Timeframe } from 'src/util/chart';
 import { relativeUrl } from 'src/util/utils';
 
 export function useRealunitApi() {
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   async function getAccountSummary(address: string): Promise<AccountSummary> {
     return call<AccountSummary>({

--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -1,6 +1,6 @@
-import { ApiError, CallConfig, Department, TfaLevel, useApi } from '@dfx.swiss/react';
-import { useCallback, useMemo } from 'react';
-import { useNavigation } from './navigation.hook';
+import { Department } from '@dfx.swiss/react';
+import { useMemo } from 'react';
+import { useGuardedApi } from './guarded-api.hook';
 
 // re-exported for existing call sites; canonical definition lives in the pure stats module
 export { CustomerAuthor } from 'src/util/support-stats';
@@ -124,22 +124,9 @@ export interface SupportStatisticsDto {
 }
 
 export function useSupportDashboard() {
-  const { call } = useApi();
-  const { navigate } = useNavigation();
-
-  // staff endpoints answer with HTTP 403 { code: 'TFA_REQUIRED' } when the session still
-  // needs 2FA; route into the existing 2FA flow instead of surfacing a raw error
-  const guardedCall = useCallback(
-    <T>(config: CallConfig): Promise<T> =>
-      call<T>(config).catch((error: ApiError) => {
-        if (error.code === 'TFA_REQUIRED') {
-          // staff 2FA is always STRICT/TOTP; route into the bearer-based (session-mode) 2FA flow
-          navigate('/2fa', { state: { level: TfaLevel.STRICT, sessionMode: true }, setRedirect: true });
-        }
-        throw error;
-      }),
-    [call, navigate],
-  );
+  // staff endpoints answer with HTTP 403 { code: 'TFA_REQUIRED' } when the session still needs 2FA;
+  // useGuardedApi routes that into the bearer-based 2FA flow instead of surfacing a raw error
+  const { call: guardedCall } = useGuardedApi();
 
   async function getIssueList(params?: {
     department?: string;

--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -133,8 +133,8 @@ export function useSupportDashboard() {
     <T>(config: CallConfig): Promise<T> =>
       call<T>(config).catch((error: ApiError) => {
         if (error.code === 'TFA_REQUIRED') {
-          const level = (error as ApiError & { level?: TfaLevel }).level;
-          navigate('/2fa', { state: { level }, setRedirect: true });
+          // staff 2FA is always STRICT/TOTP; route into the bearer-based (session-mode) 2FA flow
+          navigate('/2fa', { state: { level: TfaLevel.STRICT, sessionMode: true }, setRedirect: true });
         }
         throw error;
       }),

--- a/src/hooks/support-dashboard.hook.ts
+++ b/src/hooks/support-dashboard.hook.ts
@@ -1,5 +1,6 @@
-import { Department, useApi } from '@dfx.swiss/react';
-import { useMemo } from 'react';
+import { ApiError, CallConfig, Department, TfaLevel, useApi } from '@dfx.swiss/react';
+import { useCallback, useMemo } from 'react';
+import { useNavigation } from './navigation.hook';
 
 // re-exported for existing call sites; canonical definition lives in the pure stats module
 export { CustomerAuthor } from 'src/util/support-stats';
@@ -124,6 +125,21 @@ export interface SupportStatisticsDto {
 
 export function useSupportDashboard() {
   const { call } = useApi();
+  const { navigate } = useNavigation();
+
+  // staff endpoints answer with HTTP 403 { code: 'TFA_REQUIRED' } when the session still
+  // needs 2FA; route into the existing 2FA flow instead of surfacing a raw error
+  const guardedCall = useCallback(
+    <T>(config: CallConfig): Promise<T> =>
+      call<T>(config).catch((error: ApiError) => {
+        if (error.code === 'TFA_REQUIRED') {
+          const level = (error as ApiError & { level?: TfaLevel }).level;
+          navigate('/2fa', { state: { level }, setRedirect: true });
+        }
+        throw error;
+      }),
+    [call, navigate],
+  );
 
   async function getIssueList(params?: {
     department?: string;
@@ -138,14 +154,14 @@ export function useSupportDashboard() {
       .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`);
     const queryString = queryParts.length ? `?${queryParts.join('&')}` : '';
 
-    return call<{ data: SupportIssueListItem[]; total: number }>({
+    return guardedCall<{ data: SupportIssueListItem[]; total: number }>({
       url: `support/issue/list${queryString}`,
       method: 'GET',
     });
   }
 
   async function getIssueCounts(): Promise<Record<string, number>> {
-    return call<Record<string, number>>({
+    return guardedCall<Record<string, number>>({
       url: 'support/issue/counts',
       method: 'GET',
     });
@@ -153,21 +169,21 @@ export function useSupportDashboard() {
 
   async function getIssueActivity(since?: Date): Promise<{ count: number; latestAt?: string }> {
     const query = since ? `?since=${encodeURIComponent(since.toISOString())}` : '';
-    return call<{ count: number; latestAt?: string }>({
+    return guardedCall<{ count: number; latestAt?: string }>({
       url: `support/issue/activity${query}`,
       method: 'GET',
     });
   }
 
   async function getIssueStatistics(periodDays: number): Promise<SupportStatisticsDto> {
-    return call<SupportStatisticsDto>({
+    return guardedCall<SupportStatisticsDto>({
       url: `support/issue/statistics?days=${periodDays}`,
       method: 'GET',
     });
   }
 
   async function getClerks(): Promise<string[]> {
-    return call<string[]>({
+    return guardedCall<string[]>({
       url: 'support/issue/clerks',
       method: 'GET',
     });
@@ -175,7 +191,7 @@ export function useSupportDashboard() {
 
   // the clerk name mapped to the logged-in support account (null if unmapped)
   async function getMyClerk(): Promise<string | undefined> {
-    const result = await call<{ clerk: string | null }>({
+    const result = await guardedCall<{ clerk: string | null }>({
       url: 'support/issue/clerk',
       method: 'GET',
     });
@@ -183,7 +199,7 @@ export function useSupportDashboard() {
   }
 
   async function getIssueData(issueId: number): Promise<SupportIssueInternalData> {
-    return call<SupportIssueInternalData>({
+    return guardedCall<SupportIssueInternalData>({
       url: `support/issue/${issueId}/data`,
       method: 'GET',
     });
@@ -193,7 +209,7 @@ export function useSupportDashboard() {
     issueId: number,
     data: { state?: string; clerk?: string; department?: string },
   ): Promise<void> {
-    return call<void>({
+    return guardedCall<void>({
       url: `support/issue/${issueId}`,
       method: 'PUT',
       data,
@@ -204,7 +220,7 @@ export function useSupportDashboard() {
     issueId: number,
     data: { author: string; message?: string; file?: string; fileName?: string },
   ): Promise<SupportMessageInfo> {
-    return call<SupportMessageInfo>({
+    return guardedCall<SupportMessageInfo>({
       url: `support/issue/${issueId}/message`,
       method: 'POST',
       data,
@@ -224,7 +240,7 @@ export function useSupportDashboard() {
       fileName?: string;
     },
   ): Promise<void> {
-    return call<void>({
+    return guardedCall<void>({
       url: `support/issue/support?userDataId=${userDataId}`,
       method: 'POST',
       data,
@@ -232,7 +248,7 @@ export function useSupportDashboard() {
   }
 
   async function searchUsers(key: string): Promise<UserSearchResult[]> {
-    const result = await call<{ userDatas: UserSearchResult[] }>({
+    const result = await guardedCall<{ userDatas: UserSearchResult[] }>({
       url: `support?key=${encodeURIComponent(key)}`,
       method: 'GET',
     });
@@ -241,7 +257,7 @@ export function useSupportDashboard() {
 
   async function getIssueMessages(issueUid: string, fromMessageId?: number): Promise<SupportMessageInfo[]> {
     const query = fromMessageId ? `?fromMessageId=${fromMessageId}` : '';
-    const result = await call<{ messages: SupportMessageInfo[] }>({
+    const result = await guardedCall<{ messages: SupportMessageInfo[] }>({
       url: `support/issue/${issueUid}${query}`,
       method: 'GET',
     });
@@ -252,7 +268,7 @@ export function useSupportDashboard() {
     issueId: string,
     messageId: number,
   ): Promise<{ data: { type: string; data: number[] }; contentType: string }> {
-    return call<{ data: { type: string; data: number[] }; contentType: string }>({
+    return guardedCall<{ data: { type: string; data: number[] }; contentType: string }>({
       url: `support/issue/${issueId}/message/${messageId}/file`,
       method: 'GET',
     });
@@ -274,6 +290,6 @@ export function useSupportDashboard() {
       getMessageFile,
       searchUsers,
     }),
-    [call],
+    [guardedCall],
   );
 }

--- a/src/hooks/support-templates.hook.ts
+++ b/src/hooks/support-templates.hook.ts
@@ -1,5 +1,5 @@
-import { useApi } from '@dfx.swiss/react';
 import { useEffect, useMemo, useState } from 'react';
+import { useGuardedApi } from './guarded-api.hook';
 
 export const TEMPLATE_NAME_MAX_LENGTH = 256;
 export const TEMPLATE_CONTENT_MAX_LENGTH = 8000;
@@ -40,7 +40,7 @@ export interface UseTemplates {
 }
 
 export function useTemplates(): UseTemplates {
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   async function listTemplates(search?: string): Promise<SupportIssueTemplateInfo[]> {
     const suffix = search ? `?search=${encodeURIComponent(search)}` : '';

--- a/src/screens/mail-login.screen.tsx
+++ b/src/screens/mail-login.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, useApi } from '@dfx.swiss/react';
+import { ApiError, TfaLevel, useApi } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -31,7 +31,12 @@ export default function MailLoginScreen() {
           window.location.href = redirectUrl;
         })
         .catch((error: ApiError) => {
-          navigate({ pathname: `/error`, search: `?msg=${error.message}` });
+          if (error.code === 'TFA_REQUIRED') {
+            const level = (error as ApiError & { level?: TfaLevel }).level;
+            navigate('/2fa', { state: { level }, setRedirect: true });
+          } else {
+            navigate({ pathname: `/error`, search: `?msg=${error.message}` });
+          }
         })
         .finally(() => {
           urlParams.delete('otp');

--- a/src/screens/mail-login.screen.tsx
+++ b/src/screens/mail-login.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, TfaLevel, useApi } from '@dfx.swiss/react';
+import { ApiError, useApi } from '@dfx.swiss/react';
 import { SpinnerSize, StyledLoadingSpinner, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -31,12 +31,7 @@ export default function MailLoginScreen() {
           window.location.href = redirectUrl;
         })
         .catch((error: ApiError) => {
-          if (error.code === 'TFA_REQUIRED') {
-            const level = (error as ApiError & { level?: TfaLevel }).level;
-            navigate('/2fa', { state: { level }, setRedirect: true });
-          } else {
-            navigate({ pathname: `/error`, search: `?msg=${error.message}` });
-          }
+          navigate({ pathname: `/error`, search: `?msg=${error.message}` });
         })
         .finally(() => {
           urlParams.delete('otp');

--- a/src/screens/tfa.screen.tsx
+++ b/src/screens/tfa.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, TfaLevel, TfaSetup, TfaType, Utils, Validations, useKyc, useUserContext } from '@dfx.swiss/react';
+import { ApiError, TfaLevel, TfaSetup, TfaType, Utils, Validations, useAuth, useKyc } from '@dfx.swiss/react';
 import {
   CopyButton,
   Form,
@@ -28,8 +28,8 @@ const ANDROID_AUTHENTICATOR_URL =
 
 export default function TfaScreen(): JSX.Element {
   const { translate, translateError } = useSettingsContext();
-  const { user } = useUserContext();
-  const { setup2fa, verify2fa } = useKyc();
+  const { setup2fa: kycSetup2fa, verify2fa: kycVerify2fa } = useKyc();
+  const { setup2fa: authSetup2fa, verify2fa: authVerify2fa } = useAuth();
   const { search, state } = useLocation();
   const { copy } = useClipboard();
   const { goBack } = useNavigation();
@@ -42,14 +42,17 @@ export default function TfaScreen(): JSX.Element {
   const [setupInfo, setSetupInfo] = useState<TfaSetup>();
 
   const params = new URLSearchParams(search);
-  const kycCode = params.get('code') ?? user?.kyc.hash;
+  const urlCode = params.get('code');
+  // Staff/session 2FA (reached via mail-login/dashboard, no kyc url code) uses the bearer-based auth/2fa
+  // endpoints; kyc 2FA (with a url code) keeps using the kyc-code-based endpoints.
+  const isSessionMode = !urlCode;
   const tfaLevel: TfaLevel | undefined = state?.level;
 
-  useUserGuard('/login', !kycCode);
+  useUserGuard('/login', isSessionMode);
 
   useEffect(() => {
     load();
-  }, [kycCode]);
+  }, [isSessionMode, urlCode]);
 
   const {
     control,
@@ -62,9 +65,7 @@ export default function TfaScreen(): JSX.Element {
   });
 
   async function load(): Promise<void> {
-    if (!kycCode) return;
-
-    return setup2fa(kycCode, tfaLevel)
+    return (isSessionMode ? authSetup2fa(tfaLevel) : kycSetup2fa(urlCode as string, tfaLevel))
       .then(setSetupInfo)
       .catch((error: ApiError) => {
         if (error.message !== '2FA already set up') {
@@ -75,13 +76,11 @@ export default function TfaScreen(): JSX.Element {
   }
 
   async function onSubmit(data: { token: string }) {
-    if (!kycCode) return;
-
     setError(undefined);
     setTokenInvalid(false);
     setIsSubmitting(true);
 
-    verify2fa(kycCode, data.token)
+    (isSessionMode ? authVerify2fa(data.token) : kycVerify2fa(urlCode as string, data.token))
       .then(() => goBack())
       .catch((e: ApiError) => (e.statusCode === 403 ? setTokenInvalid(true) : setError(e.message ?? 'Unknown error')))
       .finally(() => setIsSubmitting(false));

--- a/src/screens/tfa.screen.tsx
+++ b/src/screens/tfa.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, TfaLevel, TfaSetup, TfaType, Utils, Validations, useAuth, useKyc } from '@dfx.swiss/react';
+import { ApiError, TfaLevel, TfaSetup, TfaType, Utils, Validations, useAuth, useKyc, useUserContext } from '@dfx.swiss/react';
 import {
   CopyButton,
   Form,
@@ -30,6 +30,7 @@ export default function TfaScreen(): JSX.Element {
   const { translate, translateError } = useSettingsContext();
   const { setup2fa: kycSetup2fa, verify2fa: kycVerify2fa } = useKyc();
   const { setup2fa: authSetup2fa, verify2fa: authVerify2fa } = useAuth();
+  const { user } = useUserContext();
   const { search, state } = useLocation();
   const { copy } = useClipboard();
   const { goBack } = useNavigation();
@@ -43,16 +44,18 @@ export default function TfaScreen(): JSX.Element {
 
   const params = new URLSearchParams(search);
   const urlCode = params.get('code');
-  // Staff/session 2FA (reached via mail-login/dashboard, no kyc url code) uses the bearer-based auth/2fa
-  // endpoints; kyc 2FA (with a url code) keeps using the kyc-code-based endpoints.
-  const isSessionMode = !urlCode;
+  // kyc 2FA resolves its code from the url or the logged-in user's kyc hash (unchanged for edit-mail/kyc flows).
+  const kycCode = urlCode ?? user?.kyc.hash;
+  // Session mode (staff, reached from the support dashboard) is opt-in via an explicit navigation flag and uses
+  // the bearer-based auth/2fa endpoints. Everything else stays on the kyc-code-based endpoints as before.
+  const isSessionMode = state?.sessionMode === true;
   const tfaLevel: TfaLevel | undefined = state?.level;
 
-  useUserGuard('/login', isSessionMode);
+  useUserGuard('/login', isSessionMode || !kycCode);
 
   useEffect(() => {
     load();
-  }, [isSessionMode, urlCode]);
+  }, [isSessionMode, kycCode]);
 
   const {
     control,
@@ -65,7 +68,8 @@ export default function TfaScreen(): JSX.Element {
   });
 
   async function load(): Promise<void> {
-    return (isSessionMode ? authSetup2fa(tfaLevel) : kycSetup2fa(urlCode as string, tfaLevel))
+    if (!isSessionMode && !kycCode) return;
+    return (isSessionMode ? authSetup2fa(tfaLevel) : kycSetup2fa(kycCode as string, tfaLevel))
       .then(setSetupInfo)
       .catch((error: ApiError) => {
         if (error.message !== '2FA already set up') {
@@ -80,7 +84,7 @@ export default function TfaScreen(): JSX.Element {
     setTokenInvalid(false);
     setIsSubmitting(true);
 
-    (isSessionMode ? authVerify2fa(data.token) : kycVerify2fa(urlCode as string, data.token))
+    (isSessionMode ? authVerify2fa(data.token) : kycVerify2fa(kycCode as string, data.token))
       .then(() => goBack())
       .catch((e: ApiError) => (e.statusCode === 403 ? setTokenInvalid(true) : setError(e.message ?? 'Unknown error')))
       .finally(() => setIsSubmitting(false));


### PR DESCRIPTION
Frontend part of staff mail login + 2FA. Companion to DFXswiss/api#4009 and **depends on DFXswiss/packages#181** (new `useAuth` 2FA methods + api.hook `code` fix).
- mail-login.screen: `TFA_REQUIRED` → `/2fa`.
- support-dashboard.hook: central `guardedCall` wrapper routes all dashboard calls to the 2FA flow on `TFA_REQUIRED`.
- tfa.screen: session-based `auth/2fa` (staff, no kyc url code) vs kyc-code-based (kyc).

Verified on build host with the local packages build: lint + build (CI=true) + 298 tests green.