### PR TITLE
fix: reload once on ChunkLoadError (recover stale chunks after deploy)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,13 +22,23 @@ if ((urlParams.has('address') && urlParams.has('signature')) || urlParams.has('s
 function isChunkLoadError(message?: string): boolean {
   return !!message && /Loading chunk [\w-]+ failed|ChunkLoadError|Loading CSS chunk [\w-]+ failed/i.test(message);
 }
+// A new deploy replaces the content-hashed chunks. A tab left open across a deploy can
+// request a chunk that no longer exists; the static host serves index.html (200) for it,
+// which surfaces as a ChunkLoadError. Reload once to pick up the new chunks. The guard
+// lives in localStorage (it survives the sessionStorage.clear() above that runs on
+// session/login URLs) and is time-boxed, so a persistent failure reloads at most once per
+// window instead of looping. Storage access is wrapped because embedded/iframe contexts
+// can block it.
 function reloadOnceForChunkError(): void {
-  const KEY = 'dfx.chunkReloadAt';
-  const last = Number(sessionStorage.getItem(KEY) ?? 0);
-  if (Date.now() - last > 10000) {
-    sessionStorage.setItem(KEY, String(Date.now()));
-    window.location.reload();
+  try {
+    const KEY = 'dfx.chunkReloadAt';
+    const last = Number(localStorage.getItem(KEY) ?? 0);
+    if (Date.now() - last < 30000) return;
+    localStorage.setItem(KEY, String(Date.now()));
+  } catch {
+    return; // storage blocked (e.g. embedded iframe) — skip to avoid an unguarded reload loop
   }
+  window.location.reload();
 }
 window.addEventListener('error', (event) => {
   if (isChunkLoadError(event?.message)) reloadOnceForChunkError();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,29 @@ if ((urlParams.has('address') && urlParams.has('signature')) || urlParams.has('s
   sessionStorage.clear();
 }
 
+// A new deploy replaces the content-hashed chunks. A tab left open across a deploy can
+// request a chunk that no longer exists; Cloudflare Pages then serves index.html (200)
+// for it, which surfaces as a ChunkLoadError. Reload once to pick up the new chunks,
+// guarded against a reload loop.
+function isChunkLoadError(message?: string): boolean {
+  return !!message && /Loading chunk [\w-]+ failed|ChunkLoadError|Loading CSS chunk [\w-]+ failed/i.test(message);
+}
+function reloadOnceForChunkError(): void {
+  const KEY = 'dfx.chunkReloadAt';
+  const last = Number(sessionStorage.getItem(KEY) ?? 0);
+  if (Date.now() - last > 10000) {
+    sessionStorage.setItem(KEY, String(Date.now()));
+    window.location.reload();
+  }
+}
+window.addEventListener('error', (event) => {
+  if (isChunkLoadError(event?.message)) reloadOnceForChunkError();
+});
+window.addEventListener('unhandledrejection', (event) => {
+  const message = (event?.reason as Error | undefined)?.message;
+  if (isChunkLoadError(message)) reloadOnceForChunkError();
+});
+
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(<Main />);
 


### PR DESCRIPTION
## What

Adds a global `ChunkLoadError` handler in `src/index.tsx` that reloads the page **once** (loop-guarded) when a stale/missing chunk fails to load.

## Why

After a deploy, the content-hashed chunks are replaced. A tab left open across a deploy can request a chunk that no longer exists. On a static host that serves `index.html` (200) for unknown paths (e.g. Cloudflare Pages via the SPA fallback), this surfaces as a **`ChunkLoadError`** (HTML parsed as JS) rather than a clean 404 — the app would otherwise stay broken until a manual reload.

## How

- `isChunkLoadError(message)` — regex match for JS/CSS chunk-load failures.
- `reloadOnceForChunkError()` — `window.location.reload()`, guarded by a `sessionStorage` timestamp (`dfx.chunkReloadAt`, 10s) to prevent a reload loop.
- Listeners on `error` and `unhandledrejection` (the latter casts `event.reason as Error | undefined` — no `any`).
- Inserted before `ReactDOM.createRoot`; existing session-clearing / `root.render` untouched.

## Verification

Verified on Node 20 (CI pin): `npm ci`, `npx eslint src/index.tsx` clean, `npm run build:dev` compiles successfully; `tsc` error count identical before/after (no new errors from `index.tsx`).
