### PR TITLE
ci: deploy only to Cloudflare Pages

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,10 +10,6 @@ permissions:
 
 env:
   NODE_VERSION: '20.x'
-  AZURE_ACCOUNT_NAME: 'stdfxsrvdev'
-  AZURE_CDN_PROFILE: 'cdnp-dfx-srv-dev'
-  AZURE_CDN_ENDPOINT: 'cdne-dfx-srv-dev'
-  AZURE_RESOURCE_GROUP: 'rg-dfx-srv-dev'
 
 jobs:
   build:
@@ -22,11 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.DEV_CREDENTIALS }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
@@ -69,87 +60,11 @@ jobs:
 
           sed -i "s|main-widget.css|https://dev.app.dfx.swiss/widget/$version.css|g" "./build/widget/$version"
 
-      - name: Deploy to Azure Storage (DEV)
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            # Upload static assets with immutable caching (hashed filenames never change)
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "static/*" \
-              --content-cache-control "public, max-age=31536000, immutable" \
-              --overwrite
-
-            # Upload entry points with no-cache (must revalidate on every request)
-            for file in index.html manifest.json asset-manifest.json robots.txt; do
-              if [ -f "./build/$file" ]; then
-                az storage blob upload \
-                  --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-                  -c '$web' \
-                  -f "./build/$file" \
-                  -n "$file" \
-                  --content-cache-control "no-cache, must-revalidate" \
-                  --overwrite
-              fi
-            done
-
-            # Upload other assets (favicon, logo, wasm)
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "*.ico" \
-              --content-cache-control "public, max-age=86400" \
-              --overwrite
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "*.png" \
-              --content-cache-control "public, max-age=86400" \
-              --overwrite
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "*.wasm" \
-              --content-cache-control "public, max-age=31536000, immutable" \
-              --overwrite
-
-            # Upload widget files
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "widget/*" \
-              --content-cache-control "public, max-age=3600" \
-              --overwrite
-
-      - name: Purge CDN endpoint (DEV)
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az afd endpoint purge \
-              --content-paths "/*" \
-              --profile-name ${{ env.AZURE_CDN_PROFILE }} \
-              --endpoint-name ${{ env.AZURE_CDN_ENDPOINT }} \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --no-wait
-
       - name: Install Wrangler
         run: npm install -g wrangler@4
 
-      # Dual-deploy transition: Azure (above) stays until the DNS cutover to Pages
-      # is verified; a follow-up PR removes the Azure step afterwards.
       - name: Deploy to Cloudflare Pages (DEV)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: wrangler pages deploy build --project-name=dfx-app-dev --branch=develop
-
-      - name: Logout
-        run: |
-          az logout
-        if: always()

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -10,10 +10,6 @@ permissions:
 
 env:
   NODE_VERSION: '20.x'
-  AZURE_ACCOUNT_NAME: 'stdfxsrvprd'
-  AZURE_CDN_PROFILE: 'cdnp-dfx-srv-prd'
-  AZURE_CDN_ENDPOINT: 'cdne-dfx-srv-prd'
-  AZURE_RESOURCE_GROUP: 'rg-dfx-srv-prd'
 
 jobs:
   build:
@@ -22,11 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Login
-        uses: azure/login@v2
-        with:
-          creds: ${{ secrets.PRD_CREDENTIALS }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
@@ -69,87 +60,11 @@ jobs:
 
           sed -i "s|main-widget.css|https://app.dfx.swiss/widget/$version.css|g" "./build/widget/$version"
 
-      - name: Deploy to Azure Storage (PRD)
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            # Upload static assets with immutable caching (hashed filenames never change)
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "static/*" \
-              --content-cache-control "public, max-age=31536000, immutable" \
-              --overwrite
-
-            # Upload entry points with no-cache (must revalidate on every request)
-            for file in index.html manifest.json asset-manifest.json robots.txt; do
-              if [ -f "./build/$file" ]; then
-                az storage blob upload \
-                  --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-                  -c '$web' \
-                  -f "./build/$file" \
-                  -n "$file" \
-                  --content-cache-control "no-cache, must-revalidate" \
-                  --overwrite
-              fi
-            done
-
-            # Upload other assets (favicon, logo, wasm)
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "*.ico" \
-              --content-cache-control "public, max-age=86400" \
-              --overwrite
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "*.png" \
-              --content-cache-control "public, max-age=86400" \
-              --overwrite
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "*.wasm" \
-              --content-cache-control "public, max-age=31536000, immutable" \
-              --overwrite
-
-            # Upload widget files
-            az storage blob upload-batch \
-              --account-name ${{ env.AZURE_ACCOUNT_NAME }} \
-              -d '$web' \
-              -s ./build \
-              --pattern "widget/*" \
-              --content-cache-control "public, max-age=3600" \
-              --overwrite
-
-      - name: Purge CDN endpoint (PRD)
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            az afd endpoint purge \
-              --content-paths "/*" \
-              --profile-name ${{ env.AZURE_CDN_PROFILE }} \
-              --endpoint-name ${{ env.AZURE_CDN_ENDPOINT }} \
-              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
-              --no-wait
-
       - name: Install Wrangler
         run: npm install -g wrangler@4
 
-      # Dual-deploy transition: Azure (above) stays until the DNS cutover to Pages
-      # is verified; a follow-up PR removes the Azure step afterwards.
       - name: Deploy to Cloudflare Pages (PRD)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: wrangler pages deploy build --project-name=dfx-app-prd --branch=main
-
-      - name: Logout
-        run: |
-          az logout
-        if: always()


### PR DESCRIPTION
Both pipelines now go straight from the build to the Cloudflare Pages deploy. The Azure branch — login, storage upload, CDN purge, logout — is removed, together with the `AZURE_*` variables it used.

## Why now

`DEV CI/CD` has been red since this morning, and the failure is not in the build. Linter, tests, `build:dev` and the widget all pass; the job dies one step later:

```
Deploy to Azure Storage (DEV)
ERROR: The request may be blocked by network rules of storage account.
```

The cutover to Pages has happened in the meantime. `dev.app.dfx.swiss` and `app.dfx.swiss` resolve to Cloudflare and answer `200`, and what they serve is byte-identical (same sha256) to `dfx-app-dev.pages.dev` and `dfx-app-prd.pages.dev` — the Pages projects are already the live source. The Front Door profiles that used to sit in front of the storage accounts no longer exist, and the accounts themselves no longer accept public network access. So the upload step cannot succeed again.

## Why it is worse than a red badge

The upload step has no `if:` guard, so its failure skips every step behind it — **including the Cloudflare Pages deploy**. DEV has therefore not received a new build since yesterday afternoon; the last two merges to `develop` are not on DEV. A release to `main` would fail in exactly the same place and skip the PRD Pages deploy the same way.

The comment above the Pages step announced this change: *"Dual-deploy transition: Azure (above) stays until the DNS cutover to Pages is verified; a follow-up PR removes the Azure step afterwards."* This is that follow-up, so the comment goes with it.

## Scope

Only the two workflow files. Everything before the deploy is untouched — same steps, same order, same commands.

Two things are deliberately left alone:

- The Bicep templates under `infrastructure/` still describe the Azure setup. The storage accounts still exist; removing the templates belongs with the resource teardown, not with a pipeline fix.
- `DEV_CREDENTIALS` and `PRD_CREDENTIALS` are unused after this change. Deleting them is a repository-settings action rather than part of this diff.

## Verification

- `dev.yml` and `prd.yml` still parse as YAML, and `actionlint` reports nothing new — the `SC2086` quoting hints it does report sit in `Read version` and `Copy widget`, unchanged in number against the base commit, and this PR touches neither step.
- The diff is deletions only: 170 lines removed, nothing added, in exactly two files.
- No `continue-on-error` and no commented-out remnants; the step is gone rather than muted.
- Proof that the Pages path works in these pipelines: it ran green as the last step of the DEV run on `9988dd7b` yesterday, and PRD deployed the same way on `5064986d`.

The DEV deploy that has been skipped since yesterday runs again on merge.

