### PR TITLE
docs(pages): record which cache rules the edge overrides

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,16 @@
 # Cloudflare Pages edge headers — replicate the cache/CORS semantics the previous
 # CDN served, so the Pages deployment behaves identically.
 #
+# Note: for cached responses the CDN edge raises any max-age below four hours to four
+# hours; higher values stay as written. Uncached responses pass through unchanged, and
+# whether a given file is cached shows in the cf-cache-status response header.
+#
+# In this file, /widget/* (one hour) and /robots.txt ask for less than four hours and
+# are therefore the rules this affects: /robots.txt carries a no-cache rule below, yet
+# reaches the client as max-age=14400. Check it with a cache-busting request:
+#   curl -sI "https://app.dfx.swiss/robots.txt?cb=1"
+# Changing that is a CDN configuration matter; it cannot be fixed in this file.
+#
 # Fingerprinted build assets (content-hashed filenames) never change -> cache hard.
 /static/*
   Cache-Control: public, max-age=31536000, immutable

--- a/public/_headers
+++ b/public/_headers
@@ -9,6 +9,11 @@
 # are therefore the rules this affects: /robots.txt carries a no-cache rule below, yet
 # reaches the client as max-age=14400. Check it with a cache-busting request:
 #   curl -sI "https://app.dfx.swiss/robots.txt?cb=1"
+# The /widget/* rule shows this even more clearly, since two files under it land
+# differently: /widget/v1.0.css is cached at the edge and reaches the client as
+# max-age=14400, while /widget/v1.0 is not cached (cf-cache-status: DYNAMIC) and
+# reaches the client as max-age=3600, exactly as written below — same rule, two
+# outcomes, depending only on whether that particular response gets cached.
 # Changing that is a CDN configuration matter; it cannot be fixed in this file.
 #
 # Fingerprinted build assets (content-hashed filenames) never change -> cache hard.


### PR DESCRIPTION
Follow-up to #1200, and the replacement for #1202, which was closed because its premise turned out to be wrong.

## What is actually happening

Two rules in `public/_headers` do not reach the client as written. Measured against the deployed site with a cache-busting query, so none of this is a stale edge copy:

| Path | `cf-cache-status` | rule in `_headers` | actually served |
|---|---|---|---|
| `/widget/v1.0.css` | `MISS` | `public, max-age=3600` | `public, max-age=14400` |
| `/robots.txt` | `MISS` | `no-cache, must-revalidate` | `max-age=14400, must-revalidate` |
| `/favicon.ico`, `/logo.png` | `MISS` | `public, max-age=86400` | as written |
| `/static/js/<hash>.js` | `MISS` | `max-age=31536000, immutable` | as written |
| `/manifest.json`, `/index.html` | `DYNAMIC` | `no-cache, must-revalidate` | as written |
| `/widget/v1.0` | `DYNAMIC` | `public, max-age=3600` | as written |

The rule is not "explicit numbers get through and `no-cache` does not". It is: **for responses the edge caches, any `max-age` below four hours is raised to four hours.** Values above it are untouched, and uncached responses pass through regardless. Cloudflare documents exactly this behaviour for the browser cache TTL setting — it overrides the origin header when the origin value is lower, and the default is four hours.

The two rows that show it are `/widget/v1.0.css` against `/widget/v1.0`: same rule, same asset family, different outcome purely because one is cached and the other is not.

## Why this is a comment and not a fix

#1202 proposed writing `public, max-age=0, must-revalidate` for `robots.txt`, on the theory that an explicit number would be passed through. That theory came from `favicon.ico` and `logo.png`, whose `86400` does get through — but `86400` is *above* four hours. `0` is below it and would be raised to `14400` just as `no-cache` is. The change would have looked applied while doing nothing, which is the failure this file should not contain. It was closed unmerged.

The four hours come from CDN configuration, outside this repository. Nothing written in `public/_headers` can lower it. What this file can do is say so, and say how to check — so the next person reading the `/widget/*` rule knows that the hour it asks for is not the hour clients get, and does not spend an afternoon rediscovering it.

## Scope

Comment lines only. No rule, path or header value is touched — every added line starts with `#`, and nothing is removed.
