### PR TITLE
fix(compliance): clear stale loadMoreError when switching graph node

### DIFF
--- a/src/screens/compliance-recommendation-graph.screen.tsx
+++ b/src/screens/compliance-recommendation-graph.screen.tsx
@@ -128,6 +128,9 @@ export default function ComplianceRecommendationGraphScreen(): JSX.Element {
     (nodeId: number): void => {
       setSelectedId(nodeId);
       setDetailError(undefined);
+      // loadMoreError is panel-scoped like detailError: clear the previous node's expand error
+      // when switching selection, otherwise it bleeds onto a node that never failed to expand.
+      setLoadMoreError(undefined);
       const cached = detailCache.current.get(nodeId);
       if (cached) {
         setDetail(cached);


### PR DESCRIPTION
## Problem
In the compliance recommendation graph, `loadMoreError` is a single, non-node-keyed state rendered inside the detail panel. `openDetail()` clears `setDetailError(undefined)` but **not** `loadMoreError`, and `loadMoreError` is only reset inside `loadNeighbors()` — which `handleActivate()` calls **only** when the clicked node is `expandable && neverLoaded`.

So after an expand fails (e.g. HTTP 500 → `loadMoreError` set and shown in that node's panel), selecting any **non-expandable** or **already-loaded** node runs `openDetail()` without `loadNeighbors()`, leaving the stale expand error rendered under the newly selected node — wrongly implying it failed to load.

## Fix
Clear `loadMoreError` in `openDetail()` alongside `setDetailError(undefined)`, so this panel-scoped error stays scoped to the currently selected node.

## Context
Follow-up to the review finding on #1159 (cosmetic, low severity). One-line change in `src/screens/compliance-recommendation-graph.screen.tsx`; CI validates.
