### PR TITLE
Offer the AmlCheck action on completed call outcomes

### DIFF
--- a/src/__tests__/call-queue-outcome-form.test.tsx
+++ b/src/__tests__/call-queue-outcome-form.test.tsx
@@ -1,7 +1,8 @@
 // Component tests for the call-queue outcome form: the AmlCheck action must be offered for
 // transaction-based queue items on ALL outcomes (queues like ManualCheckIpCountryPhone are excluded
-// from the AML recheck cron, so a completed call has to release the transaction explicitly) and must
-// default to Pass when the call was completed. Heavy transitive deps are mocked so the form can
+// from the AML recheck cron, so a completed call has to act on the transaction explicitly) and must
+// default to Reset when the call was completed (clears amlCheck/amlReason so the cron re-runs the
+// full AML check instead of force-passing). Heavy transitive deps are mocked so the form can
 // render under @testing-library/react without the full app shell.
 
 jest.mock('@dfx.swiss/react-components', () => ({
@@ -70,7 +71,7 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
     mockSaveCallOutcome.mockResolvedValue({ success: true, completedSteps: ['transaction', 'userData', 'log'] });
   });
 
-  it('offers the AmlCheck action for transaction items and defaults to Pass on Completed', async () => {
+  it('offers the AmlCheck action for transaction items and defaults to Reset on Completed', async () => {
     renderForm(TX_CONTEXT);
     expect(screen.getAllByRole('combobox')).toHaveLength(3);
 
@@ -80,11 +81,11 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
     expect(mockSaveCallOutcome).toHaveBeenCalledWith(TX_CONTEXT, CallOutcome.COMPLETED, {
       signature: 'JR',
       comment: 'called',
-      amlAction: 'Pass',
+      amlAction: 'Reset',
     });
   });
 
-  it('keeps the Pass default overridable', async () => {
+  it('keeps the Reset default overridable', async () => {
     renderForm(TX_CONTEXT);
 
     fillAndSubmit(CallOutcome.COMPLETED, '');
@@ -97,7 +98,7 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
     renderForm(TX_CONTEXT);
     const selects = screen.getAllByRole('combobox');
     fireEvent.change(selects[1], { target: { value: CallOutcome.COMPLETED } });
-    expect((screen.getAllByRole('combobox')[2] as HTMLSelectElement).value).toBe('Pass');
+    expect((screen.getAllByRole('combobox')[2] as HTMLSelectElement).value).toBe('Reset');
 
     fillAndSubmit(CallOutcome.UNAVAILABLE);
 

--- a/src/__tests__/call-queue-outcome-form.test.tsx
+++ b/src/__tests__/call-queue-outcome-form.test.tsx
@@ -1,0 +1,121 @@
+// Component tests for the call-queue outcome form: the AmlCheck action must be offered for
+// transaction-based queue items on ALL outcomes (queues like ManualCheckIpCountryPhone are excluded
+// from the AML recheck cron, so a completed call has to release the transaction explicitly) and must
+// default to Pass when the call was completed. Heavy transitive deps are mocked so the form can
+// render under @testing-library/react without the full app shell.
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  StyledButton: ({ label, onClick, disabled }: any) => (
+    <button disabled={disabled} onClick={onClick}>
+      {label}
+    </button>
+  ),
+  StyledButtonWidth: { FULL: 'full' },
+}));
+jest.mock('src/components/error-hint', () => ({ ErrorHint: () => null }));
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_ns: string, key: string) => key }),
+}));
+
+const mockSaveCallOutcome = jest.fn();
+jest.mock('src/hooks/compliance.hook', () => ({
+  CallOutcome: {
+    COMPLETED: 'Completed',
+    UNAVAILABLE: 'Unavailable',
+    SUSPICIOUS: 'Suspicious',
+    FAILED: 'Failed',
+    REPEAT: 'Repeat',
+  },
+  useCompliance: () => ({ saveCallOutcome: mockSaveCallOutcome }),
+}));
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { CallQueueOutcomeForm } from 'src/components/compliance/call-queue/call-queue-outcome-form';
+import { CallOutcome } from 'src/hooks/compliance.hook';
+
+const OUTCOMES = [
+  CallOutcome.COMPLETED,
+  CallOutcome.UNAVAILABLE,
+  CallOutcome.SUSPICIOUS,
+  CallOutcome.FAILED,
+  CallOutcome.REPEAT,
+];
+
+const TX_CONTEXT = { queue: 'ManualCheckIpCountryPhone', userDataId: 1, txId: 42, sourceType: 'BuyCrypto' } as any;
+const USER_CONTEXT = { queue: 'UnavailableSuspicious', userDataId: 1 } as any;
+
+function renderForm(context: any) {
+  return render(
+    <CallQueueOutcomeForm
+      context={context}
+      availableOutcomes={OUTCOMES}
+      clerks={['JR']}
+      onSaved={jest.fn()}
+      title="Save Outcome"
+    />,
+  );
+}
+
+function fillAndSubmit(outcome: CallOutcome, amlAction?: string) {
+  const selects = screen.getAllByRole('combobox');
+  fireEvent.change(selects[1], { target: { value: outcome } });
+  if (amlAction !== undefined) fireEvent.change(screen.getAllByRole('combobox')[2], { target: { value: amlAction } });
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'called' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save Outcome' }));
+}
+
+describe('CallQueueOutcomeForm AmlCheck action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSaveCallOutcome.mockResolvedValue({ success: true, completedSteps: ['transaction', 'userData', 'log'] });
+  });
+
+  it('offers the AmlCheck action for transaction items and defaults to Pass on Completed', async () => {
+    renderForm(TX_CONTEXT);
+    expect(screen.getAllByRole('combobox')).toHaveLength(3);
+
+    fillAndSubmit(CallOutcome.COMPLETED);
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(mockSaveCallOutcome).toHaveBeenCalledWith(TX_CONTEXT, CallOutcome.COMPLETED, {
+      signature: 'JR',
+      comment: 'called',
+      amlAction: 'Pass',
+    });
+  });
+
+  it('keeps the Pass default overridable', async () => {
+    renderForm(TX_CONTEXT);
+
+    fillAndSubmit(CallOutcome.COMPLETED, '');
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(mockSaveCallOutcome.mock.calls[0][2].amlAction).toBeUndefined();
+  });
+
+  it('resets the AmlCheck action to no change for other outcomes', async () => {
+    renderForm(TX_CONTEXT);
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[1], { target: { value: CallOutcome.COMPLETED } });
+    expect((screen.getAllByRole('combobox')[2] as HTMLSelectElement).value).toBe('Pass');
+
+    fillAndSubmit(CallOutcome.UNAVAILABLE);
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(mockSaveCallOutcome.mock.calls[0][1]).toBe(CallOutcome.UNAVAILABLE);
+    expect(mockSaveCallOutcome.mock.calls[0][2].amlAction).toBeUndefined();
+  });
+
+  it('does not offer an AmlCheck action for user-based queue items', async () => {
+    renderForm(USER_CONTEXT);
+    expect(screen.getAllByRole('combobox')).toHaveLength(2);
+
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[1], { target: { value: CallOutcome.COMPLETED } });
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'called' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Outcome' }));
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(mockSaveCallOutcome.mock.calls[0][2].amlAction).toBeUndefined();
+  });
+});

--- a/src/__tests__/compliance-call-outcome.hook.test.ts
+++ b/src/__tests__/compliance-call-outcome.hook.test.ts
@@ -1,0 +1,76 @@
+// Hook tests for saveCallOutcome: the userData update (phoneCallStatus + queue-specific check date)
+// must be written BEFORE the transaction step. A reset transaction is re-evaluated from scratch by
+// the AML cron; if the check date is not visible by then, the tx re-pends into its (possibly
+// recheck-blocked) queue reason and gets stuck again.
+
+const mockCalls: { method: string; url: string; data?: any }[] = [];
+const mockCall = jest.fn();
+jest.mock('src/hooks/guarded-api.hook', () => ({ useGuardedApi: () => ({ call: mockCall }) }));
+jest.mock('@dfx.swiss/react', () => ({
+  AmlReason: { MANUAL_CHECK_PHONE_FAILED: 'ManualCheckPhoneFailed' },
+  CheckStatus: { PASS: 'Pass', FAIL: 'Fail' },
+  PhoneCallStatus: {
+    COMPLETED: 'Completed',
+    UNAVAILABLE: 'Unavailable',
+    SUSPICIOUS: 'Suspicious',
+    FAILED: 'Failed',
+    REPEAT: 'Repeat',
+    USER_REJECTED: 'UserRejected',
+  },
+  CallQueue: {
+    MANUAL_CHECK_PHONE: 'ManualCheckPhone',
+    MANUAL_CHECK_IP_PHONE: 'ManualCheckIpPhone',
+    MANUAL_CHECK_IP_COUNTRY_PHONE: 'ManualCheckIpCountryPhone',
+    MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE: 'ManualCheckExternalAccountPhone',
+    UNAVAILABLE_SUSPICIOUS: 'UnavailableSuspicious',
+  },
+}));
+
+import { renderHook } from '@testing-library/react';
+import { CallOutcome, useCompliance } from 'src/hooks/compliance.hook';
+
+const TX_CONTEXT = { queue: 'ManualCheckIpCountryPhone', userDataId: 7, txId: 42, sourceType: 'BuyCrypto' } as any;
+
+describe('saveCallOutcome write order', () => {
+  beforeEach(() => {
+    mockCalls.length = 0;
+    // resetMocks is on (CRA default), so the recording implementation must be (re)set per test
+    mockCall.mockImplementation(async (cfg: any) => {
+      mockCalls.push({ method: cfg.method, url: cfg.url, data: cfg.data });
+      return {};
+    });
+  });
+
+  it('writes the userData check date before resetting the transaction', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const res = await result.current.saveCallOutcome(TX_CONTEXT, CallOutcome.COMPLETED, {
+      signature: 'JR',
+      comment: 'called',
+      amlAction: 'Reset',
+    });
+
+    expect(res.success).toBe(true);
+    expect(mockCalls.map((c) => `${c.method} ${c.url}`)).toEqual([
+      'PUT userData/7',
+      'DELETE buyCrypto/42/amlCheck',
+      'POST kyc/admin/log',
+    ]);
+    const userDataCall = mockCalls[0];
+    expect(userDataCall.data.phoneCallStatus).toBe('Completed');
+    expect(userDataCall.data.phoneCallIpCountryCheckDate).toBeDefined();
+  });
+
+  it('does not touch the transaction without an AmlCheck action', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const res = await result.current.saveCallOutcome(TX_CONTEXT, CallOutcome.UNAVAILABLE, {
+      signature: 'JR',
+      comment: 'no answer',
+    });
+
+    expect(res.success).toBe(true);
+    expect(mockCalls.map((c) => `${c.method} ${c.url}`)).toEqual(['PUT userData/7', 'POST kyc/admin/log']);
+    expect(mockCalls[0].data.phoneCallIpCountryCheckDate).toBeUndefined();
+  });
+});

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -38,10 +38,12 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
   const canSubmit = !!signature && !!outcome && !!comment.trim() && !isSaving;
 
   // Some queue reasons (e.g. ManualCheckIpCountryPhone) are excluded from the AML recheck cron, so a
-  // completed call must release the transaction explicitly. Default to Pass on Completed, overridable.
+  // completed call must act on the transaction explicitly. Default to Reset (not Pass): it clears
+  // amlCheck + amlReason so the cron re-runs the FULL AML check, which only passes the tx if no
+  // other errors remain. Overridable.
   function handleOutcomeChange(value: CallOutcome | '') {
     setOutcome(value);
-    if (hasTx) setAmlAction(value === CallOutcome.COMPLETED ? 'Pass' : '');
+    if (hasTx) setAmlAction(value === CallOutcome.COMPLETED ? 'Reset' : '');
   }
 
   async function handleSubmit() {

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -34,8 +34,15 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
   }, [clerks]);
 
   const hasTx = context.txId != null && context.sourceType != null;
-  const showAmlCheck = hasTx && outcome !== CallOutcome.COMPLETED;
+  const showAmlCheck = hasTx;
   const canSubmit = !!signature && !!outcome && !!comment.trim() && !isSaving;
+
+  // Some queue reasons (e.g. ManualCheckIpCountryPhone) are excluded from the AML recheck cron, so a
+  // completed call must release the transaction explicitly. Default to Pass on Completed, overridable.
+  function handleOutcomeChange(value: CallOutcome | '') {
+    setOutcome(value);
+    if (hasTx) setAmlAction(value === CallOutcome.COMPLETED ? 'Pass' : '');
+  }
 
   async function handleSubmit() {
     if (!outcome || !signature || !comment.trim()) return;
@@ -75,7 +82,7 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
           <select
             className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
             value={outcome}
-            onChange={(e) => setOutcome(e.target.value as CallOutcome | '')}
+            onChange={(e) => handleOutcomeChange(e.target.value as CallOutcome | '')}
           >
             <option value="">—</option>
             {availableOutcomes.map((o) => (

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -931,7 +931,30 @@ export function useCompliance() {
     const tx = context.txId != null && context.sourceType ? { id: context.txId, sourceType: context.sourceType } : null;
     const results: KycLogResult[] = [];
 
-    // 1) Transaction update (if applicable)
+    // 1) UserData update (phoneCallStatus + check date on completion). Must run BEFORE the
+    // transaction step: a reset transaction is re-evaluated from scratch by the AML cron, so the
+    // check date has to be visible by then or the tx re-pends into its (possibly recheck-blocked)
+    // queue reason and gets stuck again.
+    const phoneStatus = callOutcomeToPhoneStatus[outcome];
+    const skipUserData = outcome === CallOutcome.REPEAT && context.queue === CallQueue.UNAVAILABLE_SUSPICIOUS;
+    if (phoneStatus && !skipUserData) {
+      try {
+        const udData: Record<string, unknown> = { phoneCallStatus: phoneStatus };
+        results.push({ table: 'userData', column: 'phoneCallStatus', value: phoneStatus });
+        if (outcome === CallOutcome.COMPLETED) {
+          const checkDateField = checkDateFieldForQueue(context.queue);
+          const checkDateValue = new Date().toISOString();
+          udData[checkDateField] = checkDateValue;
+          results.push({ table: 'userData', column: checkDateField, value: checkDateValue });
+        }
+        await updateUserData(context.userDataId, udData);
+        completedSteps.push('userData');
+      } catch (e) {
+        return fail('userData', e);
+      }
+    }
+
+    // 2) Transaction update (if applicable)
     try {
       if (tx && options.amlAction) {
         const signature = options.signature.trim();
@@ -960,26 +983,6 @@ export function useCompliance() {
       }
     } catch (e) {
       return fail('transaction', e);
-    }
-
-    // 2) UserData update (phoneCallStatus + check date on completion)
-    const phoneStatus = callOutcomeToPhoneStatus[outcome];
-    const skipUserData = outcome === CallOutcome.REPEAT && context.queue === CallQueue.UNAVAILABLE_SUSPICIOUS;
-    if (phoneStatus && !skipUserData) {
-      try {
-        const udData: Record<string, unknown> = { phoneCallStatus: phoneStatus };
-        results.push({ table: 'userData', column: 'phoneCallStatus', value: phoneStatus });
-        if (outcome === CallOutcome.COMPLETED) {
-          const checkDateField = checkDateFieldForQueue(context.queue);
-          const checkDateValue = new Date().toISOString();
-          udData[checkDateField] = checkDateValue;
-          results.push({ table: 'userData', column: checkDateField, value: checkDateValue });
-        }
-        await updateUserData(context.userDataId, udData);
-        completedSteps.push('userData');
-      } catch (e) {
-        return fail('userData', e);
-      }
     }
 
     // 3) KYC log entry (always)


### PR DESCRIPTION
## Problem

Saving a call-queue outcome with **Completed** stores the comment and the userData phone-call fields, but the pending transaction is never touched. The AmlCheck action selector is hidden exactly when the outcome is Completed:

```ts
const showAmlCheck = hasTx && outcome !== CallOutcome.COMPLETED;
```

so `saveCallOutcome` skips the transaction step entirely and the payment stays on `amlCheck = Pending`.

For `ManualCheckIpCountryPhone` this is a dead end: the reason is part of `BlockAmlReasons` in the API, so the AML recheck cron never picks the pending transaction up again. Setting the userData check date alone has no effect there. This used to work in the Google-Sheet process; since the sheet access was removed, the tool is the only path.

## Fix

- Show the AmlCheck action for transaction-based queue items on all outcomes.
- When the outcome is set to **Completed**, default the action to **Reset** (per review: not Pass). Reset clears `amlCheck` + `amlReason` via `DELETE :id/amlCheck`, so the AML cron re-runs the **full** AML check: with the check date now set the phone error is gone, and the tx only passes if no other errors remain. Overridable via the selector.
- Reorder `saveCallOutcome` to write the **userData update before the transaction step**. A reset transaction is re-evaluated from scratch by the cron; if the check date were written after the reset, the cron could re-pend the tx into its recheck-blocked reason in the gap and it would be stuck again.

## Tests

- Component test `call-queue-outcome-form.test.tsx`: action offered for tx items, Reset default on Completed, override, reset on other outcomes, no action for user-based queue items.
- Hook test `compliance-call-outcome.hook.test.ts`: userData (incl. queue-specific check date, e.g. `phoneCallIpCountryCheckDate`) is written before the transaction reset; no transaction call without an action.
- `npm test`: 62 suites / 610 tests green, `npm run lint` clean on the touched files.