### PR TITLE
feat(realunit): REALU balance column in compliance list and detail

### DIFF
--- a/src/dto/realunit-compliance.dto.ts
+++ b/src/dto/realunit-compliance.dto.ts
@@ -90,6 +90,8 @@ export interface RealUnitVirtualIban {
 }
 
 export interface RealUnitCustomerListDto {
+  // current REALU holdings (share count, summed over all wallet addresses); undefined = could not be resolved
+  balance?: number;
   id: number;
   kycStatus: string;
   kycLevel?: string;
@@ -216,6 +218,9 @@ export interface RealUnitCustomerDetailDto {
   kycType?: string;
   highRisk?: boolean;
   pep?: boolean;
+
+  // current REALU holdings (share count, summed over all wallet addresses); undefined = could not be resolved
+  balance?: number;
 
   // --- Mandatory checks, resolved by the api (absent member = check missing) --- //
   checks: RealUnitChecksDto;

--- a/src/dto/realunit-compliance.dto.ts
+++ b/src/dto/realunit-compliance.dto.ts
@@ -1,8 +1,9 @@
 // Frontend mirror of the api RealUnit reduced-compliance DTOs
 // (api: src/subdomains/supporting/realunit/dto/realunit-compliance.dto.ts).
 // Every field is a whitelist copy of the api DTO; Date fields arrive as ISO strings over the wire. This is the
-// REDUCED tenant view — it structurally contains NO DFX AML work product (no name-check, no amlCheck/amlReason,
-// no compliance notes, no limitRequest, no recommendation graph). Do not add such fields here or render them.
+// REDUCED tenant view — it structurally contains NO DFX AML work product (no amlCheck/amlReason, no compliance
+// notes, no limitRequest, no recommendation graph), with one deliberate exception: the mandatory check evidences
+// (ident + Dilisense name check, `checks`). Do not add other such fields here or render them.
 
 export interface CountrySupportInfo {
   name: string;

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -213,6 +213,10 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
           <InfoRow label="KYC Type" value={customer.kycType ?? '-'} />
           <InfoRow label="High Risk" value={bool(customer.highRisk)} />
           <InfoRow label="PEP" value={bool(customer.pep)} />
+          <InfoRow
+            label={translate('screens/compliance', 'Balance (REALU)')}
+            value={customer.balance != null ? customer.balance.toLocaleString('de-CH') : '-'}
+          />
         </InfoPanel>
 
         <InfoPanel title={translate('screens/compliance', 'Checks')}>

--- a/src/screens/realunit-compliance.screen.tsx
+++ b/src/screens/realunit-compliance.screen.tsx
@@ -93,6 +93,9 @@ export default function RealunitComplianceScreen(): JSX.Element {
                   <th className="px-3 py-2 text-left font-semibold text-dfxBlue-800">
                     {translate('screens/kyc', 'KYC Level')}
                   </th>
+                  <th className="px-3 py-2 text-right font-semibold text-dfxBlue-800">
+                    {translate('screens/compliance', 'Balance (REALU)')}
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -108,6 +111,9 @@ export default function RealunitComplianceScreen(): JSX.Element {
                     <td className="px-3 py-2 text-dfxBlue-800 group-hover:text-white break-all">{u.mail ?? '-'}</td>
                     <td className="px-3 py-2 text-dfxBlue-800 group-hover:text-white">{u.kycStatus}</td>
                     <td className="px-3 py-2 text-dfxBlue-800 group-hover:text-white">{u.kycLevel ?? '-'}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-dfxBlue-800 group-hover:text-white">
+                      {u.balance != null ? u.balance.toLocaleString('de-CH') : '-'}
+                    </td>
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
## Was

Frontend-Gegenstück zu DFXswiss/api#4189 (**api zuerst mergen**): Das RealUnit-Compliance-Dashboard zeigt die aktuelle REALU-Balance des Kunden.

- **Kundenliste**: neue rechtsbündige Spalte „Balance (REALU)" (tabular-nums, de-CH-Formatierung)
- **Kunden-Detail**: Zeile „Balance (REALU)" im KYC/Status-Panel
- Rendering 1:1 des API-Felds `balance` (API = Decision Authority): `undefined` (Indexer nicht erreichbar) → „–", `0` → „0"