### PR TITLE
List RealUnit on the payment-link page (ZCHF on Ethereum)

### DIFF
--- a/src/__tests__/payment-link-wallet.test.ts
+++ b/src/__tests__/payment-link-wallet.test.ts
@@ -145,5 +145,21 @@ describe('Wallet', () => {
       const result = Wallet.qualifiesForPayment(wallet, transferInfoList);
       expect(result).toBe(true);
     });
+
+    it('should return true for RealUnit-like Ethereum/ZCHF wallet against Ethereum transfer', () => {
+      const wallet = createWallet(['Ethereum'], [{ name: 'ZCHF', uniqueName: 'Ethereum:ZCHF' }]);
+      const transferInfoList = [createTransferInfo('Ethereum', ['ZCHF'])];
+
+      const result = Wallet.qualifiesForPayment(wallet, transferInfoList);
+      expect(result).toBe(true);
+    });
+
+    it('should return false for RealUnit-like Ethereum/ZCHF wallet against Lightning-only transfer', () => {
+      const wallet = createWallet(['Ethereum'], [{ name: 'ZCHF', uniqueName: 'Ethereum:ZCHF' }]);
+      const transferInfoList = [createTransferInfo('Lightning', ['BTC'])];
+
+      const result = Wallet.qualifiesForPayment(wallet, transferInfoList);
+      expect(result).toBe(false);
+    });
   });
 });

--- a/src/__tests__/payment-link-wallets.hook.test.ts
+++ b/src/__tests__/payment-link-wallets.hook.test.ts
@@ -45,6 +45,17 @@ const cakeWallet = {
   recommended: false,
 } as WalletInfo;
 
+const phoenixWallet = {
+  id: 7,
+  name: 'Phoenix',
+  iconUrl: 'https://example.com/phoenix.png',
+  deepLink: 'phoenix:',
+  supportedMethods: ['Lightning'],
+  supportedAssets: [],
+  active: true,
+  recommended: false,
+} as WalletInfo;
+
 describe('usePaymentLinkWallets', () => {
   const originalFetch = global.fetch;
 
@@ -99,5 +110,25 @@ describe('usePaymentLinkWallets', () => {
 
     const deeplink = await result.current.getDeeplinkByWalletId(42);
     expect(deeplink).toBe('cakewallet:');
+  });
+
+  it('exposes hasActionDeepLink for Lightning wallets via supportedMethods alone, without the backend flag', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [phoenixWallet],
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => usePaymentLinkWallets());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const wallet = result.current.otherWallets.find((w) => w.id === 7);
+    expect(wallet).toBeDefined();
+    expect(wallet?.hasActionDeepLink).toBe(true);
+
+    const deeplink = await result.current.getDeeplinkByWalletId(7);
+    expect(deeplink).toBe(`phoenix:lightning:${LNURL}`);
   });
 });

--- a/src/__tests__/payment-link-wallets.hook.test.ts
+++ b/src/__tests__/payment-link-wallets.hook.test.ts
@@ -1,0 +1,72 @@
+jest.mock('@dfx.swiss/react', () => ({
+  Blockchain: { LIGHTNING: 'Lightning', Ethereum: 'Ethereum' },
+  PaymentLinkMode: { PUBLIC: 'Public' },
+}));
+
+jest.mock('src/dto/payment-link.dto', () => ({
+  C2BPaymentMethod: { BINANCE_PAY: 'BinancePay', KUCOINPAY: 'KuCoinPay' },
+}));
+
+jest.mock('src/config/api', () => ({
+  Api: { url: 'http://localhost', version: 'v1' },
+}));
+
+const mockUsePaymentLinkContext = jest.fn();
+
+jest.mock('src/contexts/payment-link.context', () => ({
+  usePaymentLinkContext: () => mockUsePaymentLinkContext(),
+}));
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { usePaymentLinkWallets } from '../hooks/payment-link-wallets.hook';
+import { WalletInfo } from 'src/dto/payment-link.dto';
+
+const LNURL = 'lnurl1dp68gurn8ghj7um9wfmxjcm99e3k7mf0v9cxj0m385ekvcenxc6r2c35xvukxefcv5mkvv34x5ekzd3ev56nyd3hxqurzepexejxxepnxscrvwfnv9nxzcn9xq6xyefhvgcxxcmmx4zkyvf5xq6ryvfev9jx2vfexgckyef5xq6x2efnxgcxxcmmx4zkyvf5xq6ryvfev9jx2';
+
+const realUnitWallet = {
+  id: 99,
+  name: 'RealUnit',
+  iconUrl: 'https://example.com/realunit.png',
+  deepLink: 'realunit-wallet:',
+  supportedMethods: ['Ethereum'],
+  supportedAssets: [{ name: 'ZCHF', uniqueName: 'Ethereum:ZCHF' }],
+  active: true,
+  recommended: false,
+} as WalletInfo;
+
+describe('usePaymentLinkWallets', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    mockUsePaymentLinkContext.mockReturnValue({
+      paymentIdentifier: `https://pay.example.com/?lightning=${LNURL}`,
+      payRequest: undefined,
+      paymentHasQuote: () => false,
+    });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [realUnitWallet],
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it('exposes hasActionDeepLink for RealUnit and builds a lightning LNURL deeplink', async () => {
+    const { result } = renderHook(() => usePaymentLinkWallets());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const wallet = result.current.otherWallets.find((w) => w.name === 'RealUnit');
+    expect(wallet).toBeDefined();
+    expect(wallet?.hasActionDeepLink).toBe(true);
+
+    const deeplink = await result.current.getDeeplinkByWalletId(99);
+    expect(deeplink).toBe(`realunit-wallet:lightning:${LNURL}`);
+  });
+});

--- a/src/__tests__/payment-link-wallets.hook.test.ts
+++ b/src/__tests__/payment-link-wallets.hook.test.ts
@@ -28,8 +28,19 @@ const realUnitWallet = {
   name: 'RealUnit',
   iconUrl: 'https://example.com/realunit.png',
   deepLink: 'realunit-wallet:',
+  hasActionDeepLink: true,
   supportedMethods: ['Ethereum'],
   supportedAssets: [{ name: 'ZCHF', uniqueName: 'Ethereum:ZCHF' }],
+  active: true,
+  recommended: false,
+} as WalletInfo;
+
+const cakeWallet = {
+  id: 42,
+  name: 'Cake Wallet',
+  iconUrl: 'https://example.com/cake.png',
+  deepLink: 'cakewallet:',
+  supportedMethods: ['Bitcoin'],
   active: true,
   recommended: false,
 } as WalletInfo;
@@ -68,5 +79,25 @@ describe('usePaymentLinkWallets', () => {
 
     const deeplink = await result.current.getDeeplinkByWalletId(99);
     expect(deeplink).toBe(`realunit-wallet:lightning:${LNURL}`);
+  });
+
+  it('does not expose hasActionDeepLink for non-Lightning wallets without the backend flag', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [cakeWallet],
+    }) as unknown as typeof fetch;
+
+    const { result } = renderHook(() => usePaymentLinkWallets());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const wallet = result.current.otherWallets.find((w) => w.id === 42);
+    expect(wallet).toBeDefined();
+    expect(wallet?.hasActionDeepLink).toBe(false);
+
+    const deeplink = await result.current.getDeeplinkByWalletId(42);
+    expect(deeplink).toBe('cakewallet:');
   });
 });

--- a/src/hooks/payment-link-wallets.hook.ts
+++ b/src/hooks/payment-link-wallets.hook.ts
@@ -46,7 +46,7 @@ export const usePaymentLinkWallets = (): PaymentLinkWalletsProps => {
   const getDeeplinkByCategory = async (wallet: WalletInfo) => {
     if (!paymentIdentifier) return undefined;
 
-    if (wallet.supportedMethods?.includes(Blockchain.LIGHTNING)) {
+    if (wallet.hasActionDeepLink) {
       const lightning = new URL(paymentIdentifier).searchParams.get('lightning');
       const suffix = 'lightning:';
       const prefix = wallet.deepLink && wallet.deepLink !== suffix ? wallet.deepLink : '';
@@ -57,7 +57,7 @@ export const usePaymentLinkWallets = (): PaymentLinkWalletsProps => {
   };
 
   const hasActionDeepLink = (wallet: WalletInfo): boolean => {
-    return (wallet.supportedMethods?.includes(Blockchain.LIGHTNING) ?? false) || wallet.name === 'RealUnit';
+    return (wallet.supportedMethods?.includes(Blockchain.LIGHTNING) ?? false) || wallet.hasActionDeepLink === true;
   };
 
   const filteredPaymentLinkWallets = useMemo(() => {
@@ -120,11 +120,6 @@ export const usePaymentLinkWallets = (): PaymentLinkWalletsProps => {
         const { uri: kucoinUri } =
           (await fetchCallbackUrlForTransferMethod<{ uri: string }>(C2BPaymentMethod.KUCOINPAY)) ?? {};
         return kucoinUri;
-
-      case 'RealUnit': {
-        const lightning = new URL(paymentIdentifier).searchParams.get('lightning');
-        return `${wallet.deepLink}lightning:${lightning}`;
-      }
 
       default:
         return getDeeplinkByCategory(wallet);

--- a/src/hooks/payment-link-wallets.hook.ts
+++ b/src/hooks/payment-link-wallets.hook.ts
@@ -57,7 +57,7 @@ export const usePaymentLinkWallets = (): PaymentLinkWalletsProps => {
   };
 
   const hasActionDeepLink = (wallet: WalletInfo): boolean => {
-    return wallet.supportedMethods?.includes(Blockchain.LIGHTNING) ?? false;
+    return (wallet.supportedMethods?.includes(Blockchain.LIGHTNING) ?? false) || wallet.name === 'RealUnit';
   };
 
   const filteredPaymentLinkWallets = useMemo(() => {
@@ -120,6 +120,11 @@ export const usePaymentLinkWallets = (): PaymentLinkWalletsProps => {
         const { uri: kucoinUri } =
           (await fetchCallbackUrlForTransferMethod<{ uri: string }>(C2BPaymentMethod.KUCOINPAY)) ?? {};
         return kucoinUri;
+
+      case 'RealUnit': {
+        const lightning = new URL(paymentIdentifier).searchParams.get('lightning');
+        return `${wallet.deepLink}lightning:${lightning}`;
+      }
 
       default:
         return getDeeplinkByCategory(wallet);


### PR DESCRIPTION
RealUnit settles OpenCryptoPay payments on-chain in ZCHF on Ethereum (it consumes the LNURL only as the payment-request identifier), so it is **not** a Lightning wallet. Two changes let a correctly-classified non-Lightning wallet work on `/pl`:

- `getDeeplinkByWalletId`: a RealUnit case that builds the payload-bearing deeplink (`<deepLink>lightning:<LNURL>`) from the backend `deepLink` prefix and the LNURL — the generic path only injects the payload for Lightning wallets.
- `hasActionDeepLink`: treat RealUnit as having an action deeplink so the UI shows "Pay in app" instead of "Open app and scan QR code again".

`Wallet.qualifiesForPayment` already matches a ZCHF/Ethereum wallet (via `supportedAsset.name === 'ZCHF'`); tests added for that plus the deeplink/label behaviour.

Backend companion (the `wallet_app` row): DFXswiss/api#4339.