### PR TITLE
Restrict RealUnit price chart to API-supported timeframes

### DIFF
--- a/src/components/realunit/price-history-chart.tsx
+++ b/src/components/realunit/price-history-chart.tsx
@@ -7,6 +7,16 @@ import { FiatCurrency } from 'src/dto/safe.dto';
 import { Timeframe } from 'src/util/chart';
 import { ButtonGroup } from '../safe/button-group';
 
+// The RealUnit price API only supports these timeframes; its data is
+// daily-granularity, so 24h/3D are meaningless here and rejected (400) by the API.
+const SUPPORTED_TIMEFRAMES: Timeframe[] = [
+  Timeframe.WEEK,
+  Timeframe.MONTH,
+  Timeframe.QUARTER,
+  Timeframe.YEAR,
+  Timeframe.ALL,
+];
+
 interface PriceHistoryChartProps {
   timeframe: Timeframe;
   priceHistory: PriceHistoryEntry[];
@@ -94,7 +104,7 @@ export const PriceHistoryChart = ({ timeframe, priceHistory, onTimeframeChange }
         <Chart type="area" height={300} options={chartOptions} series={chartSeries} />
         <div className="mt-4 flex justify-center">
           <ButtonGroup<Timeframe>
-            items={Object.values(Timeframe)}
+            items={SUPPORTED_TIMEFRAMES}
             selected={timeframe}
             onClick={(tf) => onTimeframeChange(tf)}
             buttonLabel={(tf) => tf}

--- a/src/contexts/realunit.context.tsx
+++ b/src/contexts/realunit.context.tsx
@@ -43,6 +43,7 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
   const [transactionsLoading, setTransactionsLoading] = useState(false);
   const [quotesError, setQuotesError] = useState(false);
   const [transactionsError, setTransactionsError] = useState(false);
+  const [priceHistoryError, setPriceHistoryError] = useState(false);
 
   const {
     getAccountSummary,
@@ -98,10 +99,13 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
 
   const fetchPriceHistory = useCallback(
     (timeframe = Timeframe.ALL) => {
-      getPriceHistory(timeframe).then((priceData) => {
-        setPriceHistory(priceData);
-        setTimeframe(timeframe);
-      });
+      setPriceHistoryError(false);
+      getPriceHistory(timeframe)
+        .then((priceData) => {
+          setPriceHistory(priceData);
+          setTimeframe(timeframe);
+        })
+        .catch(() => setPriceHistoryError(true));
     },
     [setPriceHistory, setTimeframe],
   );
@@ -162,6 +166,7 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
       transactionsLoading,
       quotesError,
       transactionsError,
+      priceHistoryError,
       fetchAccountSummary,
       fetchAccountHistory,
       fetchHolders,
@@ -190,6 +195,7 @@ export function RealunitContextProvider({ children }: PropsWithChildren): JSX.El
       transactionsLoading,
       quotesError,
       transactionsError,
+      priceHistoryError,
       fetchAccountSummary,
       fetchAccountHistory,
       fetchHolders,

--- a/src/dto/realunit.dto.ts
+++ b/src/dto/realunit.dto.ts
@@ -133,6 +133,7 @@ export interface RealunitContextInterface {
   transactionsLoading: boolean;
   quotesError: boolean;
   transactionsError: boolean;
+  priceHistoryError: boolean;
   fetchAccountSummary: (address: string) => void;
   fetchAccountHistory: (address: string, cursor?: string, direction?: PaginationDirection) => void;
   fetchHolders: (cursor?: string, direction?: PaginationDirection) => void;

--- a/src/screens/realunit.screen.tsx
+++ b/src/screens/realunit.screen.tsx
@@ -8,6 +8,7 @@ import {
   StyledLoadingSpinner,
 } from '@dfx.swiss/react-components';
 import { useEffect } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
 import { PriceHistoryChart } from 'src/components/realunit/price-history-chart';
 import { useRealunitContext } from 'src/contexts/realunit.context';
 import { useSettingsContext } from 'src/contexts/settings.context';
@@ -29,6 +30,7 @@ export default function RealunitScreen(): JSX.Element {
     tokenInfo,
     isLoading,
     priceHistory,
+    priceHistoryError,
     timeframe,
     quotes,
     transactions,
@@ -84,6 +86,11 @@ export default function RealunitScreen(): JSX.Element {
               priceHistory={priceHistory}
               onTimeframeChange={fetchPriceHistory}
             />
+            {priceHistoryError && (
+              <div className="mt-4">
+                <ErrorHint message={translate('screens/realunit', 'Failed to load price history.')} />
+              </div>
+            )}
           </div>
 
           {isLoading ? (


### PR DESCRIPTION
- Restrict the RealUnit price chart timeframe buttons to the API-supported subset (1W/1M/1Q/1Y/ALL) via a `SUPPORTED_TIMEFRAMES` constant, dropping the `24h`/`3D` options the backend rejected with a silently-swallowed 400. The shared `Timeframe` enum is left untouched (still used by the dashboard and safe charts).
- Add `.catch` + a `priceHistoryError` flag to `fetchPriceHistory`, surfaced via `ErrorHint` on the RealUnit screen, so a failed request no longer leaves the chart silently stuck on the old timeframe (mirrors the quotes/transactions error handling from #1151).

Fixes #1152