### PR TITLE
fix(compliance): prefer manualReview kycSteps in review

### DIFF
--- a/src/components/compliance/ident-panel.tsx
+++ b/src/components/compliance/ident-panel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ComplianceUserData, KycFile, KycStepInfo, IpLogInfo } from 'src/hooks/compliance.hook';
+import { ComplianceUserData, IpLogInfo, KycFile, KycStepInfo } from 'src/hooks/compliance.hook';
 import { display, formatBirthday, refName, statusBadge, todayAsString } from 'src/util/compliance-helpers';
 import { renderResultTable } from './compliance-review-panel';
 
@@ -34,7 +34,9 @@ interface IdentResult {
 }
 
 function findLatestStep(kycSteps: KycStepInfo[], stepName: string): KycStepInfo | undefined {
-  return kycSteps.filter((s) => s.name === stepName).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
+  const steps = kycSteps.filter((s) => s.name === stepName);
+  const manualReview = steps.filter((s) => s.status === 'ManualReview');
+  return (manualReview.length ? manualReview : steps).sort((a, b) => b.sequenceNumber - a.sequenceNumber)[0];
 }
 
 function parseIdentResult(step: KycStepInfo): IdentResult | undefined {


### PR DESCRIPTION
## Problem

When multiple Ident KYC steps exist (e.g. one kycStep with type SumsubAuto and status Completed and one kycStep with type SumsubVideo and status ManualReview), the dashboard always displayed the step with the highest sequenceNumber. If both steps share the same sequence number, the sort order is unstable, causing the Completed step to win — hiding the ManualReview step that still requires action.

## Fix

Updated findLatestStep to prioritize ManualReview steps: if any exist, only those are considered for selection (sorted by sequenceNumber). The full step list is only used as fallback when no ManualReview step is present.