### PR TITLE
7392bb63 - Skip balancesByType on the Financial Overview screen

### DIFF
--- a/src/components/dashboard/balance-by-type-area-chart.tsx
+++ b/src/components/dashboard/balance-by-type-area-chart.tsx
@@ -1,11 +1,11 @@
 import { ApexOptions } from 'apexcharts';
 import { useMemo } from 'react';
 import Chart from 'react-apexcharts';
-import { FinancialLogEntry } from 'src/dto/dashboard.dto';
+import { FinancialLogEntryWithBalancesByType } from 'src/dto/dashboard.dto';
 import { TimeRange } from 'src/util/chart';
 
 interface Props {
-  entries: FinancialLogEntry[];
+  entries: FinancialLogEntryWithBalancesByType[];
   timeRange?: TimeRange;
 }
 
@@ -19,11 +19,10 @@ const TYPE_COLORS: Record<string, string> = {
 
 const DEFAULT_COLOR = '#6b7280';
 
-function useFinancialTypes(entries: FinancialLogEntry[]) {
+function useFinancialTypes(entries: FinancialLogEntryWithBalancesByType[]) {
   return useMemo(() => {
     const types = new Set<string>();
     for (const entry of entries) {
-      if (!entry.balancesByType) continue;
       for (const type of Object.keys(entry.balancesByType)) {
         types.add(type);
       }
@@ -71,7 +70,7 @@ export function BalanceByTypePlusChart({ entries, timeRange }: Props) {
 
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
-    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType?.[type]?.plusBalanceChf ?? 0)]),
+    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType[type]?.plusBalanceChf ?? 0)]),
   })), [entries, financialTypes]);
 
   return (
@@ -88,7 +87,7 @@ export function BalanceByTypeMinusChart({ entries, timeRange }: Props) {
 
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
-    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType?.[type]?.minusBalanceChf ?? 0)]),
+    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType[type]?.minusBalanceChf ?? 0)]),
   })), [entries, financialTypes]);
 
   return (
@@ -106,7 +105,7 @@ export function BalanceByTypeTotalChart({ entries, timeRange }: Props) {
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
     data: entries.map((e) => {
-      const b = e.balancesByType?.[type];
+      const b = e.balancesByType[type];
       const net = b ? b.plusBalanceChf - b.minusBalanceChf : 0;
       return [new Date(e.timestamp).getTime(), Math.round(net)];
     }),

--- a/src/components/dashboard/balance-by-type-area-chart.tsx
+++ b/src/components/dashboard/balance-by-type-area-chart.tsx
@@ -23,6 +23,7 @@ function useFinancialTypes(entries: FinancialLogEntry[]) {
   return useMemo(() => {
     const types = new Set<string>();
     for (const entry of entries) {
+      if (!entry.balancesByType) continue;
       for (const type of Object.keys(entry.balancesByType)) {
         types.add(type);
       }
@@ -70,7 +71,7 @@ export function BalanceByTypePlusChart({ entries, timeRange }: Props) {
 
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
-    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType[type]?.plusBalanceChf ?? 0)]),
+    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType?.[type]?.plusBalanceChf ?? 0)]),
   })), [entries, financialTypes]);
 
   return (
@@ -87,7 +88,7 @@ export function BalanceByTypeMinusChart({ entries, timeRange }: Props) {
 
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
-    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType[type]?.minusBalanceChf ?? 0)]),
+    data: entries.map((e) => [new Date(e.timestamp).getTime(), Math.round(e.balancesByType?.[type]?.minusBalanceChf ?? 0)]),
   })), [entries, financialTypes]);
 
   return (
@@ -105,7 +106,7 @@ export function BalanceByTypeTotalChart({ entries, timeRange }: Props) {
   const series = useMemo(() => financialTypes.map((type) => ({
     name: type,
     data: entries.map((e) => {
-      const b = e.balancesByType[type];
+      const b = e.balancesByType?.[type];
       const net = b ? b.plusBalanceChf - b.minusBalanceChf : 0;
       return [new Date(e.timestamp).getTime(), Math.round(net)];
     }),

--- a/src/dto/dashboard.dto.ts
+++ b/src/dto/dashboard.dto.ts
@@ -4,7 +4,7 @@ export interface FinancialLogEntry {
   plusBalanceChf: number;
   minusBalanceChf: number;
   btcPriceChf: number;
-  balancesByType: Record<string, { plusBalanceChf: number; minusBalanceChf: number }>;
+  balancesByType?: Record<string, { plusBalanceChf: number; minusBalanceChf: number }>;
 }
 
 export interface FinancialLogResponse {

--- a/src/dto/dashboard.dto.ts
+++ b/src/dto/dashboard.dto.ts
@@ -7,6 +7,10 @@ export interface FinancialLogEntry {
   balancesByType?: Record<string, { plusBalanceChf: number; minusBalanceChf: number }>;
 }
 
+export type FinancialLogEntryWithBalancesByType = FinancialLogEntry & {
+  balancesByType: NonNullable<FinancialLogEntry['balancesByType']>;
+};
+
 export interface FinancialLogResponse {
   entries: FinancialLogEntry[];
 }

--- a/src/hooks/dashboard.hook.ts
+++ b/src/hooks/dashboard.hook.ts
@@ -11,10 +11,15 @@ import {
 export function useDashboard() {
   const { call } = useApi();
 
-  async function getFinancialLog(from?: string, dailySample?: boolean): Promise<FinancialLogResponse> {
+  async function getFinancialLog(
+    from?: string,
+    dailySample?: boolean,
+    byType?: boolean,
+  ): Promise<FinancialLogResponse> {
     const params = new URLSearchParams();
     if (from) params.set('from', from);
     if (dailySample !== undefined) params.set('dailySample', String(dailySample));
+    if (byType !== undefined) params.set('byType', String(byType));
     const query = params.toString();
 
     return call<FinancialLogResponse>({

--- a/src/screens/dashboard-financial-history.screen.tsx
+++ b/src/screens/dashboard-financial-history.screen.tsx
@@ -5,7 +5,7 @@ import { BalanceByTypeMinusChart, BalanceByTypePlusChart, BalanceByTypeTotalChar
 import { FinancialChangesMinusChart, FinancialChangesPlusChart, FinancialChangesTotalChart } from 'src/components/dashboard/financial-changes-chart';
 import { TotalBalanceLongChart } from 'src/components/dashboard/total-balance-long-chart';
 import { ShortTermMinusChart, ShortTermPlusChart, ShortTermTotalChart } from 'src/components/dashboard/total-balance-short-chart';
-import { FinancialChangesEntry, FinancialLogEntry } from 'src/dto/dashboard.dto';
+import { FinancialChangesEntry, FinancialLogEntry, FinancialLogEntryWithBalancesByType } from 'src/dto/dashboard.dto';
 import { useDashboard } from 'src/hooks/dashboard.hook';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
@@ -13,6 +13,10 @@ import { useNavigation } from 'src/hooks/navigation.hook';
 import { getFromDateByTimeframe, isDailySample, Timeframe, TimeRange } from 'src/util/chart';
 
 const TIMEFRAME_OPTIONS = [Timeframe.DAY, Timeframe.THREE_DAYS, Timeframe.WEEK, Timeframe.MONTH] as const;
+
+function hasBalancesByType(entry: FinancialLogEntry): entry is FinancialLogEntryWithBalancesByType {
+  return entry.balancesByType !== undefined;
+}
 
 export default function DashboardFinancialLogScreen(): JSX.Element {
   useAdminGuard();
@@ -52,6 +56,15 @@ export default function DashboardFinancialLogScreen(): JSX.Element {
     if (allTimestamps.length === 0) return undefined;
     return { min: Math.min(...allTimestamps), max: Math.max(...allTimestamps) };
   }, [logEntries, changesEntries]);
+
+  const balanceByTypeLogEntries = useMemo((): FinancialLogEntryWithBalancesByType[] | undefined => {
+    const result: FinancialLogEntryWithBalancesByType[] = [];
+    for (const entry of logEntries) {
+      if (!hasBalancesByType(entry)) return undefined;
+      result.push(entry);
+    }
+    return result;
+  }, [logEntries]);
 
   return (
     <div className="space-y-4 p-4 w-full self-stretch" style={{ color: '#111827' }}>
@@ -106,15 +119,23 @@ export default function DashboardFinancialLogScreen(): JSX.Element {
           </div>
 
           {/* Balance by Financial Type */}
-          <div className="bg-white rounded-lg shadow p-4">
-            <BalanceByTypePlusChart entries={logEntries} timeRange={timeRange} />
-          </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <BalanceByTypeMinusChart entries={logEntries} timeRange={timeRange} />
-          </div>
-          <div className="bg-white rounded-lg shadow p-4">
-            <BalanceByTypeTotalChart entries={logEntries} timeRange={timeRange} />
-          </div>
+          {balanceByTypeLogEntries ? (
+            <>
+              <div className="bg-white rounded-lg shadow p-4">
+                <BalanceByTypePlusChart entries={balanceByTypeLogEntries} timeRange={timeRange} />
+              </div>
+              <div className="bg-white rounded-lg shadow p-4">
+                <BalanceByTypeMinusChart entries={balanceByTypeLogEntries} timeRange={timeRange} />
+              </div>
+              <div className="bg-white rounded-lg shadow p-4">
+                <BalanceByTypeTotalChart entries={balanceByTypeLogEntries} timeRange={timeRange} />
+              </div>
+            </>
+          ) : (
+            <div className="bg-white rounded-lg shadow p-4">
+              Balance by financial type is unavailable because the response did not include balancesByType.
+            </div>
+          )}
         </>
       )}
     </div>

--- a/src/screens/dashboard-financial-overview.screen.tsx
+++ b/src/screens/dashboard-financial-overview.screen.tsx
@@ -48,7 +48,8 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
       getLatestBalance()
         .then(setLatestBalance)
         .catch(() => undefined);
-      getFinancialLog(from, dailySample)
+      // This screen never reads balancesByType (~82% of the payload). History still needs the full data — do not unify this parameter away.
+      getFinancialLog(from, dailySample, false)
         .then((logData) => setLogEntries(logData.entries))
         .catch(() => undefined)
         .finally(() => {

--- a/src/screens/dashboard-financial-overview.screen.tsx
+++ b/src/screens/dashboard-financial-overview.screen.tsx
@@ -48,7 +48,8 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
       getLatestBalance()
         .then(setLatestBalance)
         .catch(() => undefined);
-      // This screen never reads balancesByType (~82% of the payload). History still needs the full data — do not unify this parameter away.
+      // This screen never reads balancesByType (~82% of the payload).
+      // History still needs the full data — do not unify this parameter away.
       getFinancialLog(from, dailySample, false)
         .then((logData) => setLogEntries(logData.entries))
         .catch(() => undefined)


### PR DESCRIPTION
The Financial Overview screen refreshes once a minute and pulls ~2 MB it never reads. This tells the API to skip that part.

Companion to DFXswiss/api#4506, which adds the `byType` query parameter. **Merge that one first** — without it the parameter is ignored and this change is a no-op (harmless, but pointless).

## Measured

Standard call of this screen (`?from=<3 days ago>&dailySample=false`), against production — 2,055 rows, 2.47 MB response:

```
balancesByFinancialType   2,027 kB   (1,010 bytes/row)   82 % of the payload
balancesTotal               204 kB   (  102 bytes/row)

Database time for the same query and window:
  with    balancesByType   2,030 ms
  without balancesByType   1,078 ms
```

Endpoint latency in production is 10–14 s, CPU-bound (`wait_event: RUN`, sampled via `pg_stat_activity`, longest observed 13.05 s).

## Why this screen can skip it

`balancesByType` is read in exactly one place in this repository — `balance-by-type-area-chart.tsx` — and that component is used only by the History screen:

| screen | default window | reads `balancesByType` | auto-refresh |
| --- | --- | --- | --- |
| Overview | 3 days, minute resolution | **no** | yes, 60/h |
| History | 24 h | yes | no |

The History screen's call site still passes two arguments, so `byType` stays `undefined` and its request URL is byte-identical to today. There is no shared response cache between the two screens: `useApi().call` is a plain `fetch` wrapper, and each screen holds its own state — so the Overview call cannot take data away from History.

## What changed

- `dashboard.hook.ts` — third optional parameter, set only when defined, same pattern as `dailySample`. Omitting it leaves the URL unchanged.
- `dashboard-financial-overview.screen.tsx` — passes `false`, with a note that this screen never reads the field and that History still needs it.
- `dashboard.dto.ts` — `balancesByType` becomes optional, since the API may now omit it, plus a derived type that keeps it required for consumers that need it.
- `balance-by-type-area-chart.tsx` — takes the derived type, so its field accesses stay exactly as they are on `develop`.
- `dashboard-financial-history.screen.tsx` — resolves the requirement once via a type guard and states plainly when the data is missing.

## Why the charts are typed rather than made defensive

The first revision made the chart component defensive instead: a `continue` on a missing field and optional chaining on three accesses. Combined with the `?? 0` defaults already present on `develop`, that turned a loud crash into a **silent zero line** — a false statement about balances, which is worse than an error. Both review lenses flagged it independently.

The requirement now lives in the type. The chart declares that it needs the field, its accesses go back to the `develop` form unchanged, and the History screen — which does request the full payload — resolves it once. If the field is ever absent there, the by-type charts are replaced by a visible note instead of being drawn as zero. Entries are never filtered out individually, since a silently shortened series would be the same class of problem.

## Verification

All CI checks green at this commit, including **Build and test** — which runs the full type check and is the real proof that the narrower type holds at every call site. Verified again locally on Node 20 (`npm ci`, `lint`, `build:dev`). Longest line added by this PR: 119 characters, within `printWidth`.

One thing stated plainly: `prettier --check` reports two of the touched files as unformatted — but they are **already unformatted on `develop`**, verified by running the check against both revisions. The cause is long import lines that Prettier would wrap. This PR neither introduces nor worsens that; reformatting those import blocks would touch code unrelated to this change, so it is left alone.

No existing test imports any of the changed files — stated explicitly rather than silently skipped.

Worth flagging about this repository's CI, since it cost time here: `lint` does not cover `.tsx` files and the pipeline has no prettier check. A one-character `printWidth` overrun in the hook signature and a 142-character comment line were both caught by local runs and a review, never by CI. The two pre-existing over-length lines in `balance-by-type-area-chart.tsx` are back to their `develop` state, since the optional chaining that had lengthened them is gone.
