### PR TITLE
a0b32b4e - Give async waits the time a loaded machine needs

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,19 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { configure } from '@testing-library/react';
+
+// Jest defaults to maxWorkers = CPU cores - 1 (17 workers on 18 cores); under that load a
+// worker can go without CPU time for over a second at times.
+// Measured findBy* waits across 10 full suite runs (50 samples): median 278ms, maximum 1523ms;
+// 7 of 50 exceeded 1000ms (DOM Testing Library's default async timeout). This does not weaken
+// any assertion: every assertion still checks exactly the same condition, and a genuinely
+// broken expectation still fails — this setting only gives the scheduler the time it needs.
+// Applies to the whole suite, not only the file where the flakiness was first noticed.
+configure({ asyncUtilTimeout: 5000 });
+
+// Must stay above asyncUtilTimeout so Jest does not abort first and replace Testing Library's
+// informative DOM dump (e.g. "Unable to find role=button …") with a bare "Exceeded timeout of
+// 5000 ms" and no diagnostic detail. react-scripts does not accept testTimeout in the jest
+// section of package.json (supportedKeys in createJestConfig.js omits it), so set it here.
+jest.setTimeout(15000);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/*.test.ts", "**/__tests__/**"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/*.test.ts", "**/__tests__/**", "src/setupTests.ts"]
 }


### PR DESCRIPTION
Closes #1212.

`transaction-document-error.test.tsx` failed 1 in 5 full-suite runs on plain `develop`, with nothing changed: `findByRole('button', { name: 'Open receipt' })` ran into DOM Testing Library's 1000 ms default while the list had not rendered yet. A red "Build and test" that a plain re-run clears costs every author a diagnosis pass, and teaches reviewers to wave red checks through.

## The limit is the cause, not the test

- **20 of 20 isolated runs** of the file pass. `TransactionList` has no timer in its load path and both mocks resolve immediately — there is no race to fix in the test.
- Instrumenting every `findBy*` in the file across **ten full suite runs** on an 18-core machine:

  | Metric | Value |
  | --- | --- |
  | Measurements | 50 |
  | Median wait | 278 ms |
  | Longest wait | 1523 ms |
  | Over the 1000 ms default | 7 of 50 (14 %) |

- With the wait limit as the **only** changed variable, all ten runs passed: 6040 tests, 0 failures.

Jest runs one worker fewer than the machine has cores, and under that parallelism a single worker goes without CPU for well over a second at a time. The default assumes it does not.

## What changes

`src/setupTests.ts` only:

- `asyncUtilTimeout` 1000 → 5000 ms. The longest wait measured was 1523 ms, so the new limit sits well clear of everything observed. The margin comes from the measurements rather than from a guess.
- `jest.setTimeout` 5000 → 15000 ms. It has to stay above `asyncUtilTimeout`, or Jest ends the test first and Testing Library's DOM dump naming the missing element is replaced by a bare "Exceeded timeout of 5000 ms". `react-scripts` does not accept `testTimeout` in the `jest` section of `package.json`, so it is set here.

`tsconfig.build.json` gains one exclude entry. It kept test code out by name pattern alone — `**/*.test.ts`, `**/*spec.ts`, `**/__tests__/**` — and `src/setupTests.ts` matches none of them, so it stayed in the program that `build:lib` emits to `dist/` and that the review bot type-checks. That was invisible while the file held nothing but an import: `jest.setTimeout` is the first value access to `jest` in it, and `tsconfig.json` sets `typeRoots: ["typings"]`, which keeps `node_modules/@types` out of scope, so `@types/jest` never loads and the reference fails with TS2708. The whole test suite hits the same wall, which is why it is excluded from this config to begin with — this file was simply missed.

No assertion is weakened. Each one still waits for exactly the condition it waited for before, and a genuinely broken expectation still fails — it just gets the scheduler time it needs first. The setting is suite-wide on purpose: every `findBy*` and `waitFor` in all 604 tests runs against the same limit, and `transaction-document-error.test.tsx` (added in #1190) is only where it surfaced first.

## Verification

Ten full suite runs on this branch, same machine and command as the measurements above. Plus the four gates that matter here, including the one that caught the TS2708 above: `tsc -p tsconfig.build.json --noEmit` (no errors, one before), `npm run lint`, `npm run build:dev`, and the suite at 604 of 604.

Related: #1208 covered a different flake in the same class — a test racing its own teardown rather than the scheduler. That file was removed with #1206; the issue is closed with the evidence.
