### PR TITLE
feat(dashboard): add admin page to set financial log validity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -99,6 +99,7 @@ const DashboardFinancialHistoryScreen = lazy(() => import('./screens/dashboard-f
 const DashboardFinancialLiveScreen = lazy(() => import('./screens/dashboard-financial-live.screen'));
 const DashboardFinancialExpensesScreen = lazy(() => import('./screens/dashboard-financial-expenses.screen'));
 const DashboardFinancialLiquidityScreen = lazy(() => import('./screens/dashboard-financial-liquidity.screen'));
+const DashboardFinancialLogValidityScreen = lazy(() => import('./screens/dashboard-financial-log-validity.screen'));
 const SitemapScreen = lazy(() => import('./screens/sitemap.screen'));
 
 setupLanguages();
@@ -565,6 +566,10 @@ export const Routes = [
               {
                 path: 'liquidity',
                 element: withSuspense(<DashboardFinancialLiquidityScreen />),
+              },
+              {
+                path: 'log-validity',
+                element: withSuspense(<DashboardFinancialLogValidityScreen />),
               },
             ],
           },

--- a/src/screens/dashboard-financial-log-validity.screen.tsx
+++ b/src/screens/dashboard-financial-log-validity.screen.tsx
@@ -7,6 +7,7 @@ import {
   StyledButton,
   StyledButtonColor,
   StyledButtonWidth,
+  StyledDateAndTimePicker,
   StyledInput,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
@@ -22,8 +23,8 @@ interface IdFormData {
 }
 
 interface RangeFormData {
-  from: string;
-  to: string;
+  from?: Date;
+  to?: Date;
   min: string;
   max: string;
 }
@@ -40,10 +41,6 @@ interface FinancialValidityRequest {
   max?: number;
   valid: boolean;
 }
-
-const DATE_PLACEHOLDER = '2026-07-03T23:11:00Z';
-// Require an explicit timezone (Z or ±hh:mm) so an entry is never silently interpreted as local time.
-const ISO_DATETIME_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d{1,3})?(Z|[+-]\d{2}:\d{2})$/;
 
 export default function DashboardFinancialLogValidityScreen(): JSX.Element {
   useAdminGuard();
@@ -96,7 +93,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     reset: resetRange,
   } = useForm<RangeFormData>({
     mode: 'onTouched',
-    defaultValues: { from: '', to: '', min: '', max: '' },
+    defaultValues: { min: '', max: '' },
   });
 
   const [rangeLoading, setRangeLoading] = useState(false);
@@ -107,42 +104,19 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     setRangeError(undefined);
     setRangeSuccess(undefined);
 
-    const from = data.from.trim();
-    const to = data.to.trim();
+    const { from, to } = data;
     const minStr = data.min.trim();
     const maxStr = data.max.trim();
 
-    const hasFrom = from !== '';
-    const hasTo = to !== '';
     const hasMin = minStr !== '';
     const hasMax = maxStr !== '';
 
-    if (!hasFrom && !hasTo && !hasMin && !hasMax) {
+    if (!from && !to && !hasMin && !hasMax) {
       setRangeError('At least one filter is required (from, to, min or max).');
       return;
     }
 
-    if (hasFrom && !ISO_DATETIME_TZ.test(from)) {
-      setRangeError(`Invalid 'from' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
-      return;
-    }
-    if (hasTo && !ISO_DATETIME_TZ.test(to)) {
-      setRangeError(`Invalid 'to' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
-      return;
-    }
-
-    const fromDate = hasFrom ? new Date(from) : undefined;
-    const toDate = hasTo ? new Date(to) : undefined;
-
-    if (fromDate && isNaN(fromDate.getTime())) {
-      setRangeError(`Invalid 'from' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
-      return;
-    }
-    if (toDate && isNaN(toDate.getTime())) {
-      setRangeError(`Invalid 'to' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
-      return;
-    }
-    if (fromDate && toDate && fromDate.getTime() > toDate.getTime()) {
+    if (from && to && from.getTime() > to.getTime()) {
       setRangeError("'from' must be earlier than or equal to 'to'.");
       return;
     }
@@ -163,9 +137,11 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
       return;
     }
 
+    // The picker yields a Date in the browser's local time; toISOString() sends the
+    // unambiguous UTC instant the backend expects.
     const payload: FinancialValidityRequest = { valid };
-    if (fromDate) payload.from = fromDate.toISOString();
-    if (toDate) payload.to = toDate.toISOString();
+    if (from) payload.from = from.toISOString();
+    if (to) payload.to = to.toISOString();
     if (min !== undefined) payload.min = min;
     if (max !== undefined) payload.max = max;
 
@@ -234,14 +210,14 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
       <div className="bg-white rounded-lg shadow p-6 max-w-xl">
         <h2 className="text-lg font-semibold mb-1">By financial range / threshold</h2>
         <p className="text-sm text-gray-500 mb-4">
-          Bulk-update the validity of financial data logs. At least one filter is required. Dates are ISO-8601 UTC:
-          from is inclusive, to is exclusive. min/max apply exclusively to totalBalanceChf.
+          Bulk-update the validity of financial data logs. At least one filter is required. Dates are picked in your
+          local time and sent as UTC; from is inclusive, to is exclusive. min/max apply exclusively to totalBalanceChf.
         </p>
 
         <Form control={rangeControl} errors={rangeErrors} translate={translateError} hasFormElement={false}>
           <StyledVerticalStack gap={4} full>
-            <StyledInput name="from" type="text" label="From (created >=)" placeholder={DATE_PLACEHOLDER} full smallLabel />
-            <StyledInput name="to" type="text" label="To (created <)" placeholder={DATE_PLACEHOLDER} full smallLabel />
+            <StyledDateAndTimePicker name="from" label="From (created >=)" smallLabel />
+            <StyledDateAndTimePicker name="to" label="To (created <)" smallLabel />
             <StyledInput name="min" type="number" label="Min totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
             <StyledInput name="max" type="number" label="Max totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
 

--- a/src/screens/dashboard-financial-log-validity.screen.tsx
+++ b/src/screens/dashboard-financial-log-validity.screen.tsx
@@ -7,7 +7,6 @@ import {
   StyledButton,
   StyledButtonColor,
   StyledButtonWidth,
-  StyledDateAndTimePicker,
   StyledInput,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
@@ -23,8 +22,8 @@ interface IdFormData {
 }
 
 interface RangeFormData {
-  from?: Date;
-  to?: Date;
+  from: string;
+  to: string;
   min: string;
   max: string;
 }
@@ -93,7 +92,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     reset: resetRange,
   } = useForm<RangeFormData>({
     mode: 'onTouched',
-    defaultValues: { min: '', max: '' },
+    defaultValues: { from: '', to: '', min: '', max: '' },
   });
 
   const [rangeLoading, setRangeLoading] = useState(false);
@@ -104,19 +103,33 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     setRangeError(undefined);
     setRangeSuccess(undefined);
 
-    const { from, to } = data;
     const minStr = data.min.trim();
     const maxStr = data.max.trim();
 
+    const hasFrom = data.from !== '';
+    const hasTo = data.to !== '';
     const hasMin = minStr !== '';
     const hasMax = maxStr !== '';
 
-    if (!from && !to && !hasMin && !hasMax) {
+    if (!hasFrom && !hasTo && !hasMin && !hasMax) {
       setRangeError('At least one filter is required (from, to, min or max).');
       return;
     }
 
-    if (from && to && from.getTime() > to.getTime()) {
+    // The datetime-local field holds local wall-clock time; new Date() reads it as local,
+    // toISOString() then sends the unambiguous UTC instant the backend expects.
+    const fromDate = hasFrom ? new Date(data.from) : undefined;
+    const toDate = hasTo ? new Date(data.to) : undefined;
+
+    if (fromDate && isNaN(fromDate.getTime())) {
+      setRangeError("Invalid 'from' date.");
+      return;
+    }
+    if (toDate && isNaN(toDate.getTime())) {
+      setRangeError("Invalid 'to' date.");
+      return;
+    }
+    if (fromDate && toDate && fromDate.getTime() > toDate.getTime()) {
       setRangeError("'from' must be earlier than or equal to 'to'.");
       return;
     }
@@ -137,11 +150,9 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
       return;
     }
 
-    // The picker yields a Date in the browser's local time; toISOString() sends the
-    // unambiguous UTC instant the backend expects.
     const payload: FinancialValidityRequest = { valid };
-    if (from) payload.from = from.toISOString();
-    if (to) payload.to = to.toISOString();
+    if (fromDate) payload.from = fromDate.toISOString();
+    if (toDate) payload.to = toDate.toISOString();
     if (min !== undefined) payload.min = min;
     if (max !== undefined) payload.max = max;
 
@@ -216,8 +227,8 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
 
         <Form control={rangeControl} errors={rangeErrors} translate={translateError} hasFormElement={false}>
           <StyledVerticalStack gap={4} full>
-            <StyledDateAndTimePicker name="from" label="From (created >=)" smallLabel />
-            <StyledDateAndTimePicker name="to" label="To (created <)" smallLabel />
+            <StyledInput name="from" type="datetime-local" label="From (created >=)" full smallLabel />
+            <StyledInput name="to" type="datetime-local" label="To (created <)" full smallLabel />
             <StyledInput name="min" type="number" label="Min totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
             <StyledInput name="max" type="number" label="Max totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
 

--- a/src/screens/dashboard-financial-log-validity.screen.tsx
+++ b/src/screens/dashboard-financial-log-validity.screen.tsx
@@ -1,0 +1,264 @@
+import { useApi, Utils, Validations } from '@dfx.swiss/react';
+import {
+  DfxIcon,
+  Form,
+  IconSize,
+  IconVariant,
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledInput,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useAdminGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+interface IdFormData {
+  id: string;
+}
+
+interface RangeFormData {
+  from: string;
+  to: string;
+  min: string;
+  max: string;
+}
+
+interface LogValidityResponse {
+  id: number;
+  valid: boolean;
+}
+
+interface FinancialValidityRequest {
+  from?: string;
+  to?: string;
+  min?: number;
+  max?: number;
+  valid: boolean;
+}
+
+const DATE_PLACEHOLDER = '2026-07-03T23:11:00Z';
+
+export default function DashboardFinancialLogValidityScreen(): JSX.Element {
+  useAdminGuard();
+
+  const { translateError } = useSettingsContext();
+  const { call } = useApi();
+
+  // --- Section A: by log ID -------------------------------------------------
+  const {
+    control: idControl,
+    handleSubmit: handleIdSubmit,
+    formState: { errors: idErrors },
+    reset: resetId,
+  } = useForm<IdFormData>({ mode: 'onTouched', defaultValues: { id: '' } });
+
+  const [idLoading, setIdLoading] = useState(false);
+  const [idError, setIdError] = useState<string>();
+  const [idSuccess, setIdSuccess] = useState<string>();
+
+  const idRules = Utils.createRules({
+    id: [Validations.Required, Validations.Custom((value) => (/^\d+$/.test(String(value)) ? true : 'pattern'))],
+  });
+
+  async function onSubmitId(data: IdFormData, valid: boolean) {
+    setIdLoading(true);
+    setIdError(undefined);
+    setIdSuccess(undefined);
+
+    try {
+      const response = await call<LogValidityResponse>({
+        url: `log/${+data.id}`,
+        method: 'PUT',
+        data: { valid },
+      });
+      setIdSuccess(`Saved: log #${response.id} set to valid = ${valid}`);
+      setTimeout(() => setIdSuccess(undefined), 4000);
+      resetId();
+    } catch (e) {
+      setIdError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIdLoading(false);
+    }
+  }
+
+  // --- Section B: by financial range / threshold ----------------------------
+  const {
+    control: rangeControl,
+    handleSubmit: handleRangeSubmit,
+    formState: { errors: rangeErrors },
+    reset: resetRange,
+  } = useForm<RangeFormData>({
+    mode: 'onTouched',
+    defaultValues: { from: '', to: '', min: '', max: '' },
+  });
+
+  const [rangeLoading, setRangeLoading] = useState(false);
+  const [rangeError, setRangeError] = useState<string>();
+  const [rangeSuccess, setRangeSuccess] = useState<string>();
+
+  async function onSubmitRange(data: RangeFormData, valid: boolean) {
+    setRangeError(undefined);
+    setRangeSuccess(undefined);
+
+    const from = data.from.trim();
+    const to = data.to.trim();
+    const minStr = data.min.trim();
+    const maxStr = data.max.trim();
+
+    const hasFrom = from !== '';
+    const hasTo = to !== '';
+    const hasMin = minStr !== '';
+    const hasMax = maxStr !== '';
+
+    if (!hasFrom && !hasTo && !hasMin && !hasMax) {
+      setRangeError('At least one filter is required (from, to, min or max).');
+      return;
+    }
+
+    if (hasFrom && isNaN(Date.parse(from))) {
+      setRangeError(`Invalid 'from' date. Use ISO-8601 UTC, e.g. ${DATE_PLACEHOLDER}.`);
+      return;
+    }
+    if (hasTo && isNaN(Date.parse(to))) {
+      setRangeError(`Invalid 'to' date. Use ISO-8601 UTC, e.g. ${DATE_PLACEHOLDER}.`);
+      return;
+    }
+    if (hasFrom && hasTo && Date.parse(from) > Date.parse(to)) {
+      setRangeError("'from' must be earlier than or equal to 'to'.");
+      return;
+    }
+
+    const min = hasMin ? Number(minStr) : undefined;
+    const max = hasMax ? Number(maxStr) : undefined;
+
+    if (min !== undefined && isNaN(min)) {
+      setRangeError("'min' must be a number.");
+      return;
+    }
+    if (max !== undefined && isNaN(max)) {
+      setRangeError("'max' must be a number.");
+      return;
+    }
+    if (min !== undefined && max !== undefined && min >= max) {
+      setRangeError("'min' must be less than 'max'.");
+      return;
+    }
+
+    const payload: FinancialValidityRequest = { valid };
+    if (hasFrom) payload.from = from;
+    if (hasTo) payload.to = to;
+    if (min !== undefined) payload.min = min;
+    if (max !== undefined) payload.max = max;
+
+    setRangeLoading(true);
+    try {
+      const response = await call<{ affected: number }>({
+        url: 'log/financial/validity',
+        method: 'PUT',
+        data: payload,
+      });
+      setRangeSuccess(
+        `Updated ${response.affected} ${response.affected === 1 ? 'entry' : 'entries'} to valid = ${valid}.`,
+      );
+      setTimeout(() => setRangeSuccess(undefined), 4000);
+      resetRange();
+    } catch (e) {
+      setRangeError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setRangeLoading(false);
+    }
+  }
+
+  useLayoutOptions({ title: 'Log Validity', noMaxWidth: true });
+
+  return (
+    <div className="space-y-6 p-4 w-full self-stretch" style={{ color: '#111827' }}>
+      {/* Section A: by log ID */}
+      <div className="bg-white rounded-lg shadow p-6 max-w-xl">
+        <h2 className="text-lg font-semibold mb-1">By log ID</h2>
+        <p className="text-sm text-gray-500 mb-4">Set the validity of any single log entry by its ID.</p>
+
+        <Form control={idControl} rules={idRules} errors={idErrors} translate={translateError} hasFormElement={false}>
+          <StyledVerticalStack gap={4} full>
+            <StyledInput name="id" type="number" label="Log ID" placeholder="1234" full smallLabel />
+
+            {idError && <ErrorHint message={idError} />}
+
+            <StyledButton
+              label="Set valid = true"
+              color={StyledButtonColor.GREEN}
+              onClick={handleIdSubmit((data) => onSubmitId(data, true))}
+              width={StyledButtonWidth.FULL}
+              isLoading={idLoading}
+              disabled={idLoading}
+            />
+            <StyledButton
+              label="Set valid = false"
+              color={StyledButtonColor.RED}
+              onClick={handleIdSubmit((data) => onSubmitId(data, false))}
+              width={StyledButtonWidth.FULL}
+              isLoading={idLoading}
+              disabled={idLoading}
+            />
+
+            {idSuccess && (
+              <p className="flex flex-row gap-1 items-center font-medium" style={{ color: '#16a34a' }}>
+                <DfxIcon icon={IconVariant.CHECK} size={IconSize.SM} />
+                {idSuccess}
+              </p>
+            )}
+          </StyledVerticalStack>
+        </Form>
+      </div>
+
+      {/* Section B: by financial range / threshold */}
+      <div className="bg-white rounded-lg shadow p-6 max-w-xl">
+        <h2 className="text-lg font-semibold mb-1">By financial range / threshold</h2>
+        <p className="text-sm text-gray-500 mb-4">
+          Bulk-update the validity of financial data logs. At least one filter is required. Dates are ISO-8601 UTC:
+          from is inclusive, to is exclusive. min/max apply exclusively to totalBalanceChf.
+        </p>
+
+        <Form control={rangeControl} errors={rangeErrors} translate={translateError} hasFormElement={false}>
+          <StyledVerticalStack gap={4} full>
+            <StyledInput name="from" type="text" label="From (created >=)" placeholder={DATE_PLACEHOLDER} full smallLabel />
+            <StyledInput name="to" type="text" label="To (created <)" placeholder={DATE_PLACEHOLDER} full smallLabel />
+            <StyledInput name="min" type="number" label="Min totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
+            <StyledInput name="max" type="number" label="Max totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
+
+            {rangeError && <ErrorHint message={rangeError} />}
+
+            <StyledButton
+              label="Set valid = true"
+              color={StyledButtonColor.GREEN}
+              onClick={handleRangeSubmit((data) => onSubmitRange(data, true))}
+              width={StyledButtonWidth.FULL}
+              isLoading={rangeLoading}
+              disabled={rangeLoading}
+            />
+            <StyledButton
+              label="Set valid = false"
+              color={StyledButtonColor.RED}
+              onClick={handleRangeSubmit((data) => onSubmitRange(data, false))}
+              width={StyledButtonWidth.FULL}
+              isLoading={rangeLoading}
+              disabled={rangeLoading}
+            />
+
+            {rangeSuccess && (
+              <p className="flex flex-row gap-1 items-center font-medium" style={{ color: '#16a34a' }}>
+                <DfxIcon icon={IconVariant.CHECK} size={IconSize.SM} />
+                {rangeSuccess}
+              </p>
+            )}
+          </StyledVerticalStack>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/dashboard-financial-log-validity.screen.tsx
+++ b/src/screens/dashboard-financial-log-validity.screen.tsx
@@ -70,7 +70,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
 
     try {
       const response = await call<LogValidityResponse>({
-        url: `log/${+data.id}`,
+        url: `log/${data.id}`,
         method: 'PUT',
         data: { valid },
       });

--- a/src/screens/dashboard-financial-log-validity.screen.tsx
+++ b/src/screens/dashboard-financial-log-validity.screen.tsx
@@ -13,6 +13,7 @@ import {
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { ErrorHint } from 'src/components/error-hint';
+import { ConfirmationOverlay } from 'src/components/overlay/confirmation-overlay';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
@@ -41,11 +42,18 @@ interface FinancialValidityRequest {
   valid: boolean;
 }
 
+interface PendingConfirmation {
+  content: JSX.Element;
+  run: () => Promise<void>;
+}
+
 export default function DashboardFinancialLogValidityScreen(): JSX.Element {
   useAdminGuard();
 
   const { translateError } = useSettingsContext();
   const { call } = useApi();
+
+  const [confirmation, setConfirmation] = useState<PendingConfirmation>();
 
   // --- Section A: by log ID -------------------------------------------------
   const {
@@ -63,7 +71,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     id: [Validations.Required, Validations.Custom((value) => (/^\d+$/.test(String(value)) ? true : 'pattern'))],
   });
 
-  async function onSubmitId(data: IdFormData, valid: boolean) {
+  async function executeId(data: IdFormData, valid: boolean) {
     setIdLoading(true);
     setIdError(undefined);
     setIdSuccess(undefined);
@@ -84,6 +92,19 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     }
   }
 
+  function requestIdConfirmation(data: IdFormData, valid: boolean) {
+    setIdError(undefined);
+    setIdSuccess(undefined);
+    setConfirmation({
+      content: (
+        <p className="text-dfxBlue-800 mb-2 text-center">
+          Set validity of log <strong>#{data.id}</strong> to <strong>{String(valid)}</strong>?
+        </p>
+      ),
+      run: () => executeId(data, valid),
+    });
+  }
+
   // --- Section B: by financial range / threshold ----------------------------
   const {
     control: rangeControl,
@@ -99,10 +120,9 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
   const [rangeError, setRangeError] = useState<string>();
   const [rangeSuccess, setRangeSuccess] = useState<string>();
 
-  async function onSubmitRange(data: RangeFormData, valid: boolean) {
-    setRangeError(undefined);
-    setRangeSuccess(undefined);
-
+  // Validate the range form against the backend rules and build the request payload.
+  // Returns undefined (and sets an error) when the input is invalid.
+  function buildRangePayload(data: RangeFormData, valid: boolean): FinancialValidityRequest | undefined {
     const minStr = data.min.trim();
     const maxStr = data.max.trim();
 
@@ -113,7 +133,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
 
     if (!hasFrom && !hasTo && !hasMin && !hasMax) {
       setRangeError('At least one filter is required (from, to, min or max).');
-      return;
+      return undefined;
     }
 
     // The datetime-local field holds local wall-clock time; new Date() reads it as local,
@@ -123,15 +143,15 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
 
     if (fromDate && isNaN(fromDate.getTime())) {
       setRangeError("Invalid 'from' date.");
-      return;
+      return undefined;
     }
     if (toDate && isNaN(toDate.getTime())) {
       setRangeError("Invalid 'to' date.");
-      return;
+      return undefined;
     }
     if (fromDate && toDate && fromDate.getTime() > toDate.getTime()) {
       setRangeError("'from' must be earlier than or equal to 'to'.");
-      return;
+      return undefined;
     }
 
     const min = hasMin ? Number(minStr) : undefined;
@@ -139,15 +159,15 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
 
     if (min !== undefined && isNaN(min)) {
       setRangeError("'min' must be a number.");
-      return;
+      return undefined;
     }
     if (max !== undefined && isNaN(max)) {
       setRangeError("'max' must be a number.");
-      return;
+      return undefined;
     }
     if (min !== undefined && max !== undefined && min >= max) {
       setRangeError("'min' must be less than 'max'.");
-      return;
+      return undefined;
     }
 
     const payload: FinancialValidityRequest = { valid };
@@ -155,7 +175,10 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     if (toDate) payload.to = toDate.toISOString();
     if (min !== undefined) payload.min = min;
     if (max !== undefined) payload.max = max;
+    return payload;
+  }
 
+  async function executeRange(payload: FinancialValidityRequest) {
     setRangeLoading(true);
     try {
       const response = await call<{ affected: number }>({
@@ -164,7 +187,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
         data: payload,
       });
       setRangeSuccess(
-        `Updated ${response.affected} ${response.affected === 1 ? 'entry' : 'entries'} to valid = ${valid}.`,
+        `Updated ${response.affected} ${response.affected === 1 ? 'entry' : 'entries'} to valid = ${payload.valid}.`,
       );
       setTimeout(() => setRangeSuccess(undefined), 4000);
       resetRange();
@@ -175,7 +198,50 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     }
   }
 
+  function requestRangeConfirmation(data: RangeFormData, valid: boolean) {
+    setRangeError(undefined);
+    setRangeSuccess(undefined);
+
+    const payload = buildRangePayload(data, valid);
+    if (!payload) return;
+
+    const filters: string[] = [];
+    if (payload.from) filters.push(`from ${payload.from}`);
+    if (payload.to) filters.push(`to ${payload.to}`);
+    if (payload.min !== undefined) filters.push(`min ${payload.min}`);
+    if (payload.max !== undefined) filters.push(`max ${payload.max}`);
+
+    setConfirmation({
+      content: (
+        <p className="text-dfxBlue-800 mb-2 text-center">
+          Update all financial data logs matching <strong>{filters.join(', ')}</strong> to valid ={' '}
+          <strong>{String(valid)}</strong>?
+        </p>
+      ),
+      run: () => executeRange(payload),
+    });
+  }
+
   useLayoutOptions({ title: 'Log Validity', noMaxWidth: true });
+
+  if (confirmation) {
+    return (
+      <div className="space-y-6 p-4 w-full self-stretch" style={{ color: '#111827' }}>
+        <div className="bg-white rounded-lg shadow p-6 max-w-xl">
+          <ConfirmationOverlay
+            messageContent={confirmation.content}
+            cancelLabel="Cancel"
+            confirmLabel="Confirm"
+            onCancel={() => setConfirmation(undefined)}
+            onConfirm={async () => {
+              await confirmation.run();
+              setConfirmation(undefined);
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6 p-4 w-full self-stretch" style={{ color: '#111827' }}>
@@ -193,7 +259,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
             <StyledButton
               label="Set valid = true"
               color={StyledButtonColor.GREEN}
-              onClick={handleIdSubmit((data) => onSubmitId(data, true))}
+              onClick={handleIdSubmit((data) => requestIdConfirmation(data, true))}
               width={StyledButtonWidth.FULL}
               isLoading={idLoading}
               disabled={idLoading}
@@ -201,7 +267,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
             <StyledButton
               label="Set valid = false"
               color={StyledButtonColor.RED}
-              onClick={handleIdSubmit((data) => onSubmitId(data, false))}
+              onClick={handleIdSubmit((data) => requestIdConfirmation(data, false))}
               width={StyledButtonWidth.FULL}
               isLoading={idLoading}
               disabled={idLoading}
@@ -229,15 +295,29 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
           <StyledVerticalStack gap={4} full>
             <StyledInput name="from" type="datetime-local" label="From (created >=)" full smallLabel />
             <StyledInput name="to" type="datetime-local" label="To (created <)" full smallLabel />
-            <StyledInput name="min" type="number" label="Min totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
-            <StyledInput name="max" type="number" label="Max totalBalanceChf (exclusive)" placeholder="0" full smallLabel />
+            <StyledInput
+              name="min"
+              type="number"
+              label="Min totalBalanceChf (exclusive)"
+              placeholder="0"
+              full
+              smallLabel
+            />
+            <StyledInput
+              name="max"
+              type="number"
+              label="Max totalBalanceChf (exclusive)"
+              placeholder="0"
+              full
+              smallLabel
+            />
 
             {rangeError && <ErrorHint message={rangeError} />}
 
             <StyledButton
               label="Set valid = true"
               color={StyledButtonColor.GREEN}
-              onClick={handleRangeSubmit((data) => onSubmitRange(data, true))}
+              onClick={handleRangeSubmit((data) => requestRangeConfirmation(data, true))}
               width={StyledButtonWidth.FULL}
               isLoading={rangeLoading}
               disabled={rangeLoading}
@@ -245,7 +325,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
             <StyledButton
               label="Set valid = false"
               color={StyledButtonColor.RED}
-              onClick={handleRangeSubmit((data) => onSubmitRange(data, false))}
+              onClick={handleRangeSubmit((data) => requestRangeConfirmation(data, false))}
               width={StyledButtonWidth.FULL}
               isLoading={rangeLoading}
               disabled={rangeLoading}

--- a/src/screens/dashboard-financial-log-validity.screen.tsx
+++ b/src/screens/dashboard-financial-log-validity.screen.tsx
@@ -42,6 +42,8 @@ interface FinancialValidityRequest {
 }
 
 const DATE_PLACEHOLDER = '2026-07-03T23:11:00Z';
+// Require an explicit timezone (Z or ±hh:mm) so an entry is never silently interpreted as local time.
+const ISO_DATETIME_TZ = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d{1,3})?(Z|[+-]\d{2}:\d{2})$/;
 
 export default function DashboardFinancialLogValidityScreen(): JSX.Element {
   useAdminGuard();
@@ -120,15 +122,27 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
       return;
     }
 
-    if (hasFrom && isNaN(Date.parse(from))) {
-      setRangeError(`Invalid 'from' date. Use ISO-8601 UTC, e.g. ${DATE_PLACEHOLDER}.`);
+    if (hasFrom && !ISO_DATETIME_TZ.test(from)) {
+      setRangeError(`Invalid 'from' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
       return;
     }
-    if (hasTo && isNaN(Date.parse(to))) {
-      setRangeError(`Invalid 'to' date. Use ISO-8601 UTC, e.g. ${DATE_PLACEHOLDER}.`);
+    if (hasTo && !ISO_DATETIME_TZ.test(to)) {
+      setRangeError(`Invalid 'to' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
       return;
     }
-    if (hasFrom && hasTo && Date.parse(from) > Date.parse(to)) {
+
+    const fromDate = hasFrom ? new Date(from) : undefined;
+    const toDate = hasTo ? new Date(to) : undefined;
+
+    if (fromDate && isNaN(fromDate.getTime())) {
+      setRangeError(`Invalid 'from' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
+      return;
+    }
+    if (toDate && isNaN(toDate.getTime())) {
+      setRangeError(`Invalid 'to' date. Use ISO-8601 with timezone, e.g. ${DATE_PLACEHOLDER}.`);
+      return;
+    }
+    if (fromDate && toDate && fromDate.getTime() > toDate.getTime()) {
       setRangeError("'from' must be earlier than or equal to 'to'.");
       return;
     }
@@ -150,8 +164,8 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
     }
 
     const payload: FinancialValidityRequest = { valid };
-    if (hasFrom) payload.from = from;
-    if (hasTo) payload.to = to;
+    if (fromDate) payload.from = fromDate.toISOString();
+    if (toDate) payload.to = toDate.toISOString();
     if (min !== undefined) payload.min = min;
     if (max !== undefined) payload.max = max;
 

--- a/src/screens/dashboard-financial.screen.tsx
+++ b/src/screens/dashboard-financial.screen.tsx
@@ -8,6 +8,11 @@ const pages = [
   { path: '/dashboard/financial/history', title: 'History', description: 'Balance history over time' },
   { path: '/dashboard/financial/liquidity', title: 'Liquidity', description: 'Balance breakdown by type' },
   { path: '/dashboard/financial/history/expenses', title: 'Expenses', description: 'Revenue and cost details' },
+  {
+    path: '/dashboard/financial/log-validity',
+    title: 'Log Validity',
+    description: 'Set validity of log entries by ID or financial range',
+  },
 ];
 
 export default function DashboardFinancialScreen(): JSX.Element {

--- a/src/screens/sitemap.screen.tsx
+++ b/src/screens/sitemap.screen.tsx
@@ -127,6 +127,7 @@ const sections: PageSection[] = [
       { path: '/dashboard/financial/history', label: 'Financial History' },
       { path: '/dashboard/financial/history/expenses', label: 'Expenses' },
       { path: '/dashboard/financial/liquidity', label: 'Liquidity' },
+      { path: '/dashboard/financial/log-validity', label: 'Log Validity' },
     ],
   },
   {


### PR DESCRIPTION
## What
New admin-only screen at `/dashboard/financial/log-validity` to manually set the `valid` flag on log entries.

Two independent forms:
- **By log ID** — set a single entry's validity via `PUT /log/:id`.
- **By financial range / threshold** — bulk-update FinancialDataLog entries via `PUT /log/financial/validity`, filtering by `from`/`to` (created window, from inclusive / to exclusive) and/or `min`/`max` (exclusive on `totalBalanceChf`). Reports the number of affected rows.

## Why
FinancialDataLog balance snapshots occasionally show transient outliers (e.g. a large deposit whose plus and minus legs land in different one-minute snapshots). The automatic validator flags these, but some cases need manual review. This page lets an admin correct the `valid` flag directly from the dashboard.

## Notes
- Gated with `useAdminGuard` — uses the ADMIN role the backend endpoints already require.
- Client-side validation mirrors the backend rules (at least one filter; `from <= to`; `min < max`). Date inputs require an explicit timezone and are normalized to UTC ISO before sending, matching the UTC timestamps of the financial data log.
- Frontend-only; both endpoints already exist in the API.