### PR TITLE
feat(realunit): let COMPLIANCE staff access the RealUnit dashboards

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -216,7 +216,7 @@ function NavigationMenu({ setIsNavigationOpen, small = false }: NavigationMenuCo
                   onClose={() => setIsNavigationOpen(false)}
                 />
               )}
-              {session?.role && [UserRole.ADMIN, UserRole.REALUNIT].includes(session.role) && (
+              {session?.role && [UserRole.ADMIN, UserRole.REALUNIT, UserRole.COMPLIANCE].includes(session.role) && (
                 <NavigationLink
                   icon={IconVariant.WALLET}
                   label={translate('screens/realunit', 'RealUnit')}

--- a/src/hooks/guard.hook.ts
+++ b/src/hooks/guard.hook.ts
@@ -16,7 +16,7 @@ export function useAdminGuard(redirectPath = '/', isActive = true) {
 }
 
 export function useRealunitGuard(redirectPath = '/', isActive = true) {
-  useUserRoleGuard([UserRole.ADMIN, UserRole.REALUNIT], redirectPath, isActive);
+  useUserRoleGuard([UserRole.ADMIN, UserRole.REALUNIT, UserRole.COMPLIANCE], redirectPath, isActive);
 }
 
 export function useComplianceGuard(redirectPath = '/', isActive = true) {


### PR DESCRIPTION
## What

Let `COMPLIANCE` staff open the RealUnit dashboards (`/realunit`, `/realunit/support*`, `/realunit/compliance*`):

- `useRealunitGuard` now admits `COMPLIANCE` in addition to `ADMIN`/`REALUNIT`.
- The RealUnit navigation entry is shown to `COMPLIANCE` as well.

All `/realunit` screens route through `useRealunitGuard`, so these two entries cover the whole area.

## Why

COMPLIANCE ranks above the RealUnit role and should have full access to everything RealUnit covers. Mirrors the backend role-hierarchy change.

Backend counterpart: DFXswiss/api#4118
