### PR TITLE
fix(pages): make the robots.txt rule actually take effect

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -23,8 +23,9 @@
   Cache-Control: no-cache, must-revalidate
 
 # Crawler directives in robots.txt must always revalidate so they take effect on the next request.
+# Use max-age=0 (not no-cache): this file is edge-cached; bare no-cache is replaced by the zone TTL.
 /robots.txt
-  Cache-Control: no-cache, must-revalidate
+  Cache-Control: public, max-age=0, must-revalidate
 
 # Non-fingerprinted root assets — a day of cache is enough.
 /favicon.ico


### PR DESCRIPTION
Follow-up to #1200. That PR added a rule for `robots.txt`; measuring after the deploy showed the rule does not take effect.

## What the deploy actually returns

Measured against the deployed site with a cache-busting query, so nothing here is a stale edge copy:

| Path | `cf-cache-status` | returned | rule in `_headers` |
|---|---|---|---|
| `/robots.txt` | `MISS` | `max-age=14400, must-revalidate` | `no-cache, must-revalidate` — **not applied** |
| `/favicon.ico` | `MISS` | `public, max-age=86400` | applied |
| `/logo.png` | `MISS` | `public, max-age=86400` | applied |
| `/manifest.json` | `DYNAMIC` | `no-cache, must-revalidate` | applied |
| `/index.html` | `DYNAMIC` | `no-cache, must-revalidate` | applied |

The deciding factor is whether the edge caches the response:

- Responses it does not cache (`DYNAMIC`) pass their header through unchanged. That is why `no-cache` works for `index.html` and `manifest.json` — and why it looked like a proven pattern when #1200 reused it.
- For cached responses, an explicit `max-age` is respected: `favicon.ico` and `logo.png` return exactly the `86400` that #1200 set for them. A bare `no-cache` carries no number, and the zone's browser cache TTL of four hours is filled in instead.

`14400` is that zone setting, configured outside this repository.

## The change

`public, max-age=0, must-revalidate` expresses the same intent as `no-cache` — revalidate before reuse — but with a value the edge passes on rather than one it substitutes. The comment above the rule now records why this entry is written differently from the entry points a few lines above, so the next reader does not "fix" it back.

Nothing else changes: `/`, `/index.html`, `/manifest.json` and `/asset-manifest.json` keep `no-cache, must-revalidate`, where it demonstrably works.

## Why this is worth a follow-up rather than leaving as is

The practical effect is small — crawler directives would be up to four hours stale instead of revalidated. The reason to fix it is the other one: a rule that reads as applied but is not is exactly the failure mode #1200 argued against when it moved the wasm file instead of guessing at a pattern. Leaving it would put that trap back into the file.

Verification after merge is a single request against the deployed site; the value should read `public, max-age=0, must-revalidate`. If it still reads `max-age=14400`, then the zone overrides this case too, and the honest place for that fact is a comment in this file rather than a rule that pretends otherwise.
