### PR TITLE
Fix RealUnit dashboard 404s from double-slash API URLs

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -36,6 +36,8 @@ import {
   deepEqual,
   equalsIgnoreCase,
   formatLocationAddress,
+  apiUrl,
+  relativeUrl,
 } from '../util/utils';
 
 describe('utils', () => {
@@ -330,6 +332,35 @@ describe('utils', () => {
 
     it('should return undefined for empty address', () => {
       expect(formatLocationAddress({})).toBeUndefined();
+    });
+  });
+
+  describe('apiUrl', () => {
+    it('should never produce a leading slash (SDK joins baseUrl + "/" + url)', () => {
+      expect(apiUrl({ path: 'realunit/holders' })).toBe('realunit/holders');
+      expect(apiUrl({ path: '/realunit/holders' })).toBe('realunit/holders');
+      expect(apiUrl({ path: '///realunit/holders' })).toBe('realunit/holders');
+    });
+
+    it('should append params only when they have entries', () => {
+      expect(apiUrl({ path: 'realunit/holders', params: new URLSearchParams() })).toBe('realunit/holders');
+      expect(apiUrl({ path: 'realunit/holders', params: new URLSearchParams({ after: 'x' }) })).toBe(
+        'realunit/holders?after=x',
+      );
+    });
+  });
+
+  describe('relativeUrl', () => {
+    it('should keep a single leading slash for router navigation', () => {
+      expect(relativeUrl({ path: 'settings' })).toBe('/settings');
+      expect(relativeUrl({ path: '/settings' })).toBe('/settings');
+    });
+
+    it('should differ from apiUrl only by the leading slash', () => {
+      const path = 'realunit/admin/quotes';
+      const params = new URLSearchParams({ limit: '50' });
+      expect(relativeUrl({ path, params })).toBe('/realunit/admin/quotes?limit=50');
+      expect(apiUrl({ path, params })).toBe('realunit/admin/quotes?limit=50');
     });
   });
 });

--- a/src/contexts/realunit.context.tsx
+++ b/src/contexts/realunit.context.tsx
@@ -41,6 +41,8 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
   const [transactions, setTransactions] = useState<RealUnitTransaction[]>([]);
   const [quotesLoading, setQuotesLoading] = useState(false);
   const [transactionsLoading, setTransactionsLoading] = useState(false);
+  const [quotesError, setQuotesError] = useState(false);
+  const [transactionsError, setTransactionsError] = useState(false);
 
   const {
     getAccountSummary,
@@ -118,10 +120,12 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
 
   const fetchQuotes = useCallback(() => {
     setQuotesLoading(true);
+    setQuotesError(false);
     getAdminQuotes(50, quotes.length)
       .then((data) => {
         setQuotes((prev) => [...prev, ...data]);
       })
+      .catch(() => setQuotesError(true))
       .finally(() => setQuotesLoading(false));
   }, [quotes.length]);
 
@@ -131,10 +135,12 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
 
   const fetchTransactions = useCallback(() => {
     setTransactionsLoading(true);
+    setTransactionsError(false);
     getAdminTransactions(50, transactions.length)
       .then((data) => {
         setTransactions((prev) => [...prev, ...data]);
       })
+      .catch(() => setTransactionsError(true))
       .finally(() => setTransactionsLoading(false));
   }, [transactions.length]);
 
@@ -154,6 +160,8 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
       transactions,
       quotesLoading,
       transactionsLoading,
+      quotesError,
+      transactionsError,
       fetchAccountSummary,
       fetchAccountHistory,
       fetchHolders,
@@ -180,6 +188,8 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
       transactions,
       quotesLoading,
       transactionsLoading,
+      quotesError,
+      transactionsError,
       fetchAccountSummary,
       fetchAccountHistory,
       fetchHolders,

--- a/src/dto/realunit.dto.ts
+++ b/src/dto/realunit.dto.ts
@@ -131,6 +131,8 @@ export interface RealunitContextInterface {
   transactions: RealUnitTransaction[];
   quotesLoading: boolean;
   transactionsLoading: boolean;
+  quotesError: boolean;
+  transactionsError: boolean;
   fetchAccountSummary: (address: string) => void;
   fetchAccountHistory: (address: string, cursor?: string, direction?: PaginationDirection) => void;
   fetchHolders: (cursor?: string, direction?: PaginationDirection) => void;

--- a/src/hooks/realunit-api.hook.ts
+++ b/src/hooks/realunit-api.hook.ts
@@ -12,7 +12,7 @@ import {
   TokenPrice,
 } from 'src/dto/realunit.dto';
 import { Timeframe } from 'src/util/chart';
-import { relativeUrl } from 'src/util/utils';
+import { apiUrl } from 'src/util/utils';
 
 export function useRealunitApi() {
   const { call } = useGuardedApi();
@@ -33,7 +33,7 @@ export function useRealunitApi() {
     cursor && direction && params.set(String(direction) === 'prev' ? 'before' : 'after', cursor);
 
     return call<AccountHistory>({
-      url: relativeUrl({ path: `realunit/account/${address}/history`, params }),
+      url: apiUrl({ path: `realunit/account/${address}/history`, params }),
       method: 'GET',
     });
   }
@@ -43,7 +43,7 @@ export function useRealunitApi() {
     cursor && direction && params.set(String(direction) === 'prev' ? 'before' : 'after', cursor);
 
     return call<HoldersResponse>({
-      url: relativeUrl({ path: 'realunit/holders', params }),
+      url: apiUrl({ path: 'realunit/holders', params }),
       method: 'GET',
     });
   }
@@ -67,7 +67,7 @@ export function useRealunitApi() {
     params.set('timeFrame', timeFrame.toUpperCase());
 
     return call<PriceHistoryEntry[]>({
-      url: relativeUrl({ path: 'realunit/price/history', params }),
+      url: apiUrl({ path: 'realunit/price/history', params }),
       method: 'GET',
     });
   }
@@ -78,7 +78,7 @@ export function useRealunitApi() {
     if (offset != null) params.set('offset', String(offset));
 
     return call<RealUnitQuote[]>({
-      url: relativeUrl({ path: 'realunit/admin/quotes', params }),
+      url: apiUrl({ path: 'realunit/admin/quotes', params }),
       method: 'GET',
     });
   }
@@ -89,7 +89,7 @@ export function useRealunitApi() {
     if (offset != null) params.set('offset', String(offset));
 
     return call<RealUnitTransaction[]>({
-      url: relativeUrl({ path: 'realunit/admin/transactions', params }),
+      url: apiUrl({ path: 'realunit/admin/transactions', params }),
       method: 'GET',
     });
   }

--- a/src/screens/realunit-quote-detail.screen.tsx
+++ b/src/screens/realunit-quote-detail.screen.tsx
@@ -1,6 +1,7 @@
 import { SpinnerSize, StyledButton, StyledButtonWidth, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { ErrorHint } from 'src/components/error-hint';
 import { ConfirmationOverlay } from 'src/components/overlay/confirmation-overlay';
 import { useRealunitContext } from 'src/contexts/realunit.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
@@ -15,7 +16,7 @@ export default function RealunitQuoteDetailScreen(): JSX.Element {
   const { translate } = useSettingsContext();
   const { navigate } = useNavigation();
   const { id } = useParams<{ id: string }>();
-  const { quotes, quotesLoading, fetchQuotes, resetQuotes, confirmPayment } = useRealunitContext();
+  const { quotes, quotesLoading, quotesError, fetchQuotes, resetQuotes, confirmPayment } = useRealunitContext();
   const [showConfirmation, setShowConfirmation] = useState(false);
 
   useLayoutOptions({ title: translate('screens/realunit', 'Quote Detail'), backButton: true });
@@ -41,6 +42,12 @@ export default function RealunitQuoteDetailScreen(): JSX.Element {
     return <StyledLoadingSpinner size={SpinnerSize.LG} />;
   }
 
+  // fetch failed: show an error instead of masquerading as "not found"
+  if (quotesError && !quote) {
+    return <ErrorHint message={translate('screens/realunit', 'Failed to load quote details.')} />;
+  }
+
+  // fetch succeeded, but the requested id is not present
   if (!quote) {
     return <p className="text-dfxGray-700">{translate('screens/realunit', 'Quote not found')}</p>;
   }

--- a/src/screens/realunit-quotes.screen.tsx
+++ b/src/screens/realunit-quotes.screen.tsx
@@ -1,5 +1,6 @@
 import { SpinnerSize, StyledButton, StyledButtonWidth, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useEffect } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
 import { useRealunitContext } from 'src/contexts/realunit.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useRealunitGuard } from 'src/hooks/guard.hook';
@@ -12,7 +13,7 @@ export default function RealunitQuotesScreen(): JSX.Element {
 
   const { translate } = useSettingsContext();
   const { navigate } = useNavigation();
-  const { quotes, quotesLoading, fetchQuotes } = useRealunitContext();
+  const { quotes, quotesLoading, quotesError, fetchQuotes } = useRealunitContext();
 
   useLayoutOptions({ title: translate('screens/realunit', 'Pending Transactions'), backButton: true });
 
@@ -73,7 +74,7 @@ export default function RealunitQuotesScreen(): JSX.Element {
                     </td>
                   </tr>
                 ))}
-                {!quotes.length && !quotesLoading && (
+                {!quotes.length && !quotesLoading && !quotesError && (
                   <tr>
                     <td colSpan={4} className="px-4 py-3 text-center text-sm text-dfxGray-700">
                       {translate('screens/realunit', 'No pending transactions found')}
@@ -83,6 +84,12 @@ export default function RealunitQuotesScreen(): JSX.Element {
               </tbody>
             </table>
           </div>
+
+          {quotesError && (
+            <div className="mt-4">
+              <ErrorHint message={translate('screens/realunit', 'Failed to load pending transactions.')} />
+            </div>
+          )}
 
           {quotes.length > 0 && (
             <div className="flex justify-center mt-4">

--- a/src/screens/realunit-transaction-detail.screen.tsx
+++ b/src/screens/realunit-transaction-detail.screen.tsx
@@ -1,6 +1,7 @@
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import { ErrorHint } from 'src/components/error-hint';
 import { useRealunitContext } from 'src/contexts/realunit.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useRealunitGuard } from 'src/hooks/guard.hook';
@@ -14,7 +15,7 @@ export default function RealunitTransactionDetailScreen(): JSX.Element {
   const { translate } = useSettingsContext();
   const { navigate } = useNavigation();
   const { id } = useParams<{ id: string }>();
-  const { transactions, transactionsLoading, fetchTransactions } = useRealunitContext();
+  const { transactions, transactionsLoading, transactionsError, fetchTransactions } = useRealunitContext();
 
   useLayoutOptions({ title: translate('screens/realunit', 'Transaction Detail'), backButton: true });
 
@@ -39,6 +40,12 @@ export default function RealunitTransactionDetailScreen(): JSX.Element {
     return <StyledLoadingSpinner size={SpinnerSize.LG} />;
   }
 
+  // fetch failed: show an error instead of masquerading as "not found"
+  if (transactionsError && !transaction) {
+    return <ErrorHint message={translate('screens/realunit', 'Failed to load transaction details.')} />;
+  }
+
+  // fetch succeeded, but the requested id is not present
   if (!transaction) {
     return <p className="text-dfxGray-700">{translate('screens/realunit', 'Transaction not found')}</p>;
   }

--- a/src/screens/realunit-transactions.screen.tsx
+++ b/src/screens/realunit-transactions.screen.tsx
@@ -1,5 +1,6 @@
 import { SpinnerSize, StyledButton, StyledButtonWidth, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useEffect } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
 import { useRealunitContext } from 'src/contexts/realunit.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useRealunitGuard } from 'src/hooks/guard.hook';
@@ -12,7 +13,7 @@ export default function RealunitTransactionsScreen(): JSX.Element {
 
   const { translate } = useSettingsContext();
   const { navigate } = useNavigation();
-  const { transactions, transactionsLoading, fetchTransactions } = useRealunitContext();
+  const { transactions, transactionsLoading, transactionsError, fetchTransactions } = useRealunitContext();
 
   useLayoutOptions({ title: translate('screens/realunit', 'Received Transactions'), backButton: true });
 
@@ -75,7 +76,7 @@ export default function RealunitTransactionsScreen(): JSX.Element {
                     </td>
                   </tr>
                 ))}
-                {!transactions.length && !transactionsLoading && (
+                {!transactions.length && !transactionsLoading && !transactionsError && (
                   <tr>
                     <td colSpan={4} className="px-4 py-3 text-center text-sm text-dfxGray-700">
                       {translate('screens/realunit', 'No received transactions found')}
@@ -85,6 +86,12 @@ export default function RealunitTransactionsScreen(): JSX.Element {
               </tbody>
             </table>
           </div>
+
+          {transactionsError && (
+            <div className="mt-4">
+              <ErrorHint message={translate('screens/realunit', 'Failed to load received transactions.')} />
+            </div>
+          )}
 
           {transactions.length > 0 && (
             <div className="flex justify-center mt-4">

--- a/src/util/utils.ts
+++ b/src/util/utils.ts
@@ -57,10 +57,20 @@ export function url({
   return absoluteUrl.href;
 }
 
+// Router navigation path (react-router): the leading slash is REQUIRED so the target is treated as
+// an absolute in-app route. Use for navigate()/setCallback, never for SDK call configs.
 export function relativeUrl({ path, params }: { path: string; params?: URLSearchParams }): string {
   if (isAbsoluteUrl(path)) return url({ base: path, params });
 
   const normalizedPath = '/' + path.replace(/^\/+/, ''); // start with a single slash
+  return params && params.toString() ? `${normalizedPath}?${params}` : normalizedPath;
+}
+
+// SDK call path (DfxHttpClient config.url): the leading slash is FORBIDDEN because the client joins
+// baseUrl + '/' + url. A leading slash would produce a double slash (e.g. .../v1//realunit/...) and
+// a 404 before any guard runs. Use for call() configs, never for router navigation.
+export function apiUrl({ path, params }: { path: string; params?: URLSearchParams }): string {
+  const normalizedPath = path.replace(/^\/+/, ''); // remove leading slashes
   return params && params.toString() ? `${normalizedPath}?${params}` : normalizedPath;
 }
 


### PR DESCRIPTION
## Problem

All RealUnit staff dashboard API calls built with `relativeUrl()` were sent with a leading slash. The SDK (`@dfx.swiss/core` `DfxHttpClient`) joins `baseUrl + '/' + config.url`, so a leading slash produced a double slash (e.g. `https://api.dfx.swiss/v1//realunit/...`), which Express answers with a 404 before any guard runs.

This blocked the staff 2FA flow: because the request 404'd, the API never got to answer `403 { code: 'TFA_REQUIRED' }`, so `useGuardedApi` never redirected mail-origin staff sessions to `/2fa`.

Additionally, `fetchQuotes`/`fetchTransactions` had no `.catch`, so the 404 was silently swallowed and the screens rendered the misleading empty state ("No pending transactions found") instead of an error.

## Fix

- Add an `apiUrl()` helper next to `relativeUrl()` in `src/util/utils.ts`. It strips any leading slashes (the SDK forbids them for `config.url`) and appends `?<params>` only when params has entries. `relativeUrl()` is unchanged and stays for router navigation, where a leading slash is required — the two helpers now carry contrasting comments.
- Switch the five affected call sites in `src/hooks/realunit-api.hook.ts` from `relativeUrl` to `apiUrl`:
  - `getAccountHistory`
  - `getHolders`
  - `getPriceHistory`
  - `getAdminQuotes`
  - `getAdminTransactions`
- Add `.catch` handling to `fetchQuotes`/`fetchTransactions` in `src/contexts/realunit.context.tsx`, tracking `quotesError` / `transactionsError` (cleared on each retry) and exposing them via the context interface.
- Render a visible `ErrorHint` on the quotes and transactions **list screens** when the error state is set, replacing the misleading empty-state text. Uses the existing `ErrorHint` component (repo custom Tailwind palette, `dfxRed` tokens).
- Same on the **detail screens** (`realunit-quote-detail.screen.tsx`, `realunit-transaction-detail.screen.tsx`): they previously rendered "Quote not found" / "Transaction not found" even when the fetch itself had failed (5xx, network error, or a deep link where the fetch fails before the 2FA redirect). They now render `ErrorHint` when the fetch failed and no entity is available (ordering: loading → error → not found → content), keeping the "not found" text only for the genuine case (fetch succeeded, id not present). The error branch is guarded by the entity lookup, so a stale error flag can never hide an already-loaded quote/transaction.

## Sweep

Confirmed the only broken API call sites were the five RealUnit ones. Remaining `relativeUrl` usages (`navigation.hook.ts`, `app-handling.context.tsx`, `invoice.screen.tsx` `setCallback`) are router navigation and are correct. No `boltcards` code exists in this repo.

## Tests

Added unit tests for `apiUrl` (leading-slash stripping, conditional params) and the `relativeUrl` contrast in `src/__tests__/utils.test.ts`. Full suite passes (28 suites / 310 tests); `npm run lint` passes.

Fixes #1150