### PR TITLE
fix(pages): restore the cache semantics four assets lost

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -24,6 +24,10 @@ module.exports = function override(config, env) {
   ];
   config.output = {
     ...config.output,
+    // Content-hashed WASM belongs under static/, where public/_headers already caches
+    // fingerprinted assets; without this the file lands in the build root, which no rule
+    // covers.
+    webassemblyModuleFilename: 'static/wasm/[hash].module.wasm',
     ...(process.env.REACT_APP_PUBLIC_URL && process.env.CUSTOM_CHUNK_PATH
       ? {
           publicPath: new URL(process.env.CUSTOM_CHUNK_PATH, process.env.REACT_APP_PUBLIC_URL).href,

--- a/public/_headers
+++ b/public/_headers
@@ -22,7 +22,7 @@
 /asset-manifest.json
   Cache-Control: no-cache, must-revalidate
 
-# Crawler directives in robots.txt must take effect on the next request — do not cache.
+# Crawler directives in robots.txt must always revalidate so they take effect on the next request.
 /robots.txt
   Cache-Control: no-cache, must-revalidate
 

--- a/public/_headers
+++ b/public/_headers
@@ -21,3 +21,13 @@
   Cache-Control: no-cache, must-revalidate
 /asset-manifest.json
   Cache-Control: no-cache, must-revalidate
+
+# Crawler directives in robots.txt must take effect on the next request — do not cache.
+/robots.txt
+  Cache-Control: no-cache, must-revalidate
+
+# Non-fingerprinted root assets — a day of cache is enough.
+/favicon.ico
+  Cache-Control: public, max-age=86400
+/logo.png
+  Cache-Control: public, max-age=86400


### PR DESCRIPTION
Follow-up to #1198. That PR removed the Azure deploy branch; this one closes the gaps it made visible.

`public/_headers` opens with a promise:

> Cloudflare Pages edge headers — replicate the cache/CORS semantics the previous CDN served, so the Pages deployment behaves identically.

Four assets break it. Measured against the deployed site rather than assumed:

| Asset | previous CDN | today | after this PR |
|---|---|---|---|
| `/robots.txt` | `no-cache, must-revalidate` | `public, max-age=14400, must-revalidate` | see the correction in the comments — the rule does not take effect |
| `/favicon.ico` | `public, max-age=86400` | `public, max-age=14400, must-revalidate` | `public, max-age=86400` |
| `/logo.png` | `public, max-age=86400` | `public, max-age=14400, must-revalidate` | `public, max-age=86400` |
| the wasm chunk | `public, max-age=31536000, immutable` | `public, max-age=0, must-revalidate` | `public, max-age=31536000, immutable` |
| `/manifest.json` | `no-cache, must-revalidate` | `no-cache, must-revalidate` | unchanged |

The previous values are the ones the removed upload step set: `index.html`, `manifest.json`, `asset-manifest.json` and `robots.txt` shared one `no-cache` loop, `*.ico`/`*.png` were uploaded with a day of cache, and `*.wasm` was uploaded as immutable through a pattern that matched the whole build tree.

## The wasm chunk

This is the one worth reading closely. Before this PR, `config-overrides.js` set `webassemblyModuleFilename` only inside the branch guarded by `CUSTOM_CHUNK_PATH`, and only `scripts/build-widget.sh` sets that variable. The main build therefore fell back to the webpack default and wrote the chunk into the build root: `asset-manifest.json` on the deployed site lists `"module.wasm": "/c2d852c5a3680f3096b5.module.wasm"`, and that URL answers with `cache-control: public, max-age=0, must-revalidate` — roughly 700 KB of hardware-wallet driver revalidating on every use, where the previous CDN served it as immutable.

The filename is content-hashed, so the file belongs where every other fingerprinted asset already lives. This PR sets the default output path to `static/wasm/`, which the existing `/static/*` rule covers, and the widget branch keeps overriding it with `v<version>-chunks/` as before.

Moving the file rather than adding a `/*.module.wasm` rule is a judgement call, not a technical necessity — Cloudflare does support splat patterns of that shape. The reason to prefer the move: the file is fingerprinted, so it belongs in the bucket the existing rule already describes, and one rule keeps covering it instead of a second rule existing for a single asset.

Verified with a real build rather than argued: `npm run build:dev` now emits `build/static/wasm/c2d852c5a3680f3096b5.module.wasm` — same hash as the file live today, so same content in a covered location — and leaves no `.wasm` in the build root. `npm run widget:dev` still emits `widget/v1.0-chunks/<hash>.module.wasm`, which is the path the `Copy widget` step in both pipelines copies from. That `/static/*` matches across path segments is not an assumption either: `/static/js/main.6f300bae.js` answers with `public, max-age=31536000, immutable` on the deployed site.

## The three root files

`robots.txt` matters in practice: a change to crawler directives should take effect on the next request. It now carries its own comment so that reason is visible in the file rather than only in this description.

`favicon.ico` and `logo.png` are restored to the day of cache the previous CDN gave them. Neither is fingerprinted — `public/index.html` references both by plain path — so this is a trade rather than a pure win: a replaced logo can sit in a browser cache for a day instead of four hours. That was the behaviour before the migration and the file claims that value, so it should hold it. If the shorter window is preferred, the right fix is to say so in `_headers` explicitly rather than to leave the entry missing.

## What is deliberately left without a rule

`version.json` is written to `public/version.json` at build time by `scripts/generate-version.js` and is gitignored, so it never shows up in the committed tree — but it reaches the deployed root exactly like the other files in `public/`. It still gets no rule, because it does not need one: Cloudflare's default for it is already `public, max-age=0, must-revalidate`, which is what a version marker wants. With that, every file the deployed root contains is either covered by a rule or correct by default.

`/manifest.json` is the evidence that exact paths take effect at all: it has an exact rule and the deployed site returns exactly that value.

## Scope

`public/_headers` and `config-overrides.js`. Existing rules keep their values and their order; the widget build path is untouched.

## One correction that lives in the history

The first commit's message says the new comment makes visible "the reason it must not be cached". That is imprecise, in the same way the comment itself was: `no-cache, must-revalidate` does not forbid storing the response, it forbids reusing it without a successful revalidation — only `no-store` forbids storing. The second commit corrects the comment in the file and spells out the distinction, but the first commit's own prose cannot be corrected without rewriting a pushed commit, so it is flagged here instead. On a squash merge, the second commit's wording is the accurate one.
