### PR TITLE
ci: dual-deploy to Cloudflare Pages alongside Azure

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -138,6 +138,17 @@ jobs:
               --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
               --no-wait
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@4
+
+      # Dual-deploy transition: Azure (above) stays until the DNS cutover to Pages
+      # is verified; a follow-up PR removes the Azure step afterwards.
+      - name: Deploy to Cloudflare Pages (DEV)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy build --project-name=dfx-app-dev --branch=develop
+
       - name: Logout
         run: |
           az logout

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -138,6 +138,17 @@ jobs:
               --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
               --no-wait
 
+      - name: Install Wrangler
+        run: npm install -g wrangler@4
+
+      # Dual-deploy transition: Azure (above) stays until the DNS cutover to Pages
+      # is verified; a follow-up PR removes the Azure step afterwards.
+      - name: Deploy to Cloudflare Pages (PRD)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy build --project-name=dfx-app-prd --branch=main
+
       - name: Logout
         run: |
           az logout

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,9 @@
   Access-Control-Allow-Origin: *
 
 # The embeddable widget is loaded cross-origin from third-party sites -> needs CORS.
+# Versioned in the path; match the previous CDN's 1h cache.
 /widget/*
+  Cache-Control: public, max-age=3600
   Access-Control-Allow-Origin: *
 
 # Entry points must always revalidate so a new deploy goes live immediately.

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,21 @@
+# Cloudflare Pages edge headers — replicate the cache/CORS semantics the previous
+# CDN served, so the Pages deployment behaves identically.
+#
+# Fingerprinted build assets (content-hashed filenames) never change -> cache hard.
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+  Access-Control-Allow-Origin: *
+
+# The embeddable widget is loaded cross-origin from third-party sites -> needs CORS.
+/widget/*
+  Access-Control-Allow-Origin: *
+
+# Entry points must always revalidate so a new deploy goes live immediately.
+/
+  Cache-Control: no-cache, must-revalidate
+/index.html
+  Cache-Control: no-cache, must-revalidate
+/manifest.json
+  Cache-Control: no-cache, must-revalidate
+/asset-manifest.json
+  Cache-Control: no-cache, must-revalidate

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+# SPA deep-link fallback: unknown paths serve the app shell (client-side routing).
+# Real files (static/*, widget/*, favicon, ...) are matched by the host first.
+/*    /index.html    200


### PR DESCRIPTION
## What

Deploys the app to **Cloudflare Pages** in addition to the existing Azure Blob upload (dual-deploy), and adds the Pages edge config (`public/_headers`, `public/_redirects`).

## Why

`app.dfx.swiss` (and `services.dfx.swiss`) are being migrated off Azure Front Door onto Cloudflare Pages. To avoid any window where the live app goes stale, this is a **dual-deploy transition**: every push keeps deploying to Azure *and* now also to the Pages projects. Once the DNS cutover to Pages is verified, a follow-up PR removes the Azure steps.

## Changes

- **`prd.yml` / `dev.yml`**: after the existing Azure deploy (and CDN purge), two new steps — install `wrangler@4` and `wrangler pages deploy build --project-name=<proj> --branch=<branch>`:
  - PRD → `dfx-app-prd` / `main`
  - DEV → `dfx-app-dev` / `develop`
  - Auth via repo secrets `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` (already set). The `Logout` step (`if: always()`) stays last.
- **`public/_headers`** (CRA copies `public/*` into `build/`): replicates the current CDN cache/CORS semantics on Pages —
  - `/static/*`: `immutable` (content-hashed) + `Access-Control-Allow-Origin: *`
  - `/widget/*`: `Access-Control-Allow-Origin: *` (embeddable widget is loaded cross-origin)
  - entry points (`/`, `/index.html`, `/manifest.json`, `/asset-manifest.json`): `no-cache, must-revalidate`
- **`public/_redirects`**: `/* /index.html 200` — SPA deep-link fallback.

## Not in this PR

- Removing the Azure deploy (follow-up, after the DNS cutover is verified).
- The DNS flip / Pages custom-domain attach (infra side).

## Verification

Draft until a preview deploy on the Pages project has been verified (SPA fallback, `_headers` cache/CORS, widget). The existing PR CI (lint/test/build) covers the build with the new `public/` files.
