### PR TITLE
Bump @dfx.swiss/react to 1.4.1 for hardened URL joining

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.4.0",
+        "@dfx.swiss/react": "^1.4.1",
         "@dfx.swiss/react-components": "^1.3.2",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@dfx.swiss/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-+sbbO1B4xXePCV5uzzVG73VLxVwRz7CnDAw69pJNF5xOm7HjWj8FakJO47WPw5Ae8W6pcXbY0h2Ppg3dxgybEw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.1.tgz",
+      "integrity": "sha512-S0YVOEhNlXGWuDgt6TJe3zj86ELHAe3+6J4dUGLezDstOceinvMnUI2wkjn6FN1dFJxY7M9kt5a3I5f43fpalQ==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2642,12 +2642,12 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.0.tgz",
-      "integrity": "sha512-7RRQo704YAeXsoOF73CsRTEQK/p1wQ0L4gIU2PD9y8tzi/mKkLfqKWkdmycRomNheUibEx5EV4fxIvh9TOkNFg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.1.tgz",
+      "integrity": "sha512-tCdEf1cpA+x8ULt2sdBtkuFcnYZG0sG4E9zgyjkZbFC5iY461/cAYyexu3IqIE512lQCTV5Abx8DX0rbxtegMQ==",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/core": "^0.3.0",
+        "@dfx.swiss/core": "^0.3.1",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "typescript": "^4.9.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.4.0",
+    "@dfx.swiss/react": "^1.4.1",
     "@dfx.swiss/react-components": "^1.3.2",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",


### PR DESCRIPTION
Bumps `@dfx.swiss/react` to ^1.4.1 (lockfile now pins react 1.4.1 / core 0.3.1), bringing in the `Utils.joinUrl` hardening published in DFXswiss/packages#184: the SDK now strips duplicate slashes when building request URLs (both `DfxHttpClient` and the `api.hook`). This is defense-in-depth for the double-slash 404 class behind #1150 — the call-site fix already landed in #1151; this makes the SDK itself tolerant of a trailing/leading slash so the bug class cannot recur from the client. No source changes, dependency bump only; `npm run test` (310 tests) and `npm run lint` pass.