### PR TITLE
baa7748e - Split the financial log entry type by response mode

### DIFF
--- a/src/components/dashboard/total-balance-long-chart.tsx
+++ b/src/components/dashboard/total-balance-long-chart.tsx
@@ -1,11 +1,11 @@
 import { ApexOptions } from 'apexcharts';
 import { useMemo } from 'react';
 import Chart from 'react-apexcharts';
-import { FinancialLogEntry } from 'src/dto/dashboard.dto';
+import { FinancialLogChartEntry } from 'src/dto/dashboard.dto';
 import { TimeRange } from 'src/util/chart';
 
 interface TotalBalanceLongChartProps {
-  entries: FinancialLogEntry[];
+  entries: FinancialLogChartEntry[];
   timeRange?: TimeRange;
   dark?: boolean;
 }

--- a/src/dto/dashboard.dto.ts
+++ b/src/dto/dashboard.dto.ts
@@ -1,9 +1,14 @@
-export interface FinancialLogEntry {
+/** Chart mode: GET /dashboard/financial/log?byType=false — only these three fields are present. */
+export interface FinancialLogChartEntry {
   timestamp: string;
   totalBalanceChf: number;
+  btcPriceChf: number;
+}
+
+/** Full mode: GET /dashboard/financial/log with byType omitted or true — extends the chart fields. */
+export interface FinancialLogEntry extends FinancialLogChartEntry {
   plusBalanceChf: number;
   minusBalanceChf: number;
-  btcPriceChf: number;
   balancesByType?: Record<string, { plusBalanceChf: number; minusBalanceChf: number }>;
 }
 
@@ -13,6 +18,10 @@ export type FinancialLogEntryWithBalancesByType = FinancialLogEntry & {
 
 export interface FinancialLogResponse {
   entries: FinancialLogEntry[];
+}
+
+export interface FinancialLogChartResponse {
+  entries: FinancialLogChartEntry[];
 }
 
 export interface FinancialChangesEntry {

--- a/src/hooks/dashboard.hook.ts
+++ b/src/hooks/dashboard.hook.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import {
   FinancialChangesEntry,
   FinancialChangesResponse,
+  FinancialLogChartResponse,
   FinancialLogResponse,
   LatestBalanceResponse,
   RefRewardRecipient,
@@ -11,19 +12,29 @@ import {
 export function useDashboard() {
   const { call } = useApi();
 
-  async function getFinancialLog(
-    from?: string,
-    dailySample?: boolean,
-    byType?: boolean,
-  ): Promise<FinancialLogResponse> {
+  function financialLogParams(from?: string, dailySample?: boolean): URLSearchParams {
     const params = new URLSearchParams();
     if (from) params.set('from', from);
     if (dailySample !== undefined) params.set('dailySample', String(dailySample));
-    if (byType !== undefined) params.set('byType', String(byType));
-    const query = params.toString();
+    return params;
+  }
+
+  async function getFinancialLog(from?: string, dailySample?: boolean): Promise<FinancialLogResponse> {
+    const query = financialLogParams(from, dailySample).toString();
 
     return call<FinancialLogResponse>({
       url: `dashboard/financial/log${query ? `?${query}` : ''}`,
+      method: 'GET',
+    });
+  }
+
+  async function getFinancialLogChart(from?: string, dailySample?: boolean): Promise<FinancialLogChartResponse> {
+    const params = financialLogParams(from, dailySample);
+    params.set('byType', 'false');
+    const query = params.toString();
+
+    return call<FinancialLogChartResponse>({
+      url: `dashboard/financial/log?${query}`,
       method: 'GET',
     });
   }
@@ -63,7 +74,14 @@ export function useDashboard() {
   }
 
   return useMemo(
-    () => ({ getFinancialLog, getFinancialChanges, getLatestBalance, getLatestChanges, getRefRecipients }),
+    () => ({
+      getFinancialLog,
+      getFinancialLogChart,
+      getFinancialChanges,
+      getLatestBalance,
+      getLatestChanges,
+      getRefRecipients,
+    }),
     [call],
   );
 }

--- a/src/screens/dashboard-financial-overview.screen.tsx
+++ b/src/screens/dashboard-financial-overview.screen.tsx
@@ -5,7 +5,7 @@ import { AgeBadge } from 'src/components/dashboard/age-badge';
 import { BalanceBarChart } from 'src/components/dashboard/latest-balance-bar-chart';
 import { SummaryCard } from 'src/components/dashboard/summary-card';
 import { TotalBalanceLongChart } from 'src/components/dashboard/total-balance-long-chart';
-import { FinancialLogEntry, LatestBalanceResponse } from 'src/dto/dashboard.dto';
+import { FinancialLogChartEntry, LatestBalanceResponse } from 'src/dto/dashboard.dto';
 import { useDashboard } from 'src/hooks/dashboard.hook';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
@@ -29,11 +29,11 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
   useLayoutOptions({ title: 'Financial Overview', noMaxWidth: true });
 
   const { isLoggedIn } = useSessionContext();
-  const { getLatestBalance, getFinancialLog } = useDashboard();
+  const { getLatestBalance, getFinancialLogChart } = useDashboard();
 
   const [timeframe, setTimeframe] = useState<Timeframe>(Timeframe.THREE_DAYS);
   const [latestBalance, setLatestBalance] = useState<LatestBalanceResponse>();
-  const [logEntries, setLogEntries] = useState<FinancialLogEntry[]>([]);
+  const [logEntries, setLogEntries] = useState<FinancialLogChartEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -50,7 +50,7 @@ export default function DashboardFinancialOverviewScreen(): JSX.Element {
         .catch(() => undefined);
       // This screen never reads balancesByType (~82% of the payload).
       // History still needs the full data — do not unify this parameter away.
-      getFinancialLog(from, dailySample, false)
+      getFinancialLogChart(from, dailySample)
         .then((logData) => setLogEntries(logData.entries))
         .catch(() => undefined)
         .finally(() => {


### PR DESCRIPTION
Frontend counterpart to DFXswiss/api#4519, which is why that PR exists at all: the Financial
Overview screen is open around the clock and reloads its three-day window every minute.

## What changed on the API side

`GET /dashboard/financial/log?byType=false` now returns only `timestamp`, `totalBalanceChf` and
`btcPriceChf` per entry. The remaining fields are omitted in that mode — deriving them means
parsing a ~43 kB JSON document per data point, and the chart does not use them. The full mode
(`byType` omitted or `true`) is unchanged.

## Why this PR

Nothing is broken at runtime today. The overview screen hands its entries to
`TotalBalanceLongChart`, which reads exactly the three fields the chart mode returns; the
`plusBalanceChf`/`minusBalanceChf` values on that screen come from `getLatestBalance()`, a
different endpoint.

The problem is the type. `FinancialLogEntry` declared the omitted fields as guaranteed `number`,
so it promised something the chart mode does not deliver. Reaching for `entry.plusBalanceChf` on
the overview screen would compile cleanly and yield `undefined`.

## The change

The type is split rather than widened:

- `FinancialLogChartEntry` — the three fields the chart mode returns.
- `FinancialLogEntry extends FinancialLogChartEntry` — adds the full-mode fields.

Making the fields optional instead would have pushed the problem into the history screen, which
legitimately relies on them being present.

The mode is now chosen by which hook function you call — `getFinancialLogChart()` versus
`getFinancialLog()` — instead of by a boolean argument whose value the return type ignored. A
caller can no longer request one shape and be typed as the other.

The history screen and its components (`total-balance-short-chart`, `balance-by-type-area-chart`,
`financial-log-table`) keep using `FinancialLogEntry` and are untouched, because the split is
additive to the existing full-mode type.

## Verification

Type errors in `.tsx` files surface in the build rather than in lint, so `npm run build:dev` is
the gate that matters here. Result will be posted below.
