### PR TITLE
ci: skip the review-bot comment on fork PRs instead of failing the check

### DIFF
--- a/.github/workflows/pr-review-bot.yml
+++ b/.github/workflows/pr-review-bot.yml
@@ -90,6 +90,9 @@ jobs:
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
       - name: Post PR comment
+        # Fork PRs run with a read-only GITHUB_TOKEN, so the issue-comment API returns 403 and fails the whole job.
+        # The bot can only post on same-repo PRs; skip cleanly on forks instead of turning the check red.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## What

A fork PR's `GITHUB_TOKEN` is read-only, so the `issues.createComment` call in the PR Review Bot returns `403 Resource not accessible by integration` and fails the whole `review` check — even though the bot's own steps (commit-signature check, ESLint, TypeScript, audit) all pass.

Guard the "Post PR comment" step to same-repo PRs:

```yaml
if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
```

Fork PRs now skip the comment cleanly (it cannot post there anyway) instead of turning the check red. Same-repo PRs are unchanged and still get the comment.

## Why

Fork PRs (e.g. from a personal `<user>/services` fork) currently show a red `review` check for a reason unrelated to their code. This removes that false negative without weakening any check: the comment is purely informational, and no permissions or triggers are changed (so no `pull_request_target` exposure).

## Note

A follow-up option, if the bot should actually comment on fork PRs, is to split the untrusted build/lint steps (`pull_request`) from a no-checkout comment job (`workflow_run`/`pull_request_target`). Intentionally out of scope here to avoid running fork code with a write token.