### PR TITLE
feat(mail): redirect merged accounts to master code on mail updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.4.1",
+        "@dfx.swiss/react": "^1.5.0",
         "@dfx.swiss/react-components": "^1.3.2",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -2632,9 +2632,9 @@
       }
     },
     "node_modules/@dfx.swiss/core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.3.1.tgz",
-      "integrity": "sha512-S0YVOEhNlXGWuDgt6TJe3zj86ELHAe3+6J4dUGLezDstOceinvMnUI2wkjn6FN1dFJxY7M9kt5a3I5f43fpalQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-b0nZhGfRkj9E+75i7hG2UkPx1IA/fK6y6qI+yEWBMCfTjO8XlNPOL8JhOzX1FcAnfOHlIqBow+FHyJ441j3EgA==",
       "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
@@ -2642,12 +2642,12 @@
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.4.1.tgz",
-      "integrity": "sha512-tCdEf1cpA+x8ULt2sdBtkuFcnYZG0sG4E9zgyjkZbFC5iY461/cAYyexu3IqIE512lQCTV5Abx8DX0rbxtegMQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.5.0.tgz",
+      "integrity": "sha512-zg56lzXU97yCul6If20bDD10tIc/nShK43KdRtGoPhz6oMIDLhJ/PcD1FL3mt0BdiQJn/gjZ/LseLfR7SI2RFQ==",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/core": "^0.3.1",
+        "@dfx.swiss/core": "^0.4.0",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "typescript": "^4.9.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.4.1",
+    "@dfx.swiss/react": "^1.5.0",
     "@dfx.swiss/react-components": "^1.3.2",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",

--- a/src/components/edit/mail.edit.tsx
+++ b/src/components/edit/mail.edit.tsx
@@ -1,4 +1,4 @@
-import { Utils, Validations, useUserContext } from '@dfx.swiss/react';
+import { ApiError, Utils, Validations, useUserContext } from '@dfx.swiss/react';
 import {
   Form,
   IconColor,
@@ -13,6 +13,7 @@ import {
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSettingsContext } from '../../contexts/settings.context';
+import { useMergedAccount } from '../../hooks/merged-account.hook';
 
 interface MailEditProps {
   infoText?: string;
@@ -51,6 +52,7 @@ export function MailEdit({
   } = useForm<FormData>({ mode: 'onTouched' });
   const { updateMail, isUserUpdating } = useUserContext();
   const { translate, translateError } = useSettingsContext();
+  const { handleMergedError } = useMergedAccount();
 
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [pendingEmail, setPendingEmail] = useState<string>();
@@ -62,7 +64,12 @@ export function MailEdit({
   }
 
   async function saveUser(email: string): Promise<void> {
-    return updateMail(email).then(() => onSubmit(email));
+    return updateMail(email)
+      .then(() => onSubmit(email))
+      .catch((e: ApiError) => {
+        if (handleMergedError(e)) return;
+        throw e;
+      });
   }
 
   const rules = Utils.createRules({

--- a/src/hooks/merged-account.hook.ts
+++ b/src/hooks/merged-account.hook.ts
@@ -1,0 +1,23 @@
+import { ApiError, useSessionContext } from '@dfx.swiss/react';
+import { useNavigation } from './navigation.hook';
+
+interface MergedAccountInterface {
+  // Redirects a merged account to its master KYC code and ends the dead session.
+  // Returns true if the error was a merged-account 401 and got handled, false otherwise.
+  handleMergedError: (e: ApiError) => boolean;
+}
+
+export function useMergedAccount(): MergedAccountInterface {
+  const { navigate } = useNavigation();
+  const { logout } = useSessionContext();
+
+  function handleMergedError(e: ApiError): boolean {
+    if (e.statusCode !== 401 || !e.switchToCode) return false;
+
+    navigate({ pathname: '/kyc', search: `?code=${e.switchToCode}` });
+    logout();
+    return true;
+  }
+
+  return { handleMergedError };
+}

--- a/src/screens/edit-mail.screen.tsx
+++ b/src/screens/edit-mail.screen.tsx
@@ -14,12 +14,14 @@ import { ErrorHint } from 'src/components/error-hint';
 import { EditOverlay } from 'src/components/overlay/edit-overlay';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useMergedAccount } from 'src/hooks/merged-account.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 
 export default function EditMailScreen(): JSX.Element {
   const { translate, translateError } = useSettingsContext();
   const { updateMail, verifyMail } = useUserContext();
   const { navigate } = useNavigation();
+  const { handleMergedError } = useMergedAccount();
   const { user } = useUserContext();
   const { check2fa } = useKyc();
 
@@ -49,6 +51,8 @@ export default function EditMailScreen(): JSX.Element {
     return updateMail(newEmail)
       .then(() => setMailVerificationStep(true))
       .catch((e: ApiError) => {
+        if (handleMergedError(e)) return;
+
         if (e.statusCode === 409 && e.message?.includes('exists')) {
           if (e.message.includes('merge')) {
             setShowLinkHint(true);
@@ -69,7 +73,9 @@ export default function EditMailScreen(): JSX.Element {
     verifyMail(data.token)
       .then(() => navigate('/account'))
       .catch((e: ApiError) =>
-        e.statusCode === 403
+        handleMergedError(e)
+          ? undefined
+          : e.statusCode === 403
           ? setTokenInvalid(true)
           : e.statusCode === 409 && e.message?.includes('exists')
           ? e.message.includes('merge')


### PR DESCRIPTION
## What
Companion to DFXswiss/api#4092. That PR makes the mail-update routes return HTTP 401 + `MergedDto` (carrying `switchToCode`) for merged accounts instead of a bare 409. This handles that response on the mail flows so a merged account is redirected to its master account's code — the same behaviour `kyc.screen` already has — instead of hitting a generic session error / logout.

## Changes
- Bump `@dfx.swiss/react` to `^1.5.0` (adds `switchToCode` on `ApiException`, from DFXswiss/packages#187).
- New `useMergedAccount` hook (`handleMergedError`): on a 401 carrying `switchToCode`, navigate to `/kyc?code=<master>` + logout.
- Apply it as the first `catch` branch in `edit-mail.screen` (`onSubmit`/`onVerify`) and `mail.edit` (`saveUser`).

## Notes
- The redirect targets `pathname: '/kyc'` explicitly (not just `?code=` like `kyc.screen`, which works only because that screen already lives on `/kyc` and reads the param) — so the master code takes effect from the mail screens too.
- Redirect + logout only; no new UI / i18n.
- Prerequisite packages change is published as `@dfx.swiss/react@1.5.0`.