### PR TITLE
feat(navigation): add admin-only Financial dashboard link

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -227,6 +227,15 @@ function NavigationMenu({ setIsNavigationOpen, small = false }: NavigationMenuCo
               )}
               {session?.role === UserRole.ADMIN && (
                 <NavigationLink
+                  icon={IconVariant.BANK}
+                  label={translate('screens/dashboard/financial', 'Financial')}
+                  url="/dashboard/financial/overview"
+                  target="_self"
+                  onClose={() => setIsNavigationOpen(false)}
+                />
+              )}
+              {session?.role === UserRole.ADMIN && (
+                <NavigationLink
                   icon={IconVariant.MENU}
                   label={translate('screens/sitemap', 'Sitemap')}
                   url="/sitemap"

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -227,8 +227,8 @@ function NavigationMenu({ setIsNavigationOpen, small = false }: NavigationMenuCo
               )}
               {session?.role === UserRole.ADMIN && (
                 <NavigationLink
-                  icon={IconVariant.BANK}
-                  label={translate('screens/dashboard/financial', 'Financial')}
+                  icon={IconVariant.FILE}
+                  label={translate('screens/dashboard-financial', 'Financial')}
                   url="/dashboard/financial/overview"
                   target="_self"
                   onClose={() => setIsNavigationOpen(false)}


### PR DESCRIPTION
## What

Add a navigation menu entry for the financial dashboard, pointing to `/dashboard/financial/overview`, shown **only to admins** — alongside the existing staff dashboard links (Compliance, Support Dashboard, RealUnit).

- `src/components/navigation.tsx`: new `NavigationLink` gated by `session?.role === UserRole.ADMIN`, icon `FILE` (distinct from the Buy link's `BANK`), label `Financial`, url `/dashboard/financial/overview`.

## Why

The financial dashboard was only reachable by typing the URL directly. This surfaces it in the menu for admins, consistent with the other role-gated dashboard entries. The target route is already `useAdminGuard()`-protected, so the menu visibility matches the actual access control.
