### PR TITLE
feat(compliance): DE/EN PDF export for OnRamp/OffRamp/Account Info (DEV-4572)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
         "https-browserify": "^1.0.0",
         "i18next": "^22.4.13",
         "i18next-browser-languagedetector": "^7.1.0",
+        "jspdf": "^4.2.1",
+        "jspdf-autotable": "^5.0.8",
         "jwt-decode": "^4.0.0",
         "ledger-bitcoin": "^0.2.3",
         "libphonenumber-js": "^1.12.33",
@@ -11558,6 +11560,12 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -11591,6 +11599,13 @@
       "version": "6.9.15",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
       "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg=="
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -14495,6 +14510,16 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -15551,6 +15576,33 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
@@ -16504,6 +16556,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-loader": {
@@ -17600,6 +17662,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -19658,6 +19730,33 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fast-redact": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
@@ -19732,6 +19831,12 @@
       "dependencies": {
         "is-retry-allowed": "^3.0.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -21022,6 +21127,20 @@
         }
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -21453,6 +21572,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -24701,6 +24826,41 @@
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.8.tgz",
+      "integrity": "sha512-Hy05N86yBO7CXBrnSLOge7i1ZYpKH2DjQ94iybaP7vBhSInjvRBgDc99ngKzSbSO8Jc98ZCally8I6n0tj2RJQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
+      }
+    },
+    "node_modules/jspdf/node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/jsprim": {
@@ -30445,6 +30605,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -31999,6 +32169,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -32595,6 +32775,16 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
@@ -33110,6 +33300,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -34552,6 +34752,16 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "https-browserify": "^1.0.0",
     "i18next": "^22.4.13",
     "i18next-browser-languagedetector": "^7.1.0",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.8",
     "jwt-decode": "^4.0.0",
     "ledger-bitcoin": "^0.2.3",
     "libphonenumber-js": "^1.12.33",

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -11,15 +11,18 @@ import {
   CryptoInputInfo,
   RecallInfo,
   TransactionInfo,
+  UserDataDetail,
   useCompliance,
 } from 'src/hooks/compliance.hook';
 import { boolBadge, DetailRow, statusBadge, TransactionDetailRows, formatDate } from 'src/util/compliance-helpers';
+import { PdfLang } from 'src/util/pdf/support-pdf-common';
 
 interface TransactionsTableProps {
   transactions: TransactionInfo[];
   bankTxs: BankTxInfo[];
   cryptoInputs: CryptoInputInfo[];
   bankDatas: BankDataInfo[];
+  userData: UserDataDetail;
   userDataId: number;
   expandedBankTxId?: number;
   expandedCryptoInputId?: number;
@@ -38,6 +41,7 @@ export function TransactionsTable({
   bankTxs,
   cryptoInputs,
   bankDatas,
+  userData,
   userDataId,
   expandedBankTxId,
   expandedCryptoInputId,
@@ -95,6 +99,33 @@ export function TransactionsTable({
     } finally {
       setIsPdfDownloading(false);
     }
+  }
+
+  async function handleTxPdf(tx: TransactionInfo, ramp: 'onramp' | 'offramp', lang: PdfLang): Promise<void> {
+    const bankTx = bankTxs?.find((b) => b.transactionId === tx.id);
+    const cryptoInput = cryptoInputs?.find((c) => c.transactionId === tx.id);
+    const { generateTransactionPdf } = await import('src/util/pdf/support-tx-pdf');
+    generateTransactionPdf({
+      transaction: tx,
+      bankTx,
+      cryptoInput,
+      userData,
+      ramp,
+      lang,
+    });
+  }
+
+  async function handleAccountInfoPdf(tx: TransactionInfo, lang: PdfLang): Promise<void> {
+    const bankTx = bankTxs?.find((b) => b.transactionId === tx.id);
+    const bankData = tx.bankDataId != null ? bankDatas?.find((b) => b.id === tx.bankDataId) : undefined;
+    const { generateAccountInfoPdf } = await import('src/util/pdf/support-account-pdf');
+    generateAccountInfoPdf({
+      userData,
+      transaction: tx,
+      bankTx,
+      bankData,
+      lang,
+    });
   }
 
   function handleUidClick(uid: string): void {
@@ -385,9 +416,47 @@ export function TransactionsTable({
                                   const showStop = canStop && canPerformActions;
                                   const showChargeback = canChargeback && canPerformActions;
                                   const showRecall = canRecall && canPerformActions;
-                                  if (!showStop && !showChargeback && !showRecall && !existingRecall) return null;
+                                  const ramp: 'onramp' | 'offramp' | undefined =
+                                    tx.type === 'BuyCrypto' ? 'onramp' : tx.type === 'BuyFiat' ? 'offramp' : undefined;
+                                  const showRampPdf = ramp != null;
+                                  if (
+                                    !showStop &&
+                                    !showChargeback &&
+                                    !showRecall &&
+                                    !existingRecall &&
+                                    !showRampPdf
+                                  )
+                                    return null;
                                   return (
-                                    <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2">
+                                    <div className="mt-3 pt-3 border-t border-dfxGray-400/50 flex gap-2 flex-wrap">
+                                      {showRampPdf && (
+                                        <>
+                                          <button
+                                            className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
+                                            onClick={() => handleTxPdf(tx, ramp, 'de')}
+                                          >
+                                            {ramp === 'onramp' ? 'OnRamp' : 'OffRamp'} PDF (DE)
+                                          </button>
+                                          <button
+                                            className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
+                                            onClick={() => handleTxPdf(tx, ramp, 'en')}
+                                          >
+                                            {ramp === 'onramp' ? 'OnRamp' : 'OffRamp'} PDF (EN)
+                                          </button>
+                                          <button
+                                            className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
+                                            onClick={() => handleAccountInfoPdf(tx, 'de')}
+                                          >
+                                            Account Info PDF (DE)
+                                          </button>
+                                          <button
+                                            className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
+                                            onClick={() => handleAccountInfoPdf(tx, 'en')}
+                                          >
+                                            Account Info PDF (EN)
+                                          </button>
+                                        </>
+                                      )}
                                       {showStop && (
                                         <button
                                           className="px-3 py-1 text-xs text-white bg-dfxRed-100 hover:bg-dfxRed-100/80 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -435,25 +435,25 @@ export function TransactionsTable({
                                             className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
                                             onClick={() => handleTxPdf(tx, ramp, 'de')}
                                           >
-                                            {ramp === 'onramp' ? 'OnRamp' : 'OffRamp'} PDF (DE)
+                                            Transaction PDF (DE)
                                           </button>
                                           <button
                                             className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
                                             onClick={() => handleTxPdf(tx, ramp, 'en')}
                                           >
-                                            {ramp === 'onramp' ? 'OnRamp' : 'OffRamp'} PDF (EN)
+                                            Transaction PDF (EN)
                                           </button>
                                           <button
                                             className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
                                             onClick={() => handleAccountInfoPdf(tx, 'de')}
                                           >
-                                            Account Info PDF (DE)
+                                            Account PDF (DE)
                                           </button>
                                           <button
                                             className="px-3 py-1 text-xs text-dfxBlue-800 bg-dfxGray-300 hover:bg-dfxGray-400/80 rounded transition-colors"
                                             onClick={() => handleAccountInfoPdf(tx, 'en')}
                                           >
-                                            Account Info PDF (EN)
+                                            Account PDF (EN)
                                           </button>
                                         </>
                                       )}

--- a/src/screens/compliance-user.screen.tsx
+++ b/src/screens/compliance-user.screen.tsx
@@ -257,6 +257,7 @@ export default function ComplianceUserScreen(): JSX.Element {
               bankTxs={data.bankTxs}
               cryptoInputs={data.cryptoInputs}
               bankDatas={data.bankDatas}
+              userData={data.userData}
               userDataId={numericUserDataId}
               expandedBankTxId={expandedBankTxId}
               expandedCryptoInputId={expandedCryptoInputId}

--- a/src/util/pdf/support-account-pdf.ts
+++ b/src/util/pdf/support-account-pdf.ts
@@ -1,0 +1,206 @@
+import { jsPDF } from 'jspdf';
+import autoTable, { RowInput } from 'jspdf-autotable';
+import { BankDataInfo, BankTxInfo, TransactionInfo, UserDataDetail } from 'src/hooks/compliance.hook';
+import {
+  ageFromBirthday,
+  COLOR,
+  dashIfEmpty,
+  drawFooter,
+  filenameSafe,
+  formatAmount,
+  formatDateTimeUtc,
+  PdfLang,
+  saveWithFilename,
+} from './support-pdf-common';
+
+interface AccountLabels {
+  bannerLeft: string; // "DFX-Account"
+  bannerRight: string; // "Bank-Account ..."
+  accountName: string;
+  firstLast: string;
+  streetHouse: string;
+  zipCountry: string;
+  city: string;
+  citizenshipAge: string;
+  userDataId: string;
+  accountRiskStatus: string;
+  kycStatusLimit: string;
+  email: string;
+  phone: string;
+  accountHolder: string;
+  extraInfo: string;
+  addressLine1: string;
+  addressLine2: string;
+  amountReceived: string;
+  time: string;
+  transactionCol: string;
+  buyCryptoId: string;
+  txId: string;
+  deposit: string;
+  refCode: string;
+  purpose: string;
+  onrampNote: string;
+  noBicNote: string;
+  fromIban: string;
+  onIban: string;
+}
+
+const LABELS: Record<PdfLang, AccountLabels> = {
+  de: {
+    bannerLeft: 'DFX-Account',
+    bannerRight: 'Bank-Account  -  inkl. Zusatzinfos zu der betreffenden Banküberweisung  (Onramp = Fiat2Krypto)',
+    accountName: 'Account Name',
+    firstLast: 'Vorname + Name',
+    streetHouse: 'Straße + Hs-Nr.',
+    zipCountry: 'PLZ + Land',
+    city: 'Wohnort',
+    citizenshipAge: 'Staatsbürger von + Age',
+    userDataId: 'User Data ID',
+    accountRiskStatus: 'Account + Risk Status',
+    kycStatusLimit: 'KYC-Status + Limit',
+    email: 'Email-Adresse',
+    phone: 'Telefon-Nr.',
+    accountHolder: 'Konto-Halter',
+    extraInfo: 'Zusatz-Angabe',
+    addressLine1: 'Adress Zeile 1',
+    addressLine2: 'Adress Zeile 2',
+    amountReceived: 'Betrag erhalten',
+    time: 'Uhrzeit',
+    transactionCol: 'Transaktion',
+    buyCryptoId: 'Buy Crypto ID',
+    txId: 'Tx-ID',
+    deposit: 'Einzahlung',
+    refCode: 'RefCode',
+    purpose: 'Zahlungszweck',
+    onrampNote: 'Onramp = Fiat2Krypto',
+    noBicNote: '<keine BIC erhalten>',
+    fromIban: 'von',
+    onIban: 'auf',
+  },
+  en: {
+    bannerLeft: 'DFX-Account',
+    bannerRight: 'Bank-Account  -  incl. additional info on the relevant bank transfer  (Onramp = Fiat2Crypto)',
+    accountName: 'Account Name',
+    firstLast: 'First name + Last name',
+    streetHouse: 'Street + Nr.',
+    zipCountry: 'ZIP + Country',
+    city: 'City',
+    citizenshipAge: 'Citizen of + Age',
+    userDataId: 'User Data ID',
+    accountRiskStatus: 'Account + Risk Status',
+    kycStatusLimit: 'KYC Status + Limit',
+    email: 'Email Address',
+    phone: 'Phone number',
+    accountHolder: 'Account Holder',
+    extraInfo: 'Additional info',
+    addressLine1: 'Address line 1',
+    addressLine2: 'Address line 2',
+    amountReceived: 'Amount received',
+    time: 'Time',
+    transactionCol: 'Transaction',
+    buyCryptoId: 'Buy Crypto ID',
+    txId: 'Tx-ID',
+    deposit: 'Deposit',
+    refCode: 'RefCode',
+    purpose: 'Payment purpose',
+    onrampNote: 'Onramp = Fiat2Crypto',
+    noBicNote: '<no BIC received>',
+    fromIban: 'from',
+    onIban: 'on',
+  },
+};
+
+interface AccountPdfInput {
+  userData: UserDataDetail;
+  transaction?: TransactionInfo;
+  bankTx?: BankTxInfo;
+  bankData?: BankDataInfo;
+  lang: PdfLang;
+}
+
+function pushRow(
+  rows: RowInput[],
+  leftLabel: string,
+  leftValue: string,
+  rightLabel: string,
+  rightValue: string,
+): void {
+  rows.push([
+    { content: leftLabel + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: leftValue },
+    { content: rightLabel + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: rightValue },
+  ]);
+}
+
+export function generateAccountInfoPdf(input: AccountPdfInput): void {
+  const { userData: ud, transaction: tx, bankTx, bankData, lang } = input;
+  const t = LABELS[lang];
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+
+  // --- Header banner ---
+  const bannerY = 10;
+  const bannerH = 8;
+  const halfW = (pageWidth - 20) / 2;
+  doc.setFillColor(...COLOR.headerBg);
+  doc.rect(10, bannerY, halfW, bannerH, 'F');
+  doc.rect(10 + halfW, bannerY, halfW, bannerH, 'F');
+  doc.setDrawColor(...COLOR.border);
+  doc.rect(10, bannerY, halfW, bannerH, 'S');
+  doc.rect(10 + halfW, bannerY, halfW, bannerH, 'S');
+  doc.setFontSize(11);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(...COLOR.text);
+  doc.text(t.bannerLeft, 12, bannerY + 5.5);
+  doc.text(t.bannerRight, 12 + halfW, bannerY + 5.5);
+
+  // --- Table body ---
+  const rows: RowInput[] = [];
+  const dfxName = ud.verifiedName ?? [ud.firstname, ud.surname].filter(Boolean).join(' ');
+  const streetHouse = [ud.street, ud.houseNumber].filter(Boolean).join(' ');
+  const zipCountry = `${dashIfEmpty(ud.zip)}   ${dashIfEmpty(ud.country?.symbol ?? ud.country?.name)}`;
+  const kycLimit = `${dashIfEmpty(ud.kycStatus)} · ${dashIfEmpty(ud.kycLevel)}   ${
+    ud.depositLimit != null ? formatAmount(ud.depositLimit, 0) + ' CHF' : ''
+  }`.trim();
+  const accountRisk = `${dashIfEmpty(ud.status)}   ${dashIfEmpty(ud.riskStatus)}`;
+  const citizen = `${dashIfEmpty(ud.nationality?.name)}   ${ageFromBirthday(ud.birthday)}`;
+
+  const bank = bankData ?? undefined;
+  const bankHolder = bank?.name ?? bankTx?.name ?? '-';
+  const receivedDt = tx?.created ? formatDateTimeUtc(tx.created) : { date: '-', time: '-' };
+  const txCell = `${dashIfEmpty(tx?.buyCryptoId ?? tx?.buyFiatId)}   /   ${dashIfEmpty(tx?.id)}`;
+  const inputAmountCell =
+    tx?.inputAmount != null ? `${formatAmount(tx.inputAmount)} ${dashIfEmpty(tx.inputAsset)}` : '-';
+
+  pushRow(rows, t.accountName, dfxName || '-', t.accountHolder, bankHolder);
+  pushRow(rows, t.firstLast, dashIfEmpty([ud.firstname, ud.surname].filter(Boolean).join(' ')), t.extraInfo, '');
+  pushRow(rows, t.streetHouse, streetHouse || '-', t.addressLine1, dashIfEmpty(bank?.iban));
+  pushRow(rows, t.zipCountry, zipCountry, t.addressLine2, '');
+  pushRow(rows, t.city, dashIfEmpty(ud.location), t.amountReceived, `${receivedDt.date}   ${t.onIban}   ${dashIfEmpty(bank?.iban)}`);
+  pushRow(rows, t.citizenshipAge, citizen, t.time, `${receivedDt.time}   ${t.noBicNote}`);
+  pushRow(rows, t.userDataId, String(ud.id), t.buyCryptoId, dashIfEmpty(tx?.buyCryptoId ?? tx?.buyFiatId));
+  pushRow(rows, t.accountRiskStatus, accountRisk, t.txId, txCell);
+  pushRow(rows, t.kycStatusLimit, kycLimit, t.deposit, inputAmountCell);
+  pushRow(rows, t.email, dashIfEmpty(ud.mail), t.refCode, '-');
+  pushRow(rows, t.phone, dashIfEmpty(ud.phone), t.purpose, dashIfEmpty(bankTx?.remittanceInfo));
+
+  autoTable(doc, {
+    startY: bannerY + bannerH + 2,
+    margin: { left: 10, right: 10 },
+    theme: 'grid',
+    styles: { fontSize: 9, cellPadding: 1.5, textColor: COLOR.text, lineColor: COLOR.border },
+    columnStyles: {
+      0: { cellWidth: 42 },
+      1: { cellWidth: halfW - 42 },
+      2: { cellWidth: 42 },
+      3: { cellWidth: halfW - 42 },
+    },
+    body: rows,
+  });
+
+  drawFooter(doc, lang);
+
+  const filename = filenameSafe(`DFX_AccountInfo_${ud.id}_${lang.toUpperCase()}.pdf`);
+  saveWithFilename(doc, filename);
+}

--- a/src/util/pdf/support-pdf-common.ts
+++ b/src/util/pdf/support-pdf-common.ts
@@ -1,0 +1,116 @@
+import { jsPDF } from 'jspdf';
+
+export type PdfLang = 'de' | 'en';
+export type RGB = [number, number, number];
+
+// DFX palette (mirrors tailwind.config.js — colors validated via unit test).
+const DFX = {
+  dfxBlue400: '#124370',
+  dfxBlue800: '#072440',
+  dfxGray300: '#F3F4F7',
+  dfxGray500: '#D6DBE2',
+  dfxGray600: '#B8C4D8',
+  dfxRed100: '#F5516C',
+  dfxRed150: '#E73955',
+  dfxGreen100: '#27AE60',
+  dfxGreen300: '#196F3D',
+  dfxYellow500: '#EAB308',
+  dfxYellow700: '#A16207',
+} as const;
+
+function hexToRgb(hex: string): RGB {
+  const s = hex.replace('#', '');
+  return [parseInt(s.slice(0, 2), 16), parseInt(s.slice(2, 4), 16), parseInt(s.slice(4, 6), 16)];
+}
+
+export const COLOR = {
+  // Status accents
+  ok: hexToRgb(DFX.dfxGreen100),
+  okDark: hexToRgb(DFX.dfxGreen300),
+  warn: hexToRgb(DFX.dfxYellow500),
+  warnDark: hexToRgb(DFX.dfxYellow700),
+  error: hexToRgb(DFX.dfxRed100),
+  errorDark: hexToRgb(DFX.dfxRed150),
+  // DFX blue text / hyperlinks
+  text: hexToRgb(DFX.dfxBlue800),
+  link: hexToRgb(DFX.dfxBlue400),
+  // Neutrals for headers, labels, borders
+  headerBg: hexToRgb(DFX.dfxGray500),
+  labelBg: hexToRgb(DFX.dfxGray300),
+  border: hexToRgb(DFX.dfxGray600),
+};
+
+export function formatDateTimeUtc(iso?: string): { date: string; time: string } {
+  if (!iso) return { date: '-', time: '-' };
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return { date: iso, time: '' };
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+  const date = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`;
+  const time = `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
+  return { date, time };
+}
+
+export function dashIfEmpty(v: unknown): string {
+  if (v == null || v === '') return '-';
+  return String(v);
+}
+
+export function formatAmount(value?: number, decimals = 2): string {
+  if (value == null || Number.isNaN(value)) return '-';
+  return value.toLocaleString('de-CH', { minimumFractionDigits: decimals, maximumFractionDigits: decimals });
+}
+
+export function truncateMiddle(str: string, keepStart = 20, keepEnd = 10): string {
+  if (!str || str.length <= keepStart + keepEnd + 3) return str;
+  return `${str.slice(0, keepStart)}…${str.slice(-keepEnd)}`;
+}
+
+export function ageFromBirthday(birthday?: string): string {
+  if (!birthday) return '-';
+  const b = new Date(birthday);
+  if (Number.isNaN(b.getTime())) return '-';
+  const now = new Date();
+  let age = now.getUTCFullYear() - b.getUTCFullYear();
+  const monthDiff = now.getUTCMonth() - b.getUTCMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && now.getUTCDate() < b.getUTCDate())) age--;
+  return String(age);
+}
+
+export function drawFooter(doc: jsPDF, lang: PdfLang): void {
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const y = pageHeight - 12;
+
+  const dict: Record<PdfLang, { note: string; utc: string; cet: string; cest: string; hint: string }> = {
+    de: {
+      note: 'Die Koordinierte Weltzeit; entspricht auch GMT',
+      utc: 'UTC',
+      cet: 'MEZ = UTC +1',
+      cest: 'MESZ = UTC +2',
+      hint: 'Bitte während der Sommerzeit beachten!',
+    },
+    en: {
+      note: 'Universal Time Coordinated; also known as GMT',
+      utc: 'UTC',
+      cet: 'CET = UTC +1',
+      cest: 'CEST = UTC +2',
+      hint: 'Please note during the summer time period!',
+    },
+  };
+  const t = dict[lang];
+
+  doc.setFontSize(8);
+  doc.setTextColor(...COLOR.text);
+  doc.setDrawColor(...COLOR.border);
+  doc.line(10, y - 2, pageWidth - 10, y - 2);
+  doc.text(`${t.utc} — ${t.note}`, 10, y + 2);
+  doc.text(`${t.cet}   ${t.cest}   ${t.hint}`, 10, y + 6);
+}
+
+export function saveWithFilename(doc: jsPDF, filename: string): void {
+  doc.save(filename);
+}
+
+export function filenameSafe(str: string): string {
+  return str.replace(/[^A-Za-z0-9._-]+/g, '_');
+}

--- a/src/util/pdf/support-tx-pdf.ts
+++ b/src/util/pdf/support-tx-pdf.ts
@@ -1,0 +1,328 @@
+import { jsPDF } from 'jspdf';
+import autoTable, { RowInput } from 'jspdf-autotable';
+import { BankTxInfo, CryptoInputInfo, TransactionInfo, UserDataDetail } from 'src/hooks/compliance.hook';
+import {
+  COLOR,
+  dashIfEmpty,
+  drawFooter,
+  filenameSafe,
+  formatAmount,
+  formatDateTimeUtc,
+  PdfLang,
+  saveWithFilename,
+} from './support-pdf-common';
+
+export type TxRamp = 'onramp' | 'offramp';
+
+interface TxPdfLabels {
+  headingOn: string;
+  headingOff: string;
+  intro: string;
+  paymentMethod: string;
+  date: string;
+  time: string;
+  buyCryptoId: string;
+  paymentAmount: string;
+  paymentAmountFromIban: string;
+  kycStatus: string;
+  refCodeWallet: string;
+  cryptoAsset: string;
+  wipStatus: string;
+  order: string;
+  amount: string;
+  cryptoDelivery: string;
+  emailAddress: string;
+  emailConfirmation: string;
+  transactionId: string;
+  additionalInfo: string;
+  remittanceInfo: string;
+  dfxIban: string;
+  registered: string;
+  presentKycFound: string;
+  successfullyPassed: string;
+  cryptoDelivered: string;
+  moneyTransferred: string;
+  complete: string;
+  offrampComplete: string;
+  payoutAmount: string;
+  paidToIbanOrArrived: string;
+  bankTransfer: string;
+  additionalInfoWithdrawal: string;
+  cryptoSold: string;
+  statusUrl: string;
+  payout: string;
+  bank: string;
+  amountReceivedNote: string;
+}
+
+const LABELS: Record<PdfLang, TxPdfLabels> = {
+  de: {
+    headingOn: 'Analysebericht zu deiner Onramp (Fiat2Krypto / Kauf) Suchanfrage',
+    headingOff: 'Analysebericht zu deiner Offramp (Krypto2Fiat-Verkauf) Suchanfrage',
+    intro: 'Deine letzte Einzahlung haben wir erhalten:',
+    paymentMethod: 'Zahlungs-Methode',
+    date: 'Datum',
+    time: 'Uhrzeit',
+    buyCryptoId: 'BuyCrypto- / Tx-ID',
+    paymentAmount: 'Einzahlungsbetrag',
+    paymentAmountFromIban: 'von IBAN',
+    kycStatus: 'KYC-Status',
+    refCodeWallet: 'RefCode / Wallet',
+    cryptoAsset: 'Crypto- / Asset',
+    wipStatus: 'Bearbeitungsstatus',
+    order: 'Kaufauftrag',
+    amount: 'Betrag',
+    cryptoDelivery: 'Krypto-Lieferung',
+    emailAddress: 'Email-Adresse',
+    emailConfirmation: 'Email-Konfirmation',
+    transactionId: 'Transaktions-ID',
+    additionalInfo: 'Zusatzinfo zur Banküberweisung',
+    remittanceInfo: 'Remittance Info',
+    dfxIban: 'DFX-IBAN (Bank)',
+    registered: '(Einzahlung registriert)',
+    presentKycFound: '(KYC vorhanden)',
+    successfullyPassed: 'erfolgreich durchgeführt',
+    cryptoDelivered: 'erledigt - Krypto ausgeliefert',
+    moneyTransferred: 'erledigt - Geld überwiesen',
+    complete: 'Complete',
+    offrampComplete: 'Offramp-Prozess ist abgeschlossen',
+    payoutAmount: 'Dein Auszahlungsbetrag',
+    paidToIbanOrArrived: 'wurde an die IBAN überwiesen oder ist dort eingetroffen',
+    bankTransfer: 'SEPA-Banküberweisung',
+    additionalInfoWithdrawal: 'Zusatzinfo zu deiner Auszahlung',
+    cryptoSold: 'Kryptoasset verkauft',
+    statusUrl: 'Status-URL',
+    payout: 'Auszahlung',
+    bank: '(Banküberweisung)',
+    amountReceivedNote: 'wurde an deine IBAN überwiesen',
+  },
+  en: {
+    headingOn: 'Analysis Report on an Onramp (Fiat2Crypto / Buy) Search Request',
+    headingOff: 'Analysis Report on your Offramp (Crypto2Fiat - Sell) search request',
+    intro: 'We have received your last payment:',
+    paymentMethod: 'Payment Method',
+    date: 'Date',
+    time: 'Time',
+    buyCryptoId: 'BuyCrypto- / Tx-ID',
+    paymentAmount: 'Payment amount',
+    paymentAmountFromIban: 'from IBAN',
+    kycStatus: 'KYC status',
+    refCodeWallet: 'RefCode / Wallet',
+    cryptoAsset: 'Crypto- / Asset',
+    wipStatus: 'WIP-status',
+    order: 'Buy order',
+    amount: 'Amount',
+    cryptoDelivery: 'Crypto Delivery',
+    emailAddress: 'Email Address',
+    emailConfirmation: 'Email Confirmation',
+    transactionId: 'Transaction ID',
+    additionalInfo: 'Additional Info on the SEPA Bank Transfer',
+    remittanceInfo: 'Remittance Info',
+    dfxIban: 'DFX-IBAN (Bank)',
+    registered: '(Payment registered)',
+    presentKycFound: 'present (KYC done)',
+    successfullyPassed: 'passed',
+    cryptoDelivered: 'done · crypto delivered',
+    moneyTransferred: 'done · money transferred',
+    complete: 'Complete',
+    offrampComplete: 'Offramp Process is completed',
+    payoutAmount: 'Your payout amount',
+    paidToIbanOrArrived: 'has been transferred to your IBAN or has arrived there',
+    bankTransfer: 'SEPA Bank Transfer',
+    additionalInfoWithdrawal: 'Additional Info on your Withdrawal',
+    cryptoSold: 'Crypto Asset sold',
+    statusUrl: 'Status-URL',
+    payout: 'Payout',
+    bank: '(bank transfer)',
+    amountReceivedNote: 'has been transferred to your IBAN',
+  },
+};
+
+interface AmlStyle {
+  bg: [number, number, number];
+  textColor: [number, number, number];
+}
+
+function amlStyle(amlCheck?: string): AmlStyle {
+  const c = (amlCheck ?? '').toLowerCase();
+  if (c === 'pass') return { bg: [220, 245, 220], textColor: COLOR.okDark };
+  if (c === 'fail') return { bg: [253, 230, 230], textColor: COLOR.errorDark };
+  return { bg: [255, 250, 220], textColor: COLOR.warnDark };
+}
+
+interface TxPdfInput {
+  transaction: TransactionInfo;
+  bankTx?: BankTxInfo;
+  cryptoInput?: CryptoInputInfo;
+  userData: Pick<UserDataDetail, 'mail' | 'kycLevel' | 'kycStatus'>;
+  ramp: TxRamp;
+  lang: PdfLang;
+  dfxIban?: string;
+  bankName?: string;
+  refCode?: string;
+  wallet?: string;
+  cryptoDeliveryDate?: string;
+}
+
+export function generateTransactionPdf(input: TxPdfInput): void {
+  const { transaction: tx, bankTx, cryptoInput, userData, ramp, lang } = input;
+  const t = LABELS[lang];
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+
+  // --- Title ---
+  const heading = ramp === 'onramp' ? t.headingOn : t.headingOff;
+  doc.setFontSize(13);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(...COLOR.okDark);
+  doc.text(heading, 10, 15);
+
+  doc.setFont('helvetica', 'normal');
+  doc.setFontSize(10);
+  doc.setTextColor(...COLOR.text);
+  doc.text(t.intro, 10, 22);
+
+  // --- Body table ---
+  const created = formatDateTimeUtc(tx.created);
+  const paymentMethod = t.bankTransfer;
+  const idCell = `${tx.buyCryptoId ?? tx.buyFiatId ?? '-'} / ${tx.id}`;
+  const inputAmountCell = tx.inputAmount != null ? `${formatAmount(tx.inputAmount)} ${tx.inputAsset ?? ''}`.trim() : '-';
+  const outputAmountCell =
+    tx.outputAmount != null ? `${formatAmount(tx.outputAmount)} ${tx.outputAsset ?? ''}`.trim() : '-';
+  const kycLevelStr = userData.kycLevel != null ? `${userData.kycLevel}` : '-';
+  const kycStatusStr = userData.kycStatus ? ` (${userData.kycStatus})` : '';
+  const wipStyle = amlStyle(tx.amlCheck);
+
+  const rows: RowInput[] = [];
+
+  rows.push([
+    { content: t.paymentMethod + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: paymentMethod, styles: { textColor: COLOR.link, fontStyle: 'bold' } },
+    { content: t.registered, styles: { fontStyle: 'italic' } },
+  ]);
+  rows.push([
+    { content: t.date + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: created.date },
+    '',
+  ]);
+  rows.push([
+    { content: t.time + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: created.time },
+    '',
+  ]);
+  rows.push([
+    { content: t.buyCryptoId + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: idCell },
+    '',
+  ]);
+  rows.push([
+    { content: t.paymentAmount + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: inputAmountCell },
+    { content: bankTx?.iban ? `${t.paymentAmountFromIban} ${bankTx.iban}` : '', styles: { fontStyle: 'italic' } },
+  ]);
+  rows.push([
+    { content: t.kycStatus + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: `${kycLevelStr}${kycStatusStr}`, styles: { fontStyle: 'bold' } },
+    { content: t.presentKycFound, styles: { fontStyle: 'italic' } },
+  ]);
+  rows.push([
+    { content: t.wipStatus + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    {
+      content: dashIfEmpty(tx.amlCheck) + (tx.amlReason ? ` (${tx.amlReason})` : ''),
+      styles: { fillColor: wipStyle.bg, textColor: wipStyle.textColor, fontStyle: 'bold' },
+    },
+    { content: t.successfullyPassed, styles: { fontStyle: 'italic' } },
+  ]);
+
+  // Order status (ramp-specific)
+  const orderLabel = ramp === 'onramp' ? t.order : t.payout;
+  const orderStatus = tx.isCompleted
+    ? ramp === 'onramp'
+      ? t.cryptoDelivered
+      : t.moneyTransferred
+    : dashIfEmpty(tx.amlCheck);
+  rows.push([
+    { content: orderLabel + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: orderStatus, styles: { fontStyle: 'bold' } },
+    { content: '', styles: { fontStyle: 'italic' } },
+  ]);
+  rows.push([
+    { content: t.refCodeWallet + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: `${dashIfEmpty(input.refCode)}   ${dashIfEmpty(input.wallet)}` },
+    '',
+  ]);
+  rows.push([
+    { content: t.amount + ' / ' + t.cryptoAsset + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: outputAmountCell },
+    '',
+  ]);
+  rows.push([
+    { content: t.cryptoDelivery + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: formatDateTimeUtc(input.cryptoDeliveryDate).date + ' ' + formatDateTimeUtc(input.cryptoDeliveryDate).time },
+    '',
+  ]);
+  rows.push([
+    { content: t.emailAddress + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: dashIfEmpty(userData.mail) },
+    '',
+  ]);
+
+  const txHash = cryptoInput?.inTxId ?? tx.inputTxId ?? '';
+  rows.push([
+    { content: t.transactionId + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: txHash, styles: { font: 'courier', fontSize: 7 }, colSpan: 2 },
+  ]);
+
+  autoTable(doc, {
+    startY: 26,
+    margin: { left: 10, right: 10 },
+    theme: 'grid',
+    styles: { fontSize: 9, cellPadding: 1.5, textColor: COLOR.text, lineColor: COLOR.border },
+    columnStyles: {
+      0: { cellWidth: 55 },
+      1: { cellWidth: 65 },
+      2: { cellWidth: pageWidth - 20 - 55 - 65 },
+    },
+    body: rows,
+  });
+
+  // --- Additional info block ---
+  const finalY = (doc as unknown as { lastAutoTable: { finalY: number } }).lastAutoTable.finalY;
+  const infoTitle = ramp === 'onramp' ? t.additionalInfo : t.additionalInfoWithdrawal;
+
+  doc.setFontSize(9);
+  doc.setFont('helvetica', 'bold');
+  doc.setTextColor(...COLOR.text);
+  doc.text(infoTitle + ':', 10, finalY + 6);
+
+  const extraRows: RowInput[] = [];
+  extraRows.push([
+    { content: t.remittanceInfo + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    { content: dashIfEmpty(bankTx?.remittanceInfo), styles: { font: 'courier', fontSize: 7 } },
+  ]);
+  extraRows.push([
+    { content: t.dfxIban + ':', styles: { fillColor: COLOR.labelBg, fontStyle: 'bold' } },
+    {
+      content:
+        `${dashIfEmpty(input.dfxIban)} ${input.bankName ? '(' + input.bankName + ')' : ''}`.trim(),
+      styles: { textColor: COLOR.link },
+    },
+  ]);
+
+  autoTable(doc, {
+    startY: finalY + 8,
+    margin: { left: 10, right: 10 },
+    theme: 'grid',
+    styles: { fontSize: 9, cellPadding: 1.5, textColor: COLOR.text, lineColor: COLOR.border },
+    columnStyles: {
+      0: { cellWidth: 55 },
+      1: { cellWidth: pageWidth - 20 - 55 },
+    },
+    body: extraRows,
+  });
+
+  drawFooter(doc, lang);
+
+  const filename = filenameSafe(`DFX_${ramp === 'onramp' ? 'OnRamp' : 'OffRamp'}_${tx.uid}_${lang.toUpperCase()}.pdf`);
+  saveWithFilename(doc, filename);
+}


### PR DESCRIPTION
## Ticket

DEV-4572 — CustomerSearch custom tx pdf export

## Summary

Adds three per-transaction PDF exports to the compliance user screen (`/compliance/user/:id` → Transactions tab → expand a transaction row):

| PDF | Trigger | Layout |
|---|---|---|
| **OnRamp Analysis** (Fiat2Krypto / Buy) | Only for tx.type = \`BuyCrypto\` | Portrait A4 |
| **OffRamp Analysis** (Krypto2Fiat / Sell) | Only for tx.type = \`BuyFiat\` | Portrait A4 |
| **Customer Account Info** (DFX vs Bank) | Both ramps | Landscape A4 |

Each PDF ships in both **German** and **English** — the agent picks the language per download via a dedicated button pair (\`PDF (DE)\` / \`PDF (EN)\`). No app-wide language switch required, matching the ticket screenshots.

## Implementation

- **Library**: \`jspdf\` + \`jspdf-autotable\` (added to \`package.json\`). Chosen over pdfmake / @react-pdf for its small footprint and table-first API — the ticket layouts are all label/value grids.
- **Bundle impact**: renderers are loaded via **dynamic \`import()\`**, so the PDF bundle only ships when a compliance user actually clicks Export. The main bundle is unaffected.
- **Colors**: mirrors the DFX Tailwind palette (\`dfxBlue.400\`, \`dfxBlue.800\`, \`dfxGray.300/500/600\`, \`dfxGreen.100/300\`, \`dfxYellow.500/700\`, \`dfxRed.100/150\`) as literal constants in \`support-pdf-common.ts\` — no runtime dependency on \`tailwind.config.js\`.
- **i18n**: DE/EN label sets live in the renderer files themselves (small local dictionaries, not the app-wide \`de.json\`) since these strings are used only inside PDFs.
- **New files**:
  - \`src/util/pdf/support-pdf-common.ts\` — palette, UTC formatting, footer legend
  - \`src/util/pdf/support-tx-pdf.ts\` — OnRamp + OffRamp renderer
  - \`src/util/pdf/support-account-pdf.ts\` — two-column DFX/Bank Account Info renderer
- **Touched**:
  - \`src/components/compliance/transactions-tab.tsx\` — accepts \`userData\` prop, renders the six new buttons in the existing per-tx action row
  - \`src/screens/compliance-user.screen.tsx\` — passes \`data.userData\` down

## Verification

- \`tsc --noEmit\` — clean
- \`npm run build:dev\` — clean
- \`npx eslint\` on all touched files — clean
- Sanity-rendered a preview PDF via jsPDF standalone (no runtime errors, tables + colors correct)
- Manual browser verification pending — please test on dev by opening \`/compliance/user/:id\`, expanding a BuyCrypto and a BuyFiat, and clicking the DE + EN buttons for all three PDF types.

## Test plan

- [ ] Open a compliance user's transaction list, expand a **BuyCrypto** (OnRamp) row → see 6 new buttons: OnRamp PDF (DE), OnRamp PDF (EN), Account Info PDF (DE), Account Info PDF (EN) plus the existing Stop/Chargeback/Recall
- [ ] Click each and verify the downloaded PDF opens, layout matches ticket screenshots (DE): Bildschirmfoto 2026-05-17 um 11.06.59.png, (EN): 11.10.16.png
- [ ] Expand a **BuyFiat** (OffRamp) row → OffRamp PDF buttons appear instead. Verify DE (11.47.33.png) and EN (11.47.53.png) layouts.
- [ ] Verify Account Info PDF against the ticket screenshot (IMAGE 2026-05-21 15:00:13.jpg) for both DE and EN.
- [ ] Regression: confirm existing Stop / Chargeback / Recall / PDF (aggregate) buttons still work.