### PR TITLE
fix(buy): stop the completion mail step from silently swallowing its result

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/react": "^1.7.0-beta.0",
+        "@dfx.swiss/react": "^1.7.0",
         "@dfx.swiss/react-components": "^1.3.2",
         "@ledgerhq/hw-app-btc": "^6.24.1",
         "@ledgerhq/hw-app-eth": "^6.33.7",
@@ -2634,20 +2634,22 @@
       }
     },
     "node_modules/@dfx.swiss/core": {
-      "version": "0.6.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.6.0-beta.0.tgz",
-      "integrity": "sha512-H413v7NcdYyYke5sA2IVK5fi4Q80BHj3N2/KqR+7pnHTWYPn/59egwT79RXrY+PZvw++WtbpN4rpyj3Ad5Uxrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-gy/jpa8IEwRDCw8ZI+Fp4R3MqVtzqpUPHZQ7dkcG9Nn9VEATAqalvW4hA+SQOANuBREToGvWBoHOIfT5ofUXUQ==",
+      "license": "MIT",
       "dependencies": {
         "ibantools": "^4.2.1",
         "libphonenumber-js": "^1.10.39"
       }
     },
     "node_modules/@dfx.swiss/react": {
-      "version": "1.7.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.7.0-beta.0.tgz",
-      "integrity": "sha512-Ai31Ev+Qp240KxyxfrGccI6athHxMnuE8h+qHwHCTsZ5SlYhPDDefnrJTR3ZNAm7wFB6A6iRjLlVUvsSqpwSzA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@dfx.swiss/react/-/react-1.7.0.tgz",
+      "integrity": "sha512-X15Az10a3TJhIsmH6VIaFIDmrBKlFLgr1vo/6rVOoO35E/vPvSR2l8RywD4gUJYEUEGV6mAIX1UR7MjjPj3jgg==",
+      "license": "MIT",
       "dependencies": {
-        "@dfx.swiss/core": "^0.6.0-beta.0",
+        "@dfx.swiss/core": "^0.6.0",
         "jwt-decode": "^3.1.2",
         "react": "^18.2.0",
         "typescript": "^4.9.3"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dfx.swiss/react": "^1.7.0-beta.0",
+    "@dfx.swiss/react": "^1.7.0",
     "@dfx.swiss/react-components": "^1.3.2",
     "@ledgerhq/hw-app-btc": "^6.24.1",
     "@ledgerhq/hw-app-eth": "^6.33.7",

--- a/src/__tests__/buy-completion-close.test.tsx
+++ b/src/__tests__/buy-completion-close.test.tsx
@@ -1,0 +1,90 @@
+const mockCloseServices = jest.fn();
+const mockNavigate = jest.fn();
+const mockUseAppHandlingContext = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  DfxIcon: () => <div data-testid="completion-icon" />,
+  IconColor: { BLUE: 'blue' },
+  IconSize: { XXL: 'xxl' },
+  IconVariant: { PROCESS_DONE: 'process-done' },
+  SpinnerSize: { LG: 'lg' },
+  StyledButton: ({ label, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {label}
+    </button>
+  ),
+  StyledButtonColor: { STURDY_WHITE: 'sturdy-white' },
+  StyledButtonWidth: { FULL: 'full' },
+  StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
+  StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('../contexts/app-handling.context', () => ({
+  CloseType: { BUY: 'buy' },
+  useAppHandlingContext: () => mockUseAppHandlingContext(),
+}));
+
+jest.mock('../contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_namespace: string, text: string) => text,
+  }),
+}));
+
+jest.mock('../hooks/navigation.hook', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('../components/edit/mail.edit', () => ({ MailEdit: () => null }));
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BuyCompletion } from '../components/payment/buy-completion';
+
+describe('BuyCompletion close handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function renderCompletion() {
+    return render(
+      <BuyCompletion
+        user={{ mail: 'user@example.com' } as any}
+        paymentInfo={{ id: 1 } as any}
+        navigateOnClose={false}
+      />,
+    );
+  }
+
+  it('falls back to the account without blanking the completion when no close channel fired', () => {
+    mockCloseServices.mockReturnValue(false);
+    // These legacy flags claim a close path exists; only the closeServices result is authoritative.
+    mockUseAppHandlingContext.mockReturnValue({
+      closeServices: mockCloseServices,
+      isEmbedded: true,
+      canClose: true,
+    });
+    renderCompletion();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/account');
+    expect(screen.getByTestId('completion-icon')).toBeInTheDocument();
+  });
+
+  it('does not navigate to the account when a close channel fired', () => {
+    mockCloseServices.mockReturnValue(true);
+    // The legacy flags deny a close path, so the old flag-based implementation would navigate.
+    mockUseAppHandlingContext.mockReturnValue({
+      closeServices: mockCloseServices,
+      isEmbedded: false,
+      canClose: false,
+    });
+    renderCompletion();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('completion-icon')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/mail-parameter-retry.test.tsx
+++ b/src/__tests__/mail-parameter-retry.test.tsx
@@ -1,0 +1,127 @@
+const mockUpdateUserMail = jest.fn();
+const mockUseUserContext = jest.fn();
+
+const mockLanguage = { id: 1, symbol: 'EN' };
+
+jest.mock('@dfx.swiss/react', () => ({
+  useCountry: () => ({ getCountries: () => Promise.resolve([]) }),
+  useFiatContext: () => ({ currencies: [] }),
+  useKyc: () => ({ setData: jest.fn() }),
+  useLanguage: () => ({ getDefaultLanguage: (languages: any[]) => languages[0] }),
+  useLanguageContext: () => ({ languages: [mockLanguage] }),
+  useSettings: () => ({ getInfoBanner: () => Promise.resolve(undefined) }),
+  useUserContext: () => mockUseUserContext(),
+}));
+
+jest.mock('browser-lang', () => () => 'en');
+jest.mock('i18next', () => ({ changeLanguage: jest.fn() }));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, defaultValue: string) => defaultValue }),
+}));
+
+jest.mock('../hooks/app-params.hook', () => ({
+  useAppParams: () => ({
+    mail: '  User@Example.COM ',
+    setParams: jest.fn(),
+  }),
+}));
+
+jest.mock('../hooks/store.hook', () => ({
+  useStore: () => ({
+    language: { get: jest.fn(), set: jest.fn() },
+    infoBanner: { get: jest.fn(), set: jest.fn(), remove: jest.fn() },
+  }),
+}));
+
+jest.mock('../contexts/app-handling.context', () => ({
+  useAppHandlingContext: () => ({ isInitialized: false }),
+}));
+
+import { act, render, waitFor } from '@testing-library/react';
+import { SettingsContextProvider } from '../contexts/settings.context';
+
+function user(id: number) {
+  return { id, mail: undefined, language: mockLanguage, currency: undefined, kyc: {} };
+}
+
+function userContext(currentUser: ReturnType<typeof user>) {
+  return {
+    user: currentUser,
+    updateLanguage: jest.fn(),
+    updateMail: mockUpdateUserMail,
+    updatePhone: jest.fn(),
+    updateCurrency: jest.fn(),
+  };
+}
+
+describe('SettingsContextProvider mail parameter retry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockUseUserContext.mockReturnValue(userContext(user(1)));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  async function renderAndRerenderWithNewUser() {
+    const view = render(
+      <SettingsContextProvider>
+        <div>settings</div>
+      </SettingsContextProvider>,
+    );
+
+    await waitFor(() => expect(mockUpdateUserMail).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    mockUseUserContext.mockReturnValue(userContext(user(2)));
+    view.rerender(
+      <SettingsContextProvider>
+        <div>settings</div>
+      </SettingsContextProvider>,
+    );
+
+    return view;
+  }
+
+  it('retries the normalized parameter after a transient rate-limit error', async () => {
+    mockUpdateUserMail.mockRejectedValueOnce({ statusCode: 429 }).mockResolvedValue(undefined);
+
+    await renderAndRerenderWithNewUser();
+
+    await waitFor(() => expect(mockUpdateUserMail).toHaveBeenCalledTimes(2));
+    expect(mockUpdateUserMail).toHaveBeenNthCalledWith(1, 'user@example.com');
+    expect(mockUpdateUserMail).toHaveBeenNthCalledWith(2, 'user@example.com');
+    expect(console.error).toHaveBeenCalledWith('Failed to apply the mail parameter:', { statusCode: 429 });
+  });
+
+  it('keeps a permanently rejected parameter guarded', async () => {
+    mockUpdateUserMail.mockRejectedValueOnce({ statusCode: 400 });
+
+    await renderAndRerenderWithNewUser();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockUpdateUserMail).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('Failed to apply the mail parameter:', { statusCode: 400 });
+  });
+
+  it('keeps a successful parameter guarded', async () => {
+    const successfulSubmit = Promise.resolve();
+    const catchSpy = jest.spyOn(successfulSubmit, 'catch');
+    mockUpdateUserMail.mockReturnValue(successfulSubmit);
+
+    await renderAndRerenderWithNewUser();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockUpdateUserMail).toHaveBeenCalledTimes(1);
+    // The previous implementation ignored the returned promise entirely.
+    expect(catchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/edit/mail.edit.tsx
+++ b/src/components/edit/mail.edit.tsx
@@ -1,4 +1,4 @@
-import { ApiError, TfaLevel, Utils, Validations, useUserContext } from '@dfx.swiss/react';
+import { ApiError, Utils, Validations, useUserContext } from '@dfx.swiss/react';
 import {
   Form,
   IconColor,
@@ -14,7 +14,6 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSettingsContext } from '../../contexts/settings.context';
 import { useMergedAccount } from '../../hooks/merged-account.hook';
-import { useNavigation } from '../../hooks/navigation.hook';
 import { ErrorHint } from '../error-hint';
 
 interface MailEditProps {
@@ -55,14 +54,15 @@ export function MailEdit({
   const { updateMail, isUserUpdating } = useUserContext();
   const { translate, translateError } = useSettingsContext();
   const { handleMergedError } = useMergedAccount();
-  const { navigate } = useNavigation();
 
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [pendingEmail, setPendingEmail] = useState<string>();
   const [isSaving, setIsSaving] = useState(false);
+  const [showLinkHint, setShowLinkHint] = useState(false);
   const [error, setError] = useState<string>();
 
   function showMailConfirmation({ email }: FormData): void {
+    setError(undefined);
     if (!email || email.length === 0) return onSubmit(email);
     setPendingEmail(email);
     setShowConfirmation(true);
@@ -70,6 +70,7 @@ export function MailEdit({
 
   async function saveUser(email: string): Promise<void> {
     setError(undefined);
+    setShowLinkHint(false);
     setIsSaving(true);
 
     return updateMail(email)
@@ -77,9 +78,21 @@ export function MailEdit({
       .catch((e: ApiError) => {
         if (handleMergedError(e)) return;
 
-        // an account that already carries a mail has to pass 2FA before it can change it
+        // the address belongs to an existing account: the merge mail is already out, so retrying
+        // only sends another one — the user has to follow the link instead
+        if (e.statusCode === 409 && e.message?.includes('exists') && e.message.includes('merge'))
+          return setShowLinkHint(true);
+
+        // This step can only set a first address. Changing an existing one needs 2FA plus a code
+        // sent to the new address, and this component has no field to enter that code — so say so
+        // instead of sending the user through a 2FA redirect that cannot restore this screen.
         if (e.code === 'TFA_REQUIRED')
-          return navigate('/2fa', { state: { level: TfaLevel.BASIC }, setRedirect: true });
+          return setError(
+            translate(
+              'screens/kyc',
+              'This account already has an email address. You can change it in your account settings.',
+            ),
+          );
 
         setError(e.message);
       })
@@ -89,6 +102,25 @@ export function MailEdit({
   const rules = Utils.createRules({
     email: [!isOptional && Validations.Required, Validations.Mail],
   });
+
+  if (showLinkHint) {
+    return (
+      <StyledVerticalStack gap={6} full>
+        <p className="text-dfxGray-700">
+          {translate('screens/kyc', 'It looks like you already have an account with DFX.')}{' '}
+          {translate(
+            'screens/kyc',
+            'We have just sent you an email. To continue with your existing account, please confirm your email address by clicking on the link sent.',
+          )}
+        </p>
+        <StyledButton
+          width={StyledButtonWidth.MIN}
+          label={translate('general/actions', 'OK')}
+          onClick={() => onSubmit()}
+        />
+      </StyledVerticalStack>
+    );
+  }
 
   if (showConfirmation && pendingEmail) {
     return (
@@ -105,7 +137,10 @@ export function MailEdit({
         <StyledHorizontalStack gap={4}>
           <StyledButton
             label={translate('general/actions', 'Change')}
-            onClick={() => setShowConfirmation(false)}
+            onClick={() => {
+              setError(undefined);
+              setShowConfirmation(false);
+            }}
             color={StyledButtonColor.STURDY_WHITE}
             width={StyledButtonWidth.FULL}
             caps

--- a/src/components/edit/mail.edit.tsx
+++ b/src/components/edit/mail.edit.tsx
@@ -80,14 +80,12 @@ export function MailEdit({
       .catch((e: ApiError) => {
         if (handleMergedError(e)) return;
 
-        // the address belongs to an existing account: the merge mail is already out, so retrying
-        // only sends another one — the user has to follow the link instead
+        // the merge mail is already out; retrying only sends another one
         if (e.statusCode === 409 && e.message?.includes('exists') && e.message.includes('merge'))
           return setShowLinkHint(true);
 
-        // This step can only set a first address. Changing an existing one needs 2FA plus a code
-        // sent to the new address, and this component has no field to enter that code. Its own
-        // screen, not ErrorHint, because retrying here can never succeed.
+        // This step can only set a FIRST address: changing one needs 2FA plus a code this component
+        // cannot collect. Its own screen, not ErrorHint, because retrying can never succeed.
         if (e.code === 'TFA_REQUIRED') return setShowAccountHint(true);
 
         setError(e.message);

--- a/src/components/edit/mail.edit.tsx
+++ b/src/components/edit/mail.edit.tsx
@@ -59,6 +59,7 @@ export function MailEdit({
   const [pendingEmail, setPendingEmail] = useState<string>();
   const [isSaving, setIsSaving] = useState(false);
   const [showLinkHint, setShowLinkHint] = useState(false);
+  const [showAccountHint, setShowAccountHint] = useState(false);
   const [error, setError] = useState<string>();
 
   function showMailConfirmation({ email }: FormData): void {
@@ -71,6 +72,7 @@ export function MailEdit({
   async function saveUser(email: string): Promise<void> {
     setError(undefined);
     setShowLinkHint(false);
+    setShowAccountHint(false);
     setIsSaving(true);
 
     return updateMail(email)
@@ -84,15 +86,9 @@ export function MailEdit({
           return setShowLinkHint(true);
 
         // This step can only set a first address. Changing an existing one needs 2FA plus a code
-        // sent to the new address, and this component has no field to enter that code — so say so
-        // instead of sending the user through a 2FA redirect that cannot restore this screen.
-        if (e.code === 'TFA_REQUIRED')
-          return setError(
-            translate(
-              'screens/kyc',
-              'This account already has an email address. You can change it in your account settings.',
-            ),
-          );
+        // sent to the new address, and this component has no field to enter that code. Its own
+        // screen, not ErrorHint, because retrying here can never succeed.
+        if (e.code === 'TFA_REQUIRED') return setShowAccountHint(true);
 
         setError(e.message);
       })
@@ -102,6 +98,24 @@ export function MailEdit({
   const rules = Utils.createRules({
     email: [!isOptional && Validations.Required, Validations.Mail],
   });
+
+  if (showAccountHint) {
+    return (
+      <StyledVerticalStack gap={6} full>
+        <p className="text-dfxGray-700">
+          {translate(
+            'screens/kyc',
+            'This account already has an email address. You can change it in your account settings.',
+          )}
+        </p>
+        <StyledButton
+          width={StyledButtonWidth.MIN}
+          label={translate('general/actions', 'OK')}
+          onClick={() => onSubmit()}
+        />
+      </StyledVerticalStack>
+    );
+  }
 
   if (showLinkHint) {
     return (

--- a/src/components/edit/mail.edit.tsx
+++ b/src/components/edit/mail.edit.tsx
@@ -1,4 +1,4 @@
-import { ApiError, Utils, Validations, useUserContext } from '@dfx.swiss/react';
+import { ApiError, TfaLevel, Utils, Validations, useUserContext } from '@dfx.swiss/react';
 import {
   Form,
   IconColor,
@@ -14,6 +14,8 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useSettingsContext } from '../../contexts/settings.context';
 import { useMergedAccount } from '../../hooks/merged-account.hook';
+import { useNavigation } from '../../hooks/navigation.hook';
+import { ErrorHint } from '../error-hint';
 
 interface MailEditProps {
   infoText?: string;
@@ -53,9 +55,12 @@ export function MailEdit({
   const { updateMail, isUserUpdating } = useUserContext();
   const { translate, translateError } = useSettingsContext();
   const { handleMergedError } = useMergedAccount();
+  const { navigate } = useNavigation();
 
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [pendingEmail, setPendingEmail] = useState<string>();
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string>();
 
   function showMailConfirmation({ email }: FormData): void {
     if (!email || email.length === 0) return onSubmit(email);
@@ -64,12 +69,21 @@ export function MailEdit({
   }
 
   async function saveUser(email: string): Promise<void> {
+    setError(undefined);
+    setIsSaving(true);
+
     return updateMail(email)
       .then(() => onSubmit(email))
       .catch((e: ApiError) => {
         if (handleMergedError(e)) return;
-        throw e;
-      });
+
+        // an account that already carries a mail has to pass 2FA before it can change it
+        if (e.code === 'TFA_REQUIRED')
+          return navigate('/2fa', { state: { level: TfaLevel.BASIC }, setRedirect: true });
+
+        setError(e.message);
+      })
+      .finally(() => setIsSaving(false));
   }
 
   const rules = Utils.createRules({
@@ -82,6 +96,12 @@ export function MailEdit({
         <p className="text-dfxGray-700 text-center">{translate('screens/kyc', 'Is this email address correct?')}</p>
         <p className="text-lg font-bold text-dfxBlue-800 break-all text-center">{pendingEmail}</p>
 
+        {error && (
+          <StyledVerticalStack full center>
+            <ErrorHint message={error} />
+          </StyledVerticalStack>
+        )}
+
         <StyledHorizontalStack gap={4}>
           <StyledButton
             label={translate('general/actions', 'Change')}
@@ -93,7 +113,7 @@ export function MailEdit({
           <StyledButton
             label={translate('general/actions', 'Confirm')}
             onClick={() => saveUser(pendingEmail)}
-            isLoading={isUserUpdating}
+            isLoading={isSaving || isUserUpdating}
             width={StyledButtonWidth.FULL}
             caps
           />

--- a/src/components/order/payment-info.tsx
+++ b/src/components/order/payment-info.tsx
@@ -110,9 +110,12 @@ export const PaymentInfo = React.memo(function PaymentInfoComponent({
 
     if (canSendTransaction() && !activeWallet) {
       // TODO (later): Refactor CloseServicesParams
-      return orderType === OrderType.SELL
-        ? closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo as Sell }, false)
-        : closeServices({ type: CloseType.SWAP, isComplete: false, swap: paymentInfo as Swap }, false);
+      if (orderType === OrderType.SELL) {
+        closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo as Sell }, false);
+      } else {
+        closeServices({ type: CloseType.SWAP, isComplete: false, swap: paymentInfo as Swap }, false);
+      }
+      return;
     }
 
     try {

--- a/src/components/payment/buy-completion.tsx
+++ b/src/components/payment/buy-completion.tsx
@@ -45,7 +45,7 @@ export function BuyCompletion({ user, paymentInfo, navigateOnClose }: BuyComplet
   function close() {
     closeServices({ type: CloseType.BUY, isComplete: true, buy: paymentInfo }, navigateOnClose);
 
-    // On a host that neither navigates nor has anywhere to hand off to, closeServices does nothing,
+    // closeServices does nothing on a host that neither navigates nor has anywhere to hand off to,
     // and blanking the screen would strand the user: the completion suppresses the back button.
     if (!navigateOnClose && !isEmbedded && !canClose) return navigate('/account');
 

--- a/src/components/payment/buy-completion.tsx
+++ b/src/components/payment/buy-completion.tsx
@@ -25,7 +25,7 @@ interface BuyCompletionProps {
 
 export function BuyCompletion({ user, paymentInfo, navigateOnClose }: BuyCompletionProps): JSX.Element {
   const { translate } = useSettingsContext();
-  const { closeServices, isEmbedded, canClose } = useAppHandlingContext();
+  const { closeServices } = useAppHandlingContext();
   const { navigate } = useNavigation();
 
   const [isClosed, setIsClosed] = useState(false);
@@ -43,11 +43,11 @@ export function BuyCompletion({ user, paymentInfo, navigateOnClose }: BuyComplet
   }
 
   function close() {
-    closeServices({ type: CloseType.BUY, isComplete: true, buy: paymentInfo }, navigateOnClose);
+    const closed = closeServices({ type: CloseType.BUY, isComplete: true, buy: paymentInfo }, navigateOnClose);
 
-    // closeServices does nothing on a host that neither navigates nor has anywhere to hand off to,
-    // and blanking the screen would strand the user: the completion suppresses the back button.
-    if (!navigateOnClose && !isEmbedded && !canClose) return navigate('/account');
+    // Blanking the screen would strand the user — the completion suppresses the back button — so fall
+    // back to the account screen whenever no close channel actually fired.
+    if (!closed) return navigate('/account');
 
     setIsClosed(true);
   }

--- a/src/components/payment/buy-completion.tsx
+++ b/src/components/payment/buy-completion.tsx
@@ -14,6 +14,7 @@ import {
 import { useState } from 'react';
 import { CloseType, useAppHandlingContext } from '../../contexts/app-handling.context';
 import { useSettingsContext } from '../../contexts/settings.context';
+import { useNavigation } from '../../hooks/navigation.hook';
 import { MailEdit } from '../edit/mail.edit';
 
 interface BuyCompletionProps {
@@ -24,7 +25,8 @@ interface BuyCompletionProps {
 
 export function BuyCompletion({ user, paymentInfo, navigateOnClose }: BuyCompletionProps): JSX.Element {
   const { translate } = useSettingsContext();
-  const { closeServices } = useAppHandlingContext();
+  const { closeServices, isEmbedded, canClose } = useAppHandlingContext();
+  const { navigate } = useNavigation();
 
   const [isClosed, setIsClosed] = useState(false);
 
@@ -42,6 +44,11 @@ export function BuyCompletion({ user, paymentInfo, navigateOnClose }: BuyComplet
 
   function close() {
     closeServices({ type: CloseType.BUY, isComplete: true, buy: paymentInfo }, navigateOnClose);
+
+    // On a host that neither navigates nor has anywhere to hand off to, closeServices does nothing,
+    // and blanking the screen would strand the user: the completion suppresses the back button.
+    if (!navigateOnClose && !isEmbedded && !canClose) return navigate('/account');
+
     setIsClosed(true);
   }
 

--- a/src/components/payment/buy-completion.tsx
+++ b/src/components/payment/buy-completion.tsx
@@ -76,7 +76,7 @@ export function BuyCompletion({ user, paymentInfo, navigateOnClose }: BuyComplet
         </>
       ) : (
         <MailEdit
-          onSubmit={(email) => (!email || email.length === 0) && close()}
+          onSubmit={() => close()}
           infoText={translate(
             'screens/payment',
             'Enter your email address if you want to be informed about the progress of any purchase or sale',

--- a/src/contexts/app-handling.context.tsx
+++ b/src/contexts/app-handling.context.tsx
@@ -189,7 +189,7 @@ interface AppHandlingContextInterface {
   availableBlockchains?: Blockchain[];
   params: AppParams;
   setParams: (params: Partial<AppParams>) => void;
-  closeServices: (params: CloseServicesParams, navigate: boolean) => void;
+  closeServices: (params: CloseServicesParams, navigate: boolean) => boolean;
   redirectPath?: string;
   setRedirectPath: (path?: string) => void;
   canClose: boolean;
@@ -397,12 +397,18 @@ export function AppHandlingContextProvider(props: AppHandlingContextProps): JSX.
   }
 
   // closing
-  function closeServices(params: CloseServicesParams, navigate: boolean) {
+  function closeServices(params: CloseServicesParams, navigate: boolean): boolean {
+    let closed = false;
+
     if (props.isWidget) {
-      props.closeCallback?.(createCloseMessageData(params));
+      if (props.closeCallback) {
+        props.closeCallback(createCloseMessageData(params));
+        closed = true;
+      }
     } else {
       if (isUsedByIframe) {
         sendMessage(createCloseMessageData(params));
+        closed = true;
       }
 
       if (redirectUri) {
@@ -413,11 +419,17 @@ export function AppHandlingContextProvider(props: AppHandlingContextProps): JSX.
         if (isSafeRedirectUri(redirectUri)) {
           const uri = getRedirectUri(redirectUri, params);
           setTimeout(() => ((window as Window).location = uri), 2000);
+          closed = true;
         }
       }
     }
 
-    if (navigate) props.router.navigate('/account');
+    if (navigate) {
+      props.router.navigate('/account');
+      closed = true;
+    }
+
+    return closed;
   }
 
   function getRedirectUri(baseUri: string, params: CloseServicesParams): string {

--- a/src/contexts/settings.context.tsx
+++ b/src/contexts/settings.context.tsx
@@ -1,4 +1,5 @@
 import {
+  ApiError,
   Country,
   Fiat,
   InfoBanner,
@@ -154,14 +155,20 @@ export function SettingsContextProvider(props: PropsWithChildren): JSX.Element {
 
   useEffect(() => {
     // Normalised like the API (trim + lowercase), or a padded/mixed-case parameter would never close
-    // this guard and would re-submit on every change of the user object. The ref additionally bounds
-    // the cases normalising cannot close: a rejected value, and a change still pending verification.
+    // this guard and would re-submit on every change of the user object. The ref bounds pending,
+    // successful, and permanently rejected submissions while transient failures clear it for retry.
     const paramMail = mail?.trim().toLowerCase();
     if (!user || !paramMail) return;
     if (user.mail?.trim().toLowerCase() === paramMail || submittedMail.current === paramMail) return;
 
     submittedMail.current = paramMail;
-    updateUserMail(paramMail);
+    updateUserMail(paramMail).catch((e: ApiError) => {
+      // A rejected address stays rejected — keep the guard. Anything transient (offline, rate limit,
+      // server error) has to stay retryable, or one blip loses the parameter for the whole session.
+      const isRetryable = !e?.statusCode || e.statusCode === 429 || e.statusCode >= 500;
+      if (isRetryable) submittedMail.current = undefined;
+      console.error('Failed to apply the mail parameter:', e);
+    });
   }, [user, mail]);
 
   useEffect(() => {

--- a/src/contexts/settings.context.tsx
+++ b/src/contexts/settings.context.tsx
@@ -14,7 +14,7 @@ import {
 } from '@dfx.swiss/react';
 import browserLang from 'browser-lang';
 import i18n from 'i18next';
-import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppParams } from '../hooks/app-params.hook';
 import { useStore } from '../hooks/store.hook';
@@ -117,6 +117,7 @@ export function SettingsContextProvider(props: PropsWithChildren): JSX.Element {
   const [store, setStore] = useState<Record<string, any>>({});
   const [processingKycData, setProcessingKycData] = useState(true);
   const [infoBanner, setInfoBanner] = useState<InfoBanner>();
+  const submittedMail = useRef<string>();
 
   const availableLanguages = useMemo(
     () => languages?.filter((l) => appLanguages.includes(l.symbol)) ?? [],
@@ -152,9 +153,17 @@ export function SettingsContextProvider(props: PropsWithChildren): JSX.Element {
   }, [user, lang, language, currencies, availableLanguages]);
 
   useEffect(() => {
-    // compared case-insensitively because the API lowercases the stored address: a mixed-case mail
-    // parameter would otherwise never satisfy this guard and re-submit on every user refresh
-    if (user && mail && user.mail?.toLowerCase() !== mail.toLowerCase()) updateUserMail(mail);
+    // The stored address is normalised by the API (trimmed and lowercased) and a change may stay
+    // pending mail verification, so comparing the raw parameter against it can never close for a
+    // padded or mixed-case value — the effect would then re-submit on every change of the user
+    // object, and each of those is a 403 once the account carries an address. Normalising the same
+    // way and remembering what was already sent bounds this to one attempt per target address.
+    const paramMail = mail?.trim().toLowerCase();
+    if (!user || !paramMail) return;
+    if (user.mail?.trim().toLowerCase() === paramMail || submittedMail.current === paramMail) return;
+
+    submittedMail.current = paramMail;
+    updateUserMail(paramMail);
   }, [user, mail]);
 
   useEffect(() => {

--- a/src/contexts/settings.context.tsx
+++ b/src/contexts/settings.context.tsx
@@ -152,7 +152,9 @@ export function SettingsContextProvider(props: PropsWithChildren): JSX.Element {
   }, [user, lang, language, currencies, availableLanguages]);
 
   useEffect(() => {
-    if (user && mail && user.mail !== mail) updateUserMail(mail);
+    // compared case-insensitively because the API lowercases the stored address: a mixed-case mail
+    // parameter would otherwise never satisfy this guard and re-submit on every user refresh
+    if (user && mail && user.mail?.toLowerCase() !== mail.toLowerCase()) updateUserMail(mail);
   }, [user, mail]);
 
   useEffect(() => {

--- a/src/contexts/settings.context.tsx
+++ b/src/contexts/settings.context.tsx
@@ -153,11 +153,9 @@ export function SettingsContextProvider(props: PropsWithChildren): JSX.Element {
   }, [user, lang, language, currencies, availableLanguages]);
 
   useEffect(() => {
-    // The stored address is normalised by the API (trimmed and lowercased) and a change may stay
-    // pending mail verification, so comparing the raw parameter against it can never close for a
-    // padded or mixed-case value — the effect would then re-submit on every change of the user
-    // object, and each of those is a 403 once the account carries an address. Normalising the same
-    // way and remembering what was already sent bounds this to one attempt per target address.
+    // Normalised like the API (trim + lowercase), or a padded/mixed-case parameter would never close
+    // this guard and would re-submit on every change of the user object. The ref additionally bounds
+    // the cases normalising cannot close: a rejected value, and a change still pending verification.
     const paramMail = mail?.trim().toLowerCase();
     if (!user || !paramMail) return;
     if (user.mail?.trim().toLowerCase() === paramMail || submittedMail.current === paramMail) return;

--- a/src/screens/sell-info.screen.tsx
+++ b/src/screens/sell-info.screen.tsx
@@ -227,8 +227,10 @@ export default function SellInfoScreen(): JSX.Element {
   async function handleNext(paymentInfo: Sell): Promise<void> {
     setIsProcessing(true);
 
-    if (canSendTransaction() && !activeWallet)
-      return closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo }, false);
+    if (canSendTransaction() && !activeWallet) {
+      closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo }, false);
+      return;
+    }
 
     try {
       if (canSendTransaction()) await sendTransaction(paymentInfo).then(setSellTxId);

--- a/src/screens/sell.screen.tsx
+++ b/src/screens/sell.screen.tsx
@@ -489,8 +489,10 @@ export default function SellScreen(): JSX.Element {
 
     await updateBankAccount();
 
-    if (canSendTransaction() && !activeWallet)
-      return closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo }, false);
+    if (canSendTransaction() && !activeWallet) {
+      closeServices({ type: CloseType.SELL, isComplete: false, sell: paymentInfo }, false);
+      return;
+    }
 
     try {
       if (canSendTransaction()) {

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -80,6 +80,7 @@
   },
   "screens/kyc": {
     "Is this email address correct?": "Ist diese E-Mail-Adresse korrekt?",
+    "This account already has an email address. You can change it in your account settings.": "Dieses Konto hat bereits eine E-Mail-Adresse. Du kannst sie in Deinen Kontoeinstellungen ändern.",
     "DFX KYC": "DFX KYC",
     "KYC level": "KYC-Level",
     "Trading limit": "Trading-Limit",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -80,6 +80,7 @@
   },
   "screens/kyc": {
     "Is this email address correct?": "Cette adresse e-mail est-elle correcte ?",
+    "This account already has an email address. You can change it in your account settings.": "Ce compte possède déjà une adresse e-mail. Vous pouvez la modifier dans les paramètres de votre compte.",
     "DFX KYC": "DFX KYC",
     "KYC level": "KYC level",
     "Trading limit": "Limite de transactions",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -80,6 +80,7 @@
   },
   "screens/kyc": {
     "Is this email address correct?": "Questo indirizzo e-mail è corretto?",
+    "This account already has an email address. You can change it in your account settings.": "Questo account ha già un indirizzo e-mail. Puoi modificarlo nelle impostazioni del tuo account.",
     "DFX KYC": "DFX KYC",
     "KYC level": "KYC level",
     "Trading limit": "Limite delle transazioni",


### PR DESCRIPTION
## Problem

`BuyCompletion` renders `MailEdit` when the account has no mail yet — the "Is this email address correct? / [Change] [Confirm]" step at the end of a buy. Two defects make it a dead end.

**The success path does nothing.** `buy-completion.tsx` passed:

```tsx
onSubmit={(email) => (!email || email.length === 0) && close()}
```

For a non-empty address that is `false && close()` — a no-op. `MailEdit` keeps `showConfirmation` true and `pendingEmail` set, so it re-renders the identical screen. `user.mail` is still stale (the react package's `updateMail` does not refresh it), so `BuyCompletion` stays in the `MailEdit` branch too. The user gets no confirmation, no navigation, nothing — and clicks Confirm again.

**The second click's error is discarded.** The account now has a mail, so the API requires 2FA and answers `403 {"code":"TFA_REQUIRED", ...}`. `saveUser` only handled the merged-account 401 and rethrew everything else into a promise nobody catches — an unhandled rejection with zero UI change, which invites another click. The Confirm button is never disabled either: it receives `isLoading={isUserUpdating}`, and that flag is never set for this call.

Production, `PUT /v2/user/mail` over 30 days: **1206** `TFA_REQUIRED` against **19** successful sets. A representative session:

```
16:48:51  PUT /v2/user/mail  200      <- the address was saved here
16:49:00  PUT /v2/user/mail  403
16:49:24  PUT /v2/user/mail  403      (x17 more over two minutes)
```

Reported by a partner-wallet user who saw the 403 and assumed the step had failed. It had not — their address was stored on the first click.

## Changes

**Buy completion mail step**

- `buy-completion.tsx` closes on a successful submit, which is what its own Close button does in the branch for accounts that already have a mail.
- Local `isSaving` state disables Confirm while the request is in flight, so the fix does not depend on a `@dfx.swiss/react` release landing first.
- Two outcomes that retrying can never resolve now get their own short screen with an OK button that ends the step, instead of the generic `ErrorHint` — whose fixed opening line ("Something went wrong. Please try again…") is the wrong instruction for both:
  - **`TFA_REQUIRED`** — the account already carries an address. This step can only ever set a *first* one; changing an existing one additionally needs a code mailed to the new address, and this component has no field to enter one.
  - **`409 "account already exists - account merge request sent"`** — reachable on the first-set path too. Retrying only sends another merge mail; the user has to follow the link. Reuses the hint the account and KYC screens already show for this case.
- `close()` falls back to the account screen when `closeServices` has nothing to do. On `/buy/info` (`navigateOnClose={false}`, not a widget, not in an iframe, no redirect URI) it executed nothing, and blanking the component left an empty body with the back button suppressed. That state predates this branch, but this PR routes three more outcomes into it.
- A stale error no longer survives the Change button.
- The one new string is added to the German, French and Italian translations.

**Mail app-parameter (`settings.context.tsx`) — a second source of the same 403s**

```ts
useEffect(() => {
  if (user && mail && user.mail !== mail) updateUserMail(mail);
}, [user, mail]);
```

The comparison is raw, but the API normalises the address on write (`@Transform(Util.toLowerCaseTrim)` plus a `toLowerCase()` in `doUpdateUserMail`) and the `mail` parameter is never normalised on the client. So `?mail=John.Doe@Example.com` — or a padded ` a@b.com` — never satisfies the guard: the effect re-submits on every change of the `user` object, and once the address is stored each of those is another `403 TFA_REQUIRED`. The parameter is persisted to local storage, so it survives reloads.

The guard now normalises the same way the server does, and remembers the address it already submitted. That bound also covers the two cases normalising alone cannot close: a value the API rejects outright, and a change accepted with `202` that stays pending mail verification, where the stored address legitimately does not move.

### Why not redirect to `/2fa`

An earlier revision of this PR did redirect, mirroring `kyc.screen.tsx`. Review showed that is worse than the dead end it replaces: `setRedirect` records only the pathname (`navigation.hook.ts`), while the completion view is component-local state (`buy.screen.tsx` `showsCompletion`, `buy-info.screen.tsx`). Returning from `/2fa` therefore remounts an empty buy form — typed address gone, completion screen unreachable, no explanation. Routing to `/account/mail` instead was considered; it sends the user on an errand they usually do not need, since reaching this branch at all means the account already has a valid address.

## Known limitation (pre-existing, not addressed here)

When the account already has a mail **and** a valid 2FA log exists, `PUT /v2/user/mail` answers `202` and mails a verification code instead of `403`. `updateMail` is typed `Promise<void>` and every 2xx resolves identically, so the client cannot distinguish `202` from `200` and will close as if the address were stored — when it is only pending. Narrow (it needs a stale `user.mail`, a recent same-IP 2FA log, and a different address) and unchanged by this PR. It applies to the `MailEdit` step only — the app-parameter path above is bounded by its submitted-address guard. Closing it properly needs the status code surfaced through `@dfx.swiss/react` plus the token field this component lacks; tracked for a follow-up rather than smuggled in here.

## Verification

The four CI commands pass locally on Node 20.20.2 / npm 10.8.2: `npm run lint`, `npm run test` (62 suites, 617 tests), `npm run build:dev` and `npm run widget:dev`. `npx tsc -p tsconfig.build.json --noEmit`, the type check the review bot runs, is also clean.

`widget:dev` is the build that matters for strictness: `scripts/build-widget.sh` does not pin `CI`, so GitHub Actions runs it with warnings-as-errors. `scripts/build.sh` pins `CI=false` inline, in the repo, so `build:dev` never enforces that gate anywhere.

(A bare `npx tsc --noEmit` is not a usable gate in this repo and is not part of CI: `tsconfig.json` sets `"typeRoots": ["typings"]`, so `@types/jest` never resolves and the test files produce thousands of `Cannot find name 'describe'` errors on `develop` as well. None of them touch the files in this PR.)

## Related

- DFXswiss/api#4439 (open) — will let an unchanged address through without demanding 2FA, making a retry harmless server-side. This PR does not depend on it.
- DFXswiss/packages#196 — `updateMail` refreshes the cached user and sets `isUserUpdating`. This PR does not wait on it.


