### PR TITLE
a0b32b4e - Say why a completed order may fall back to its creation date

### DIFF
--- a/src/components/safe/transaction-history.tsx
+++ b/src/components/safe/transaction-history.tsx
@@ -54,8 +54,11 @@ function formatTimestamp(tx: CustodyOrderHistory, locale: string): string | unde
   // completedAt is the valuta timestamp, and it only means anything while the order actually is
   // completed: the backend sets it once and never clears it, so an order moved back out of
   // Completed would otherwise keep showing a valuta it no longer has. Every other state has its
-  // creation date and nothing else. Both are absent when the API still predates the fields, in
-  // which case the row shows no date rather than "Invalid Date".
+  // creation date and nothing else. The fallback inside the completed branch covers exactly one
+  // case: an order completed before the valuta column existed, which carries a creation date but
+  // no valuta - the creation date is then the closest thing to the truth we hold, and closer than
+  // showing nothing. Both are absent when the API still predates the fields altogether, in which
+  // case the row shows no date rather than "Invalid Date".
   const timestamp = tx.status === CustodyOrderHistoryStatus.COMPLETED ? (tx.completedAt ?? tx.created) : tx.created;
   if (!timestamp) return undefined;
 

--- a/src/components/safe/transaction-history.tsx
+++ b/src/components/safe/transaction-history.tsx
@@ -54,11 +54,13 @@ function formatTimestamp(tx: CustodyOrderHistory, locale: string): string | unde
   // completedAt is the valuta timestamp, and it only means anything while the order actually is
   // completed: the backend sets it once and never clears it, so an order moved back out of
   // Completed would otherwise keep showing a valuta it no longer has. Every other state has its
-  // creation date and nothing else. The fallback in the completed branch guards that invariant
-  // rather than a known gap — the migration that added the column backfilled every Completed row,
-  // and production holds none without a valuta — but a write path that ever set Completed without
-  // one would leave the row dated by its creation instead of blank. Both fields are absent against
-  // an API predating them, and the row then shows no date rather than "Invalid Date".
+  // creation date and nothing else. A completed order without a valuta is an anomaly, and the
+  // fallback in that branch does not repair it — it hides it behind a less precise date. That is
+  // the right trade here and only here: the backend raises the same anomaly where interest depends
+  // on it, whereas a row losing its date buys nobody anything. Production has no such order today
+  // (the migration adding the column backfilled every completed row), so this covers a future
+  // write path rather than a known gap. When talking to an API that predates both fields, the row
+  // shows no date at all rather than "Invalid Date".
   const timestamp = tx.status === CustodyOrderHistoryStatus.COMPLETED ? (tx.completedAt ?? tx.created) : tx.created;
   if (!timestamp) return undefined;
 

--- a/src/components/safe/transaction-history.tsx
+++ b/src/components/safe/transaction-history.tsx
@@ -54,11 +54,11 @@ function formatTimestamp(tx: CustodyOrderHistory, locale: string): string | unde
   // completedAt is the valuta timestamp, and it only means anything while the order actually is
   // completed: the backend sets it once and never clears it, so an order moved back out of
   // Completed would otherwise keep showing a valuta it no longer has. Every other state has its
-  // creation date and nothing else. The fallback inside the completed branch covers exactly one
-  // case: an order completed before the valuta column existed, which carries a creation date but
-  // no valuta - the creation date is then the closest thing to the truth we hold, and closer than
-  // showing nothing. Both are absent when the API still predates the fields altogether, in which
-  // case the row shows no date rather than "Invalid Date".
+  // creation date and nothing else. The fallback in the completed branch guards that invariant
+  // rather than a known gap — the migration that added the column backfilled every Completed row,
+  // and production holds none without a valuta — but a write path that ever set Completed without
+  // one would leave the row dated by its creation instead of blank. Both fields are absent against
+  // an API predating them, and the row then shows no date rather than "Invalid Date".
   const timestamp = tx.status === CustodyOrderHistoryStatus.COMPLETED ? (tx.completedAt ?? tx.created) : tx.created;
   if (!timestamp) return undefined;
 


### PR DESCRIPTION
Follow-up to DFXswiss/services#1207 (merged), closing the last open review point from it.

`formatTimestamp` reads the valuta timestamp only while the order is completed, and falls back to the creation date inside that branch. The comment explained why the valuta is tied to the completed state, but said nothing about why that fallback exists — and under the rule that a fallback carries its justification in the code, that is the one thing missing.

Getting that justification right took three attempts, and both discarded ones were wrong in a way worth recording:

1. The first claimed a historical data gap — orders completed before the column existed. There is no such gap: the migration that added the column backfilled every existing `Completed` row from `updated`, and production holds 189 completed orders, none without a valuta.
2. The second said the fallback *guards* the invariant. It does not. It hides a violation behind a less precise date.

The comment now says that plainly, and why hiding it is the right trade in a rendered row and not where money depends on it — `accrueTranche()` in the backend raises the same anomaly rather than working around it.

Comment only, no behaviour change: across all three commits the diff touches nothing but comment lines.