### PR TITLE
feat(realunit): show all compliance customers upfront

### DIFF
--- a/e2e/realunit-compliance.spec.ts
+++ b/e2e/realunit-compliance.spec.ts
@@ -322,7 +322,12 @@ test.describe('RealUnit Compliance dashboards - Visual Regression Tests', () => 
     const input = page.locator('input').first();
     await expect(input).toBeVisible();
     await input.fill('example');
+    // Enter must actually issue the keyed search request. Without this wait the assertions below would also pass on
+    // the upfront-loaded list alone (the mock serves the same fixture for both requests), so a broken onKeyDown →
+    // handleSearch → loadCustomers(key) wiring would still go green.
+    const keyedSearch = page.waitForRequest((req) => /\/realunit\/compliance\/customers\?key=example/.test(req.url()));
     await input.press('Enter');
+    await keyedSearch;
 
     // results table rendered
     await expect(page.getByText('ACME Example AG')).toBeVisible();

--- a/e2e/realunit-compliance.spec.ts
+++ b/e2e/realunit-compliance.spec.ts
@@ -22,7 +22,7 @@ import { createTestCredentials } from './test-wallet';
  * test fills the input and presses Enter (the screen's onKeyDown handler runs handleSearch).
  *
  * Intercepted endpoints (base `/v1/` is prepended by useApi):
- *   - GET realunit/compliance/customers?key=...   (search → RealUnitCustomerListDto[])
+ *   - GET realunit/compliance/customers[?key=...] (upfront list / search → RealUnitCustomerListDto[])
  *   - GET realunit/compliance/customers/:id        (dossier → RealUnitCustomerDetailDto)
  *
  * Synthetic fixtures: fake ids (7100+), fixed ISO dates, fake names/emails/IBANs — no production data.
@@ -314,6 +314,9 @@ test.describe('RealUnit Compliance dashboards - Visual Regression Tests', () => 
     await page.goto(`/realunit/compliance?session=${token}`);
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(1000);
+
+    // the complete customer list is loaded upfront (list request without a key)
+    await expect(page.getByText('ACME Example AG')).toBeVisible();
 
     // the screen exposes only a controlled input (no ?search= URL support) — type a key and submit via Enter
     const input = page.locator('input').first();

--- a/src/__tests__/realunit-dashboard.hook.test.ts
+++ b/src/__tests__/realunit-dashboard.hook.test.ts
@@ -94,6 +94,15 @@ describe('useRealunitCompliance', () => {
     expect(mockCall).toHaveBeenCalledWith({ url: 'realunit/compliance/customers?key=a%20b%40c', method: 'GET' });
   });
 
+  it('omits the query string for the keyless full-list request', async () => {
+    mockCall.mockResolvedValue([]);
+    const { result } = renderHook(() => useRealunitCompliance());
+
+    await result.current.searchCustomers();
+
+    expect(mockCall).toHaveBeenCalledWith({ url: 'realunit/compliance/customers', method: 'GET' });
+  });
+
   it('hits the reduced dossier and download endpoints', async () => {
     const { result } = renderHook(() => useRealunitCompliance());
 

--- a/src/__tests__/realunit-dashboard.hook.test.ts
+++ b/src/__tests__/realunit-dashboard.hook.test.ts
@@ -9,6 +9,7 @@ jest.mock('@dfx.swiss/react', () => ({
   useApi: () => ({ call: mockCall }),
   Department: { SUPPORT: 'Support', COMPLIANCE: 'Compliance', MARKETING: 'Marketing' },
   TfaLevel: { STRICT: 'Strict' },
+  ResponseType: { BLOB: 'blob' },
 }));
 
 // useGuardedApi calls useNavigation (react-router hooks); stub it so renderHook works without a <Router> wrapper.
@@ -16,6 +17,14 @@ jest.mock('../hooks/navigation.hook', () => ({
   useNavigation: () => ({ navigate: jest.fn() }),
 }));
 
+// downloadDossier hands the blob to the shared saveFile util (utils.downloadFile), which touches the DOM; stub it
+// so the hook test can assert the api call without a real browser download.
+jest.mock('src/util/utils', () => ({
+  ...jest.requireActual('src/util/utils'),
+  downloadFile: jest.fn(),
+}));
+
+import { ResponseType } from '@dfx.swiss/react';
 import { useRealunitCompliance } from '../hooks/realunit-compliance.hook';
 import { useRealunitSupport } from '../hooks/realunit-support.hook';
 
@@ -111,5 +120,18 @@ describe('useRealunitCompliance', () => {
 
     await result.current.downloadFile(9, 'file-uid');
     expect(mockCall).toHaveBeenCalledWith({ url: 'realunit/compliance/customers/9/files/file-uid', method: 'GET' });
+  });
+
+  it('requests the dossier as a blob from the dossier endpoint', async () => {
+    mockCall.mockResolvedValue({ data: new Blob(['zip']), headers: {} });
+    const { result } = renderHook(() => useRealunitCompliance());
+
+    await result.current.downloadDossier(9);
+
+    expect(mockCall).toHaveBeenCalledWith({
+      url: 'realunit/compliance/customers/9/dossier',
+      method: 'GET',
+      responseType: ResponseType.BLOB,
+    });
   });
 });

--- a/src/dto/realunit-compliance.dto.ts
+++ b/src/dto/realunit-compliance.dto.ts
@@ -106,10 +106,12 @@ export interface RealUnitKycFileDto {
 }
 
 // Reduced KYC step: raw result/comment and the recommendation/referral graph are omitted by the api.
-// One resolved check evidence, decided by the api (which step/file counts). `status` only for step-backed checks
-// (ident); `fileUid`/`fileName` point at the downloadable evidence when one exists.
+// One resolved check evidence, decided by the api (which step/file counts). `status`/`type` only for step-backed
+// checks (ident; type = KycStepType, e.g. SumsubAuto/SumsubVideo/Video/Manual); `fileUid`/`fileName` point at the
+// downloadable evidence when one exists.
 export interface RealUnitCheckEvidenceDto {
   status?: string;
+  type?: string;
   date: string;
   fileUid?: string;
   fileName?: string;

--- a/src/dto/realunit-compliance.dto.ts
+++ b/src/dto/realunit-compliance.dto.ts
@@ -106,6 +106,21 @@ export interface RealUnitKycFileDto {
 }
 
 // Reduced KYC step: raw result/comment and the recommendation/referral graph are omitted by the api.
+// One resolved check evidence, decided by the api (which step/file counts). `status` only for step-backed checks
+// (ident); `fileUid`/`fileName` point at the downloadable evidence when one exists.
+export interface RealUnitCheckEvidenceDto {
+  status?: string;
+  date: string;
+  fileUid?: string;
+  fileName?: string;
+}
+
+// Mandatory checks of the dossier. An absent member = check missing — render as a finding, never hide the row.
+export interface RealUnitChecksDto {
+  identCheck?: RealUnitCheckEvidenceDto;
+  nameCheck?: RealUnitCheckEvidenceDto;
+}
+
 export interface RealUnitDossierKycStepDto {
   id: number;
   name: string;
@@ -199,6 +214,9 @@ export interface RealUnitCustomerDetailDto {
   kycType?: string;
   highRisk?: boolean;
   pep?: boolean;
+
+  // --- Mandatory checks, resolved by the api (absent member = check missing) --- //
+  checks: RealUnitChecksDto;
 
   // --- Customer-scoped slices (reduced, AML work products structurally omitted) --- //
   kycFiles: RealUnitKycFileDto[];

--- a/src/hooks/realunit-compliance.hook.ts
+++ b/src/hooks/realunit-compliance.hook.ts
@@ -1,9 +1,11 @@
+import { ResponseType } from '@dfx.swiss/react';
 import { useMemo } from 'react';
 import {
   RealUnitCustomerDetailDto,
   RealUnitCustomerListDto,
   RealUnitKycFileDownloadDto,
 } from 'src/dto/realunit-compliance.dto';
+import { downloadFile as saveFile, filenameDateFormat } from 'src/util/utils';
 import { useGuardedApi } from './guarded-api.hook';
 
 // RealUnit tenant compliance hook. READ-ONLY, strictly customer-scoped `/v1/realunit/compliance/*` endpoints over
@@ -34,11 +36,23 @@ export function useRealunitCompliance() {
     });
   }
 
+  // Full dossier as ZIP (all allowlisted files, bundled and audit-logged api-side).
+  async function downloadDossier(id: number): Promise<void> {
+    const { data, headers } = await call<{ data: Blob; headers: Record<string, string> }>({
+      url: `realunit/compliance/customers/${id}/dossier`,
+      method: 'GET',
+      responseType: ResponseType.BLOB,
+    });
+
+    saveFile(data, headers, `RealUnit_dossier_${id}_${filenameDateFormat()}.zip`);
+  }
+
   return useMemo(
     () => ({
       searchCustomers,
       getCustomer,
       downloadFile,
+      downloadDossier,
     }),
     [call],
   );

--- a/src/hooks/realunit-compliance.hook.ts
+++ b/src/hooks/realunit-compliance.hook.ts
@@ -12,9 +12,10 @@ import { useGuardedApi } from './guarded-api.hook';
 export function useRealunitCompliance() {
   const { call } = useGuardedApi();
 
-  async function searchCustomers(key: string): Promise<RealUnitCustomerListDto[]> {
+  // Without a key the api returns the complete tenant scope (all RealUnit customers).
+  async function searchCustomers(key?: string): Promise<RealUnitCustomerListDto[]> {
     return call<RealUnitCustomerListDto[]>({
-      url: `realunit/compliance/customers?key=${encodeURIComponent(key)}`,
+      url: `realunit/compliance/customers${key ? `?key=${encodeURIComponent(key)}` : ''}`,
       method: 'GET',
     });
   }

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -71,10 +71,11 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
 
   const { id } = useParams();
   const { translate } = useSettingsContext();
-  const { getCustomer, downloadFile } = useRealunitCompliance();
+  const { getCustomer, downloadFile, downloadDossier } = useRealunitCompliance();
 
   const [customer, setCustomer] = useState<RealUnitCustomerDetailDto>();
   const [isLoading, setIsLoading] = useState(true);
+  const [isDossierLoading, setIsDossierLoading] = useState(false);
   const [loadError, setLoadError] = useState<string>();
   const [actionError, setActionError] = useState<string>();
 
@@ -120,6 +121,19 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
     [id, downloadFile],
   );
 
+  const handleDossierDownload = useCallback(async (): Promise<void> => {
+    if (!id) return;
+    setActionError(undefined);
+    setIsDossierLoading(true);
+    try {
+      await downloadDossier(+id);
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Error downloading dossier');
+    } finally {
+      setIsDossierLoading(false);
+    }
+  }, [id, downloadDossier]);
+
   if (loadError) return <ErrorHint message={loadError} />;
   if (isLoading || !customer) return <StyledLoadingSpinner size={SpinnerSize.LG} />;
 
@@ -131,6 +145,7 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
     check ? (
       <span className="inline-flex items-center gap-2">
         {check.status && statusBadge(check.status)}
+        {check.type && <span className="text-dfxGray-700">{check.type}</span>}
         {formatDate(check.date)}
         {check.fileUid && check.fileName && (
           <button
@@ -150,6 +165,19 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
   return (
     <div className="w-full max-w-screen-xl mx-auto flex flex-col gap-6 p-4 md:p-6 text-left">
       {actionError && <ErrorHint message={actionError} />}
+
+      {/* Full dossier export (ZIP of all visible files; audit-logged api-side) */}
+      <div className="flex justify-end">
+        <button
+          className="px-3 py-1.5 text-sm font-medium bg-white border border-dfxGray-400 text-dfxBlue-800 rounded hover:bg-dfxGray-300 transition-colors disabled:opacity-50"
+          onClick={handleDossierDownload}
+          disabled={isDossierLoading}
+        >
+          {isDossierLoading
+            ? translate('screens/compliance', 'Preparing ZIP ...')
+            : translate('screens/compliance', 'Download dossier (ZIP)')}
+        </button>
+      </div>
 
       {/* Identity / KYC status */}
       <div className="flex gap-4 flex-wrap">

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -127,12 +127,16 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
 
   // Mandatory check evidence: latest ident step (Sumsub) and latest Dilisense name-check file.
   // Both rows must always be visible — a missing check is a compliance finding, not an empty state.
+  const latestFileOfType = (type: string) =>
+    [...customer.kycFiles]
+      .filter((f) => f.type === type)
+      .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())[0];
+
   const identStep = [...customer.kycSteps]
     .filter((s) => s.name === 'Ident')
     .sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
-  const dilisenseFile = [...customer.kycFiles]
-    .filter((f) => f.type === 'NameCheck')
-    .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())[0];
+  const identFile = latestFileOfType('Identification');
+  const dilisenseFile = latestFileOfType('NameCheck');
 
   const missingBadge = (
     <span className="px-2 py-1 rounded text-xs bg-dfxGray-300 text-primary-red font-semibold">
@@ -178,10 +182,18 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
           <InfoRow
             label={translate('screens/compliance', 'Ident Check (Sumsub)')}
             value={
-              identStep ? (
+              identStep || identFile ? (
                 <span className="inline-flex items-center gap-2">
-                  {statusBadge(identStep.status)}
-                  {formatDate(identStep.created)}
+                  {identStep && statusBadge(identStep.status)}
+                  {formatDate((identStep ?? identFile).created)}
+                  {identFile && (
+                    <button
+                      className="px-2 py-1 text-xs font-medium bg-white border border-dfxGray-400 text-dfxBlue-800 rounded hover:bg-dfxGray-300 transition-colors"
+                      onClick={() => handleDownload(identFile.uid, identFile.name)}
+                    >
+                      {translate('general/actions', 'Download')}
+                    </button>
+                  )}
                 </span>
               ) : (
                 missingBadge

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import { ErrorHint } from 'src/components/error-hint';
 import { InfoPanel, InfoRow, SupportMessageList } from 'src/components/support/info-panel';
 import { useSettingsContext } from 'src/contexts/settings.context';
-import { RealUnitCustomerDetailDto } from 'src/dto/realunit-compliance.dto';
+import { RealUnitCheckEvidenceDto, RealUnitCustomerDetailDto } from 'src/dto/realunit-compliance.dto';
 import { useRealunitGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useRealunitCompliance } from 'src/hooks/realunit-compliance.hook';
@@ -125,24 +125,27 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
 
   const org = customer.organization;
 
-  // Mandatory check evidence: latest ident step (Sumsub) and latest Dilisense name-check file.
-  // Both rows must always be visible — a missing check is a compliance finding, not an empty state.
-  const latestFileOfType = (type: string) =>
-    [...customer.kycFiles]
-      .filter((f) => f.type === type)
-      .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())[0];
-
-  const identStep = [...customer.kycSteps]
-    .filter((s) => s.name === 'Ident')
-    .sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
-  const identFile = latestFileOfType('Identification');
-  const dilisenseFile = latestFileOfType('NameCheck');
-
-  const missingBadge = (
-    <span className="px-2 py-1 rounded text-xs bg-dfxGray-300 text-primary-red font-semibold">
-      {translate('screens/compliance', 'Missing')}
-    </span>
-  );
+  // Renders one api-resolved check evidence 1:1 (api = decision authority; which step/file counts is decided
+  // there). Both rows must always be visible — a missing check is a compliance finding, not an empty state.
+  const checkValue = (check?: RealUnitCheckEvidenceDto) =>
+    check ? (
+      <span className="inline-flex items-center gap-2">
+        {check.status && statusBadge(check.status)}
+        {formatDate(check.date)}
+        {check.fileUid && check.fileName && (
+          <button
+            className="px-2 py-1 text-xs font-medium bg-white border border-dfxGray-400 text-dfxBlue-800 rounded hover:bg-dfxGray-300 transition-colors"
+            onClick={() => handleDownload(check.fileUid!, check.fileName!)}
+          >
+            {translate('general/actions', 'Download')}
+          </button>
+        )}
+      </span>
+    ) : (
+      <span className="px-2 py-1 rounded text-xs bg-dfxGray-300 text-primary-red font-semibold">
+        {translate('screens/compliance', 'Missing')}
+      </span>
+    );
 
   return (
     <div className="w-full max-w-screen-xl mx-auto flex flex-col gap-6 p-4 md:p-6 text-left">
@@ -181,42 +184,11 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
         <InfoPanel title={translate('screens/compliance', 'Checks')}>
           <InfoRow
             label={translate('screens/compliance', 'Ident Check (Sumsub)')}
-            value={
-              identStep || identFile ? (
-                <span className="inline-flex items-center gap-2">
-                  {identStep && statusBadge(identStep.status)}
-                  {formatDate((identStep ?? identFile).created)}
-                  {identFile && (
-                    <button
-                      className="px-2 py-1 text-xs font-medium bg-white border border-dfxGray-400 text-dfxBlue-800 rounded hover:bg-dfxGray-300 transition-colors"
-                      onClick={() => handleDownload(identFile.uid, identFile.name)}
-                    >
-                      {translate('general/actions', 'Download')}
-                    </button>
-                  )}
-                </span>
-              ) : (
-                missingBadge
-              )
-            }
+            value={checkValue(customer.checks.identCheck)}
           />
           <InfoRow
             label={translate('screens/compliance', 'Dilisense Check')}
-            value={
-              dilisenseFile ? (
-                <span className="inline-flex items-center gap-2">
-                  {formatDate(dilisenseFile.created)}
-                  <button
-                    className="px-2 py-1 text-xs font-medium bg-white border border-dfxGray-400 text-dfxBlue-800 rounded hover:bg-dfxGray-300 transition-colors"
-                    onClick={() => handleDownload(dilisenseFile.uid, dilisenseFile.name)}
-                  >
-                    {translate('general/actions', 'Download')}
-                  </button>
-                </span>
-              ) : (
-                missingBadge
-              )
-            }
+            value={checkValue(customer.checks.nameCheck)}
           />
         </InfoPanel>
 

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -141,26 +141,32 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
 
   // Renders one api-resolved check evidence 1:1 (api = decision authority; which step/file counts is decided
   // there). Both rows must always be visible — a missing check is a compliance finding, not an empty state.
-  const checkValue = (check?: RealUnitCheckEvidenceDto) =>
-    check ? (
+  const checkValue = (check?: RealUnitCheckEvidenceDto) => {
+    if (!check)
+      return (
+        <span className="px-2 py-1 rounded text-xs bg-dfxGray-300 text-primary-red font-semibold">
+          {translate('screens/compliance', 'Missing')}
+        </span>
+      );
+
+    // capture as locals so the download closure keeps the narrowing without a non-null assertion
+    const { fileUid, fileName } = check;
+    return (
       <span className="inline-flex items-center gap-2">
         {check.status && statusBadge(check.status)}
         {check.type && <span className="text-dfxGray-700">{check.type}</span>}
         {formatDate(check.date)}
-        {check.fileUid && check.fileName && (
+        {fileUid && fileName && (
           <button
             className="px-2 py-1 text-xs font-medium bg-white border border-dfxGray-400 text-dfxBlue-800 rounded hover:bg-dfxGray-300 transition-colors"
-            onClick={() => handleDownload(check.fileUid!, check.fileName!)}
+            onClick={() => handleDownload(fileUid, fileName)}
           >
             {translate('general/actions', 'Download')}
           </button>
         )}
       </span>
-    ) : (
-      <span className="px-2 py-1 rounded text-xs bg-dfxGray-300 text-primary-red font-semibold">
-        {translate('screens/compliance', 'Missing')}
-      </span>
     );
+  };
 
   return (
     <div className="w-full max-w-screen-xl mx-auto flex flex-col gap-6 p-4 md:p-6 text-left">

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -125,6 +125,21 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
 
   const org = customer.organization;
 
+  // Mandatory check evidence: latest ident step (Sumsub) and latest Dilisense name-check file.
+  // Both rows must always be visible — a missing check is a compliance finding, not an empty state.
+  const identStep = [...customer.kycSteps]
+    .filter((s) => s.name === 'Ident')
+    .sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
+  const dilisenseFile = [...customer.kycFiles]
+    .filter((f) => f.type === 'NameCheck')
+    .sort((a, b) => new Date(b.created).getTime() - new Date(a.created).getTime())[0];
+
+  const missingBadge = (
+    <span className="px-2 py-1 rounded text-xs bg-dfxGray-300 text-primary-red font-semibold">
+      {translate('screens/compliance', 'Missing')}
+    </span>
+  );
+
   return (
     <div className="w-full max-w-screen-xl mx-auto flex flex-col gap-6 p-4 md:p-6 text-left">
       {actionError && <ErrorHint message={actionError} />}
@@ -157,6 +172,40 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
           <InfoRow label="KYC Type" value={customer.kycType ?? '-'} />
           <InfoRow label="High Risk" value={bool(customer.highRisk)} />
           <InfoRow label="PEP" value={bool(customer.pep)} />
+        </InfoPanel>
+
+        <InfoPanel title={translate('screens/compliance', 'Checks')}>
+          <InfoRow
+            label={translate('screens/compliance', 'Ident Check (Sumsub)')}
+            value={
+              identStep ? (
+                <span className="inline-flex items-center gap-2">
+                  {statusBadge(identStep.status)}
+                  {formatDate(identStep.created)}
+                </span>
+              ) : (
+                missingBadge
+              )
+            }
+          />
+          <InfoRow
+            label={translate('screens/compliance', 'Dilisense Check')}
+            value={
+              dilisenseFile ? (
+                <span className="inline-flex items-center gap-2">
+                  {formatDate(dilisenseFile.created)}
+                  <button
+                    className="px-2 py-1 text-xs font-medium bg-white border border-dfxGray-400 text-dfxBlue-800 rounded hover:bg-dfxGray-300 transition-colors"
+                    onClick={() => handleDownload(dilisenseFile.uid, dilisenseFile.name)}
+                  >
+                    {translate('general/actions', 'Download')}
+                  </button>
+                </span>
+              ) : (
+                missingBadge
+              )
+            }
+          />
         </InfoPanel>
 
         {org && (

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -184,11 +184,11 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
         <InfoPanel title={translate('screens/compliance', 'Checks')}>
           <InfoRow
             label={translate('screens/compliance', 'Ident Check (Sumsub)')}
-            value={checkValue(customer.checks.identCheck)}
+            value={checkValue(customer.checks?.identCheck)}
           />
           <InfoRow
             label={translate('screens/compliance', 'Dilisense Check')}
-            value={checkValue(customer.checks.nameCheck)}
+            value={checkValue(customer.checks?.nameCheck)}
           />
         </InfoPanel>
 

--- a/src/screens/realunit-compliance.screen.tsx
+++ b/src/screens/realunit-compliance.screen.tsx
@@ -1,5 +1,5 @@
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { RealUnitCustomerListDto } from 'src/dto/realunit-compliance.dto';
@@ -26,15 +26,21 @@ export default function RealunitComplianceScreen(): JSX.Element {
     noMaxWidth: true,
   });
 
-  function handleSearch(): void {
-    if (!searchKey.trim()) return;
+  // Load the complete customer list upfront; a search key narrows it down, an empty search shows all again.
+  useEffect(() => loadCustomers(), []);
+
+  function loadCustomers(key?: string): void {
     setIsLoading(true);
     setError(undefined);
     setResults(undefined);
-    searchCustomers(searchKey.trim())
+    searchCustomers(key)
       .then((res) => setResults(res))
       .catch((e: Error) => setError(e.message ?? 'Unknown error'))
       .finally(() => setIsLoading(false));
+  }
+
+  function handleSearch(): void {
+    loadCustomers(searchKey.trim() || undefined);
   }
 
   return (
@@ -53,7 +59,7 @@ export default function RealunitComplianceScreen(): JSX.Element {
           <button
             className="px-4 py-1.5 bg-dfxBlue-400 text-white rounded text-sm hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
             onClick={handleSearch}
-            disabled={isLoading || !searchKey.trim()}
+            disabled={isLoading}
           >
             {isLoading ? '…' : translate('general/actions', 'Search')}
           </button>

--- a/src/screens/realunit-compliance.screen.tsx
+++ b/src/screens/realunit-compliance.screen.tsx
@@ -52,7 +52,7 @@ export default function RealunitComplianceScreen(): JSX.Element {
             value={searchKey}
             onChange={(e) => setSearchKey(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSearch();
+              if (e.key === 'Enter' && !isLoading) handleSearch();
             }}
             placeholder={translate('screens/compliance', 'Search by ID, email, phone or name...')}
           />


### PR DESCRIPTION
## Summary

The RealUnit compliance dashboard (`/realunit/compliance`) now shows **all** customers with a registered RealUnit wallet when opened; the search only narrows the list down. An empty search shows the full list again.

- `useRealunitCompliance.searchCustomers`: `key` is optional — without it the api returns the complete tenant scope
- Screen loads the full list on mount; the Search button is only disabled while loading
- e2e spec: asserts the upfront list is rendered before any input

## Depends on

API pair PR: DFXswiss/api#4135 — without it, the initial no-key request is rejected (`key` was `@IsNotEmpty`). Merge the api PR first.

## Visual baselines

Not regenerated: the committed `01-search` screenshot is taken after a search and is visually unchanged by this PR. The new upfront-list state has no committed baseline yet; can be added once the local stack is up.

## Tests

- All 32 suites green (369 tests), ESLint clean