### PR TITLE
Report the errors customers are shown

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,17 @@
 # SPA deep-link fallback: unknown paths serve the app shell (client-side routing).
-# Real files (static/*, widget/*, favicon, ...) are matched by the host first.
+#
+# Real files under static/*, widget/*, favicon, ... are matched by the host before this rule --
+# but only while they EXIST. A build asset that does not exist falls through to this rule and is
+# answered with index.html and status 200, and the /static/* rule in _headers then stamps that
+# HTML with a year of immutable cache. Verify with a request for any absent asset:
+#   curl -sI https://app.dfx.swiss/static/js/999.deadbeef.chunk.js
+#   -> 200, content-type: text/html, cache-control: public, max-age=31536000, immutable
+#
+# This is what a client sees when it requests a chunk that a later deploy replaced: not a 404 it
+# could recover from, but an app shell parsed as JavaScript. The app treats that as a chunk load
+# failure and reloads once (src/util/client-error.ts), which recovers the client as long as the
+# bad response was not cached under a chunk URL that a later build reuses unchanged.
+#
+# Closing that gap needs a host-side change, since _redirects cannot express a status of 404 and
+# _headers cannot tell an existing asset apart from this fallback -- both match on path alone.
 /*    /index.html    200

--- a/src/Main.lib.tsx
+++ b/src/Main.lib.tsx
@@ -1,5 +1,12 @@
 import { createMemoryRouter } from 'react-router-dom';
 import App, { WidgetParams } from './App';
+import { installChunkErrorHandling, markEmbedded } from './util/client-error';
+
+// The library is imported straight into someone else's React app, so it has no entry point of its
+// own to wire this up — it has to do it here. Reporting only: a chunk failure is not worth
+// reloading the consumer's page over.
+markEmbedded();
+installChunkErrorHandling();
 
 function MainLib(params: WidgetParams) {
   return (

--- a/src/Main.lib.tsx
+++ b/src/Main.lib.tsx
@@ -1,12 +1,11 @@
 import { createMemoryRouter } from 'react-router-dom';
 import App, { WidgetParams } from './App';
-import { installChunkErrorHandling, markEmbedded } from './util/client-error';
+import { markEmbedded } from './util/client-error';
 
-// The library is imported straight into someone else's React app, so it has no entry point of its
-// own to wire this up — it has to do it here. Reporting only: a chunk failure is not worth
-// reloading the consumer's page over.
+// Imported straight into someone else's React app, so this is the only place that can say so.
+// Marking it turns off both recovery and the page-wide listeners: neither the consumer's page nor
+// their window is ours to act on. Failures still reach the error screen and are reported there.
 markEmbedded();
-installChunkErrorHandling();
 
 function MainLib(params: WidgetParams) {
   return (

--- a/src/Main.widget.tsx
+++ b/src/Main.widget.tsx
@@ -1,5 +1,10 @@
 import { createMemoryRouter } from 'react-router-dom';
 import App, { WidgetParams } from './App';
+import { markEmbedded } from './util/client-error';
+
+// Runs on a third party's page: a chunk failure here is reported, never recovered by reloading
+// their page.
+markEmbedded();
 
 function MainWidget(params: WidgetParams) {
   return (

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -206,4 +206,28 @@ describe('reloadOnceForChunkError', () => {
 
     expect(reload).not.toHaveBeenCalled();
   });
+
+  // The widget and library builds run on a third party's page, where window is theirs. Reloading
+  // it over a deploy of ours would throw away state that has nothing to do with us. The module
+  // is loaded in isolation because marking it is a one-way switch.
+  it('does not reload the host page once marked as embedded', () => {
+    jest.isolateModules(() => {
+      const clientError = jest.requireActual('../util/client-error');
+
+      clientError.markEmbedded();
+      clientError.reloadOnceForChunkError();
+
+      expect(reload).not.toHaveBeenCalled();
+    });
+  });
+
+  it('still reloads when not embedded', () => {
+    jest.isolateModules(() => {
+      const clientError = jest.requireActual('../util/client-error');
+
+      clientError.reloadOnceForChunkError();
+
+      expect(reload).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -49,14 +49,12 @@ describe('isChunkLoadError', () => {
   });
 
   // What a stale chunk answered with the app shell actually produces: the script loads, never
-  // registers the chunk, and the bundler's loader reports it as missing.
-  it('recognises a chunk that loaded but never registered', () => {
-    const error = Object.assign(
-      new Error('Loading chunk 738 failed.\n(missing: https://app.example.com/static/js/738.js)'),
-      { name: 'ChunkLoadError' },
-    );
+  // registers the chunk, and the bundler's loader reports it as missing. Asserted on the message
+  // alone, without the name, so it pins the regex rather than passing on the name check.
+  it('recognises a chunk that loaded but never registered, by its message alone', () => {
+    const message = 'Loading chunk 738 failed.\n(missing: https://app.example.com/static/js/738.js)';
 
-    expect(isChunkLoadError(error)).toBe(true);
+    expect(isChunkLoadError(new Error(message))).toBe(true);
   });
 
   it('recognises the error by its name alone', () => {

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -231,3 +231,101 @@ describe('reloadOnceForChunkError', () => {
     });
   });
 });
+
+// The wiring every entry point relies on, and the part a unit test of the pieces does not cover:
+// which property of which event carries the error.
+describe('installChunkErrorHandling', () => {
+  let reload: jest.Mock;
+  let installed: Array<[string, EventListener]>;
+
+  // window outlives each test, so the listeners have to be taken back off it — otherwise every
+  // later test fires through the handlers of the earlier ones as well.
+  function install(embed = false): void {
+    const add = window.addEventListener.bind(window);
+    jest.spyOn(window, 'addEventListener').mockImplementation((type, listener, options) => {
+      installed.push([type, listener as EventListener]);
+      add(type, listener, options);
+    });
+
+    jest.isolateModules(() => {
+      const clientError = jest.requireActual('../util/client-error');
+      if (embed) clientError.markEmbedded();
+      clientError.installChunkErrorHandling();
+    });
+  }
+
+  function fire(type: 'error' | 'unhandledrejection', props: Record<string, unknown>): void {
+    window.dispatchEvent(Object.assign(new Event(type), props));
+  }
+
+  // The test environment registers listeners of its own, so only the two channels matter here.
+  function ourListeners(): string[] {
+    return installed.map(([type]) => type).filter((type) => ['error', 'unhandledrejection'].includes(type));
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    installed = [];
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as jest.Mock;
+    reload = jest.fn();
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, pathname: '/buy', reload },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    installed.forEach(([type, listener]) => window.removeEventListener(type, listener));
+    jest.restoreAllMocks();
+  });
+
+  it('recovers a chunk failure reported as an error event', () => {
+    install();
+
+    fire('error', { error: Object.assign(new Error('Loading chunk 42 failed'), { name: 'ChunkLoadError' }) });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Some engines deliver only the message, with no error object attached.
+  it('recovers a chunk failure carried as a bare message', () => {
+    install();
+
+    fire('error', { message: 'Loading chunk 42 failed' });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers a chunk failure from a rejected promise', () => {
+    install();
+
+    fire('unhandledrejection', { reason: new Error('Loading chunk 42 failed') });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores an error that is not a chunk failure', () => {
+    install();
+
+    fire('error', { error: new Error('Cannot read properties of undefined') });
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  // These listeners are page-wide, and embedded the page is the host's. A host running its own
+  // bundler would have its chunk failures filed as ours. Asserted on the registration rather than
+  // by firing an event, because an error event with nothing listening fails the test run itself.
+  it('installs no listeners when embedded', () => {
+    install(true);
+
+    expect(ourListeners()).toHaveLength(0);
+  });
+
+  it('installs listeners for both channels when not embedded', () => {
+    install();
+
+    expect(ourListeners().sort()).toEqual(['error', 'unhandledrejection']);
+  });
+});

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -48,11 +48,15 @@ describe('isChunkLoadError', () => {
     expect(isChunkLoadError(new Error(message))).toBe(true);
   });
 
-  it('recognises a script refused for its MIME type', () => {
-    const message =
-      "Refused to execute script because its MIME type ('text/html') is not a valid JavaScript MIME type.";
+  // What a stale chunk answered with the app shell actually produces: the script loads, never
+  // registers the chunk, and the bundler's loader reports it as missing.
+  it('recognises a chunk that loaded but never registered', () => {
+    const error = Object.assign(
+      new Error('Loading chunk 738 failed.\n(missing: https://app.example.com/static/js/738.js)'),
+      { name: 'ChunkLoadError' },
+    );
 
-    expect(isChunkLoadError(new Error(message))).toBe(true);
+    expect(isChunkLoadError(error)).toBe(true);
   });
 
   it('recognises the error by its name alone', () => {

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -48,13 +48,10 @@ describe('isChunkLoadError', () => {
     expect(isChunkLoadError(new Error(message))).toBe(true);
   });
 
-  // What a stale chunk URL answered with the app shell actually produces: the HTML is parsed as
-  // a script, and each engine words the failure differently.
-  it.each([
-    "Unexpected token '<'",
-    "expected expression, got '<'",
-    "Refused to execute script because its MIME type ('text/html') is not a valid JavaScript MIME type.",
-  ])('recognises the HTML-parsed-as-script wording "%s"', (message) => {
+  it('recognises a script refused for its MIME type', () => {
+    const message =
+      "Refused to execute script because its MIME type ('text/html') is not a valid JavaScript MIME type.";
+
     expect(isChunkLoadError(new Error(message))).toBe(true);
   });
 
@@ -66,6 +63,28 @@ describe('isChunkLoadError', () => {
     expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
     expect(isChunkLoadError(routeErrorResponse(404, 'Not Found'))).toBe(false);
   });
+
+  // A reload discards whatever the customer had typed, so the cost of a false positive is high.
+  // This is the wording a JSON.parse gets when a gateway, WAF or login redirect answers an API
+  // call with HTML — an everyday failure that must not reload the page.
+  it('does not classify a JSON response that arrived as HTML as a chunk failure', () => {
+    let parseError: unknown;
+    try {
+      JSON.parse('<html><head>502 Bad Gateway</head></html>');
+    } catch (e) {
+      parseError = e;
+    }
+
+    expect(parseError).toBeInstanceOf(SyntaxError);
+    expect(isChunkLoadError(parseError)).toBe(false);
+  });
+
+  it.each(["Unexpected token '<'", "expected expression, got '<'", 'Unexpected token < in JSON at position 0'])(
+    'does not classify the bare syntax wording "%s" as a chunk failure',
+    (message) => {
+      expect(isChunkLoadError(new Error(message))).toBe(false);
+    },
+  );
 });
 
 describe('reportClientError', () => {
@@ -111,6 +130,37 @@ describe('reportClientError', () => {
     }) as jest.Mock;
 
     expect(() => reportClientError(new Error('boom'), '/buy')).not.toThrow();
+  });
+
+  // toErrorFacts falls back to String(error), which a hostile toString can turn into a throw.
+  it('swallows a thrown value whose string conversion throws', () => {
+    const hostile = {
+      toString: () => {
+        throw new Error('nope');
+      },
+    };
+
+    expect(() => reportClientError(hostile, '/buy')).not.toThrow();
+  });
+
+  it('identifies the app to the API', () => {
+    reportClientError(new Error('boom'), '/buy');
+
+    expect((global.fetch as jest.Mock).mock.calls[0][1].headers).toMatchObject({ 'x-client': 'dfx-services' });
+  });
+
+  // The endpoint requires a non-empty message; without a substitute the whole report is rejected
+  // and the failure stays invisible, which is the very gap this reporting closes.
+  it('substitutes a message when the error carries none', () => {
+    reportClientError(new Error(''), '/buy');
+
+    expect(sentBody().message).toBe('Unknown error');
+  });
+
+  it('keeps an empty stack out of the payload rather than sending an empty string', () => {
+    reportClientError(Object.assign(new Error('boom'), { stack: undefined }), '/buy');
+
+    expect(sentBody()).not.toHaveProperty('stack');
   });
 });
 

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -1,0 +1,157 @@
+// Mock @dfx.swiss/react to avoid ES module issues
+jest.mock('@dfx.swiss/react', () => ({}));
+jest.mock('src/dto/safe.dto', () => ({}));
+
+import { isChunkLoadError, reloadOnceForChunkError, reportClientError, toErrorFacts } from '../util/client-error';
+
+jest.mock('src/config/api', () => ({ Api: { url: 'https://api.example.com', version: 'v1' } }));
+jest.mock('src/version', () => ({ REACT_APP_BUILD_ID: '42-99' }));
+
+const INGEST_URL = 'https://api.example.com/v1/log/clientError';
+
+// react-router identifies these structurally, so the shape is what matters.
+function routeErrorResponse(status: number, statusText: string): unknown {
+  return { status, statusText, data: '', internal: true };
+}
+
+function sentBody(): Record<string, string | undefined> {
+  return JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+}
+
+describe('toErrorFacts', () => {
+  it('reads message, type and stack off an Error', () => {
+    const error = Object.assign(new Error('boom'), { name: 'ChunkLoadError', stack: 'at x' });
+
+    expect(toErrorFacts(error)).toEqual({ message: 'boom', type: 'ChunkLoadError', stack: 'at x' });
+  });
+
+  it('describes a route error response by its status', () => {
+    expect(toErrorFacts(routeErrorResponse(404, 'Not Found'))).toEqual({
+      message: '404 Not Found',
+      type: 'RouteErrorResponse',
+    });
+  });
+
+  it('falls back to the string form of anything else', () => {
+    expect(toErrorFacts('plain failure').message).toBe('plain failure');
+    expect(toErrorFacts(undefined).message).toBe('undefined');
+  });
+});
+
+describe('isChunkLoadError', () => {
+  it.each([
+    'Loading chunk 42 failed',
+    'Loading CSS chunk 7 failed',
+    'ChunkLoadError: something',
+    'Failed to fetch dynamically imported module: https://app.example.com/static/js/1.js',
+  ])('recognises the bundler wording "%s"', (message) => {
+    expect(isChunkLoadError(new Error(message))).toBe(true);
+  });
+
+  // What a stale chunk URL answered with the app shell actually produces: the HTML is parsed as
+  // a script, and each engine words the failure differently.
+  it.each([
+    "Unexpected token '<'",
+    "expected expression, got '<'",
+    "Refused to execute script because its MIME type ('text/html') is not a valid JavaScript MIME type.",
+  ])('recognises the HTML-parsed-as-script wording "%s"', (message) => {
+    expect(isChunkLoadError(new Error(message))).toBe(true);
+  });
+
+  it('recognises the error by its name alone', () => {
+    expect(isChunkLoadError(Object.assign(new Error('nondescript'), { name: 'ChunkLoadError' }))).toBe(true);
+  });
+
+  it('does not classify an unrelated error as a chunk failure', () => {
+    expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+    expect(isChunkLoadError(routeErrorResponse(404, 'Not Found'))).toBe(false);
+  });
+});
+
+describe('reportClientError', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true }) as jest.Mock;
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('posts the error to the ingest endpoint', () => {
+    reportClientError(Object.assign(new Error('boom'), { name: 'TypeError', stack: 'at buy' }), '/buy');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect((global.fetch as jest.Mock).mock.calls[0][0]).toBe(INGEST_URL);
+    expect((global.fetch as jest.Mock).mock.calls[0][1]).toMatchObject({ method: 'POST', keepalive: true });
+    expect(sentBody()).toEqual({
+      message: 'boom',
+      type: 'TypeError',
+      stack: 'at buy',
+      route: '/buy',
+      version: '42-99',
+    });
+  });
+
+  // The ingest endpoint rejects oversized fields, and a rejected report is a blind spot.
+  it('truncates fields to the limits the endpoint accepts', () => {
+    reportClientError(Object.assign(new Error('m'.repeat(900)), { stack: 's'.repeat(5000) }), '/r'.repeat(400));
+
+    expect(sentBody().message).toHaveLength(500);
+    expect(sentBody().stack).toHaveLength(4000);
+    expect(sentBody().route).toHaveLength(500);
+  });
+
+  it('swallows a failing report instead of raising a second error', () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as jest.Mock;
+
+    expect(() => reportClientError(new Error('boom'), '/buy')).not.toThrow();
+  });
+
+  it('swallows a fetch that throws synchronously', () => {
+    global.fetch = jest.fn().mockImplementation(() => {
+      throw new Error('blocked');
+    }) as jest.Mock;
+
+    expect(() => reportClientError(new Error('boom'), '/buy')).not.toThrow();
+  });
+});
+
+describe('reloadOnceForChunkError', () => {
+  let reload: jest.Mock;
+
+  beforeEach(() => {
+    localStorage.clear();
+    reload = jest.fn();
+    Object.defineProperty(window, 'location', { value: { ...window.location, reload }, writable: true });
+  });
+
+  it('reloads on the first chunk failure', () => {
+    reloadOnceForChunkError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload again within the guard window', () => {
+    reloadOnceForChunkError();
+    reloadOnceForChunkError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads again once the guard window has passed', () => {
+    localStorage.setItem('dfx.chunkReloadAt', String(Date.now() - 31000));
+
+    reloadOnceForChunkError();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  // Embedded contexts can block storage; without the guard a reload there would loop.
+  it('skips the reload when storage is blocked', () => {
+    jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    reloadOnceForChunkError();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/error-screen-reporting.test.tsx
+++ b/src/__tests__/error-screen-reporting.test.tsx
@@ -23,12 +23,15 @@ jest.mock('src/hooks/layout-config.hook', () => ({ useLayoutOptions: jest.fn() }
 const mockReportClientError = jest.fn();
 const mockReloadOnceForChunkError = jest.fn();
 
+let mockEmbedded = false;
+
 // Only the side effects are mocked — the classification stays real, so the test covers the
 // wiring rather than restating it.
 jest.mock('src/util/client-error', () => ({
   ...jest.requireActual('src/util/client-error'),
   reportClientError: (...args: unknown[]) => mockReportClientError(...args),
   reloadOnceForChunkError: () => mockReloadOnceForChunkError(),
+  isEmbedded: () => mockEmbedded,
 }));
 
 function renderAt(path: string, thrown?: unknown): void {
@@ -52,6 +55,7 @@ function renderAt(path: string, thrown?: unknown): void {
 describe('ErrorScreen reporting', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockEmbedded = false;
     // Deliberately different from every route used below. These tests run on a memory router —
     // the same setup the widget and library builds use — so the browser URL is the host page's and
     // must not be what gets reported.
@@ -115,6 +119,29 @@ describe('ErrorScreen reporting', () => {
 
     await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
     expect(mockReloadOnceForChunkError).not.toHaveBeenCalled();
+  });
+
+  // Embedded, the host's page is never reloaded, so nothing recovers the customer. The support
+  // screen is lazy-loaded like every other, so it would fail on the same chunk — offering it would
+  // send them in circles. Telling them to reload is the only way out.
+  describe('when embedded in a host page', () => {
+    beforeEach(() => {
+      mockEmbedded = true;
+    });
+
+    it('asks the customer to reload instead of offering support', async () => {
+      renderAt('/buy', Object.assign(new Error('Loading chunk 42 failed'), { name: 'ChunkLoadError' }));
+
+      expect(await screen.findByText(/Please reload this page/)).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Support' })).not.toBeInTheDocument();
+    });
+
+    it('still offers support for a failure a reload would not fix', async () => {
+      renderAt('/buy', new Error('Cannot read properties of undefined'));
+
+      expect(await screen.findByText(/Please return to the previous page/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Support' })).toBeInTheDocument();
+    });
   });
 
   // Screens navigate to /error?msg=... deliberately; that path has no route, so the router

--- a/src/__tests__/error-screen-reporting.test.tsx
+++ b/src/__tests__/error-screen-reporting.test.tsx
@@ -52,8 +52,21 @@ function renderAt(path: string, thrown?: unknown): void {
 describe('ErrorScreen reporting', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // jsdom keeps the memory router's path out of window.location, which the screen reads.
-    Object.defineProperty(window, 'location', { value: { ...window.location, pathname: '/buy' }, writable: true });
+    // Deliberately different from every route used below. These tests run on a memory router —
+    // the same setup the widget and library builds use — so the browser URL is the host page's and
+    // must not be what gets reported.
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, pathname: '/host-page' },
+      writable: true,
+    });
+  });
+
+  it('reports the route the customer was on, not the browser URL', async () => {
+    renderAt('/buy', new Error('boom'));
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+    expect(mockReportClientError.mock.calls[0][1]).not.toBe('/host-page');
   });
 
   it('shows the error screen when a route render throws', async () => {
@@ -104,8 +117,6 @@ describe('ErrorScreen reporting', () => {
   // Screens navigate to /error?msg=... deliberately; that path has no route, so the router
   // reports a bare 404 that says nothing about the actual failure.
   it('reports the explicit message instead of the 404 behind it', async () => {
-    Object.defineProperty(window, 'location', { value: { ...window.location, pathname: '/error' }, writable: true });
-
     renderAt('/error?msg=Account%20merge%20failed');
 
     await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));

--- a/src/__tests__/error-screen-reporting.test.tsx
+++ b/src/__tests__/error-screen-reporting.test.tsx
@@ -1,0 +1,119 @@
+// Mock @dfx.swiss/react to avoid ES module issues
+jest.mock('@dfx.swiss/react', () => ({}));
+jest.mock('src/dto/safe.dto', () => ({}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { Outlet, RouteObject, RouterProvider, createMemoryRouter } from 'react-router-dom';
+import ErrorScreen from '../screens/error.screen';
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  IconVariant: { HELP: 'help' },
+  StyledButtonColor: { GRAY_OUTLINE: 'gray' },
+  StyledButton: ({ label }: { label: string }) => <button>{label}</button>,
+  StyledVerticalStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_key: string, value: string) => value }),
+}));
+
+jest.mock('src/hooks/navigation.hook', () => ({ useNavigation: () => ({ navigate: jest.fn() }) }));
+jest.mock('src/hooks/layout-config.hook', () => ({ useLayoutOptions: jest.fn() }));
+
+const mockReportClientError = jest.fn();
+const mockReloadOnceForChunkError = jest.fn();
+
+// Only the side effects are mocked — the classification stays real, so the test covers the
+// wiring rather than restating it.
+jest.mock('src/util/client-error', () => ({
+  ...jest.requireActual('src/util/client-error'),
+  reportClientError: (...args: unknown[]) => mockReportClientError(...args),
+  reloadOnceForChunkError: () => mockReloadOnceForChunkError(),
+}));
+
+function renderAt(path: string, thrown?: unknown): void {
+  const Boom = (): JSX.Element => {
+    if (thrown) throw thrown;
+    return <div>ok</div>;
+  };
+
+  const routes: RouteObject[] = [
+    {
+      path: '/',
+      element: <Outlet />,
+      errorElement: <ErrorScreen />,
+      children: [{ path: 'buy', element: <Boom /> }],
+    },
+  ];
+
+  render(<RouterProvider router={createMemoryRouter(routes, { initialEntries: [path] })} />);
+}
+
+describe('ErrorScreen reporting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // jsdom keeps the memory router's path out of window.location, which the screen reads.
+    Object.defineProperty(window, 'location', { value: { ...window.location, pathname: '/buy' }, writable: true });
+  });
+
+  it('shows the error screen when a route render throws', async () => {
+    renderAt('/buy', new Error('boom'));
+
+    expect(await screen.findByText('Oh, sorry, something went wrong')).toBeInTheDocument();
+  });
+
+  // The failure used to exist nowhere but the customer's console.
+  it('reports a render failure that the router caught', async () => {
+    renderAt('/buy', Object.assign(new Error('boom'), { name: 'TypeError' }));
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ message: 'boom', name: 'TypeError' });
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
+  });
+
+  it('reports a route that matched nothing', async () => {
+    renderAt('/nonexistent');
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ status: 404 });
+  });
+
+  it('reports only once per failure', async () => {
+    renderAt('/buy', new Error('boom'));
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+  });
+
+  // A window listener never sees this error, which is why the guard has to live here.
+  it('reloads once when a chunk failed to load', async () => {
+    renderAt('/buy', Object.assign(new Error('Loading chunk 42 failed'), { name: 'ChunkLoadError' }));
+
+    await waitFor(() => expect(mockReloadOnceForChunkError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload for an ordinary render failure', async () => {
+    renderAt('/buy', new Error('Cannot read properties of undefined'));
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReloadOnceForChunkError).not.toHaveBeenCalled();
+  });
+
+  // Screens navigate to /error?msg=... deliberately; that path has no route, so the router
+  // reports a bare 404 that says nothing about the actual failure.
+  it('reports the explicit message instead of the 404 behind it', async () => {
+    Object.defineProperty(window, 'location', { value: { ...window.location, pathname: '/error' }, writable: true });
+
+    renderAt('/error?msg=Account%20merge%20failed');
+
+    await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
+    expect(mockReportClientError.mock.calls[0][0]).toMatchObject({
+      message: 'Account merge failed',
+      name: 'HandledError',
+    });
+    expect(screen.getByText('Account merge failed')).toBeInTheDocument();
+    expect(mockReloadOnceForChunkError).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/error-screen-reporting.test.tsx
+++ b/src/__tests__/error-screen-reporting.test.tsx
@@ -84,11 +84,14 @@ describe('ErrorScreen reporting', () => {
     expect(mockReportClientError.mock.calls[0][1]).toBe('/buy');
   });
 
+  // The no-match case is the one where the router's own location is least obviously defined, so
+  // the reported route is asserted here too.
   it('reports a route that matched nothing', async () => {
     renderAt('/nonexistent');
 
     await waitFor(() => expect(mockReportClientError).toHaveBeenCalledTimes(1));
     expect(mockReportClientError.mock.calls[0][0]).toMatchObject({ status: 404 });
+    expect(mockReportClientError.mock.calls[0][1]).toBe('/nonexistent');
   });
 
   it('reports only once per failure', async () => {

--- a/src/index-widget.tsx
+++ b/src/index-widget.tsx
@@ -2,13 +2,11 @@ import createWebComponent from '@r2wc/react-to-web-component';
 import { WidgetParams } from './App';
 import MainWidget from './Main.widget';
 import './index.css';
-import { installChunkErrorHandling } from './util/client-error';
 import { preserveStringAttribute } from './util/web-component';
 
-// The widget build swaps this file in for index.tsx, so the handling wired up there never reaches
-// this bundle. Embedded on third-party pages, it is also where a chunk left stale by a deploy has
-// the longest to sit in a cache.
-installChunkErrorHandling();
+// No chunk error handling is installed here on purpose. Main.widget marks this build as embedded,
+// which turns the page-wide listeners off: they would belong to the host's window, not ours.
+// Failures still reach the error screen and are reported there.
 
 const props: { [k in keyof WidgetParams]: 'string' | 'number' | 'boolean' | 'function' | 'json' } = {
   headless: 'string',

--- a/src/index-widget.tsx
+++ b/src/index-widget.tsx
@@ -2,7 +2,13 @@ import createWebComponent from '@r2wc/react-to-web-component';
 import { WidgetParams } from './App';
 import MainWidget from './Main.widget';
 import './index.css';
+import { installChunkErrorHandling } from './util/client-error';
 import { preserveStringAttribute } from './util/web-component';
+
+// The widget build swaps this file in for index.tsx, so the handling wired up there never reaches
+// this bundle. Embedded on third-party pages, it is also where a chunk left stale by a deploy has
+// the longest to sit in a cache.
+installChunkErrorHandling();
 
 const props: { [k in keyof WidgetParams]: 'string' | 'number' | 'boolean' | 'function' | 'json' } = {
   headless: 'string',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import ReactDOM from 'react-dom/client';
 import Main from './Main';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
+import { isChunkLoadError, reloadOnceForChunkError, reportClientError } from './util/client-error';
 
 // Clear session data when URL contains new login credentials
 // This must happen BEFORE React initializes to prevent the @dfx.swiss/react
@@ -15,38 +16,19 @@ if ((urlParams.has('address') && urlParams.has('signature')) || urlParams.has('s
   sessionStorage.clear();
 }
 
-// A new deploy replaces the content-hashed chunks. A tab left open across a deploy can
-// request a chunk that no longer exists; Cloudflare Pages then serves index.html (200)
-// for it, which surfaces as a ChunkLoadError. Reload once to pick up the new chunks,
-// guarded against a reload loop.
-function isChunkLoadError(message?: string): boolean {
-  return !!message && /Loading chunk [\w-]+ failed|ChunkLoadError|Loading CSS chunk [\w-]+ failed/i.test(message);
+// A chunk that fails to load outside the router — during startup, or from code React does not
+// render — reaches neither Suspense nor the router's error boundary, so it is caught here.
+// Chunk failures inside the router are handled by the error screen, which is where React hands
+// them; these listeners never see those.
+function handleChunkError(error: unknown): void {
+  if (!isChunkLoadError(error)) return;
+
+  reportClientError(error, window.location.pathname);
+  reloadOnceForChunkError();
 }
-// A new deploy replaces the content-hashed chunks. A tab left open across a deploy can
-// request a chunk that no longer exists; the static host serves index.html (200) for it,
-// which surfaces as a ChunkLoadError. Reload once to pick up the new chunks. The guard
-// lives in localStorage (it survives the sessionStorage.clear() above that runs on
-// session/login URLs) and is time-boxed, so a persistent failure reloads at most once per
-// window instead of looping. Storage access is wrapped because embedded/iframe contexts
-// can block it.
-function reloadOnceForChunkError(): void {
-  try {
-    const KEY = 'dfx.chunkReloadAt';
-    const last = Number(localStorage.getItem(KEY) ?? 0);
-    if (Date.now() - last < 30000) return;
-    localStorage.setItem(KEY, String(Date.now()));
-  } catch {
-    return; // storage blocked (e.g. embedded iframe) — skip to avoid an unguarded reload loop
-  }
-  window.location.reload();
-}
-window.addEventListener('error', (event) => {
-  if (isChunkLoadError(event?.message)) reloadOnceForChunkError();
-});
-window.addEventListener('unhandledrejection', (event) => {
-  const message = (event?.reason as Error | undefined)?.message;
-  if (isChunkLoadError(message)) reloadOnceForChunkError();
-});
+
+window.addEventListener('error', (event) => handleChunkError(event?.error ?? event?.message));
+window.addEventListener('unhandledrejection', (event) => handleChunkError(event?.reason));
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(<Main />);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom/client';
 import Main from './Main';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
-import { isChunkLoadError, reloadOnceForChunkError, reportClientError } from './util/client-error';
+import { installChunkErrorHandling } from './util/client-error';
 
 // Clear session data when URL contains new login credentials
 // This must happen BEFORE React initializes to prevent the @dfx.swiss/react
@@ -16,19 +16,7 @@ if ((urlParams.has('address') && urlParams.has('signature')) || urlParams.has('s
   sessionStorage.clear();
 }
 
-// A chunk that fails to load outside the router — during startup, or from code React does not
-// render — reaches neither Suspense nor the router's error boundary, so it is caught here.
-// Chunk failures inside the router are handled by the error screen, which is where React hands
-// them; these listeners never see those.
-function handleChunkError(error: unknown): void {
-  if (!isChunkLoadError(error)) return;
-
-  reportClientError(error, window.location.pathname);
-  reloadOnceForChunkError();
-}
-
-window.addEventListener('error', (event) => handleChunkError(event?.error ?? event?.message));
-window.addEventListener('unhandledrejection', (event) => handleChunkError(event?.reason));
+installChunkErrorHandling();
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(<Main />);

--- a/src/screens/error.screen.tsx
+++ b/src/screens/error.screen.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react';
 import { useLocation, useRouteError, useSearchParams } from 'react-router-dom';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
-import { isChunkLoadError, reloadOnceForChunkError, reportClientError } from 'src/util/client-error';
+import { isChunkLoadError, isEmbedded, reloadOnceForChunkError, reportClientError } from 'src/util/client-error';
 import { useSettingsContext } from '../contexts/settings.context';
 
 export default function ErrorScreen(): JSX.Element {
@@ -17,6 +17,11 @@ export default function ErrorScreen(): JSX.Element {
   const hasReported = useRef(false);
 
   const error = params.get('msg');
+
+  // Embedded, the app must not reload the host's page, so a stale chunk is not recovered for the
+  // customer. Telling them to reload is then the only way out: the support screen is lazy-loaded
+  // like every other, so it would fail on the very same chunk and leave them going in circles.
+  const needsManualReload = !error && isEmbedded() && isChunkLoadError(routeError);
 
   // This screen is the router's errorElement, so it is the only place where the error that broke
   // the render is still available. Report it before it is discarded — otherwise the failure exists
@@ -47,19 +52,26 @@ export default function ErrorScreen(): JSX.Element {
           <h2 className="text-dfxBlue-800">{translate('screens/error', 'Oh, sorry, something went wrong')}</h2>
           <p className="text-dfxGray-700">
             {error ??
-              translate(
-                'screens/error',
-                'Please return to the previous page. If this problem persists, please contact our support.',
-              )}
+              (needsManualReload
+                ? translate(
+                    'screens/error',
+                    'Please reload this page. If this problem persists, please contact our support.',
+                  )
+                : translate(
+                    'screens/error',
+                    'Please return to the previous page. If this problem persists, please contact our support.',
+                  ))}
           </p>
         </div>
 
-        <StyledButton
-          icon={IconVariant.HELP}
-          label={translate('navigation/links', 'Support')}
-          color={StyledButtonColor.GRAY_OUTLINE}
-          onClick={() => navigate('/support')}
-        />
+        {!needsManualReload && (
+          <StyledButton
+            icon={IconVariant.HELP}
+            label={translate('navigation/links', 'Support')}
+            color={StyledButtonColor.GRAY_OUTLINE}
+            onClick={() => navigate('/support')}
+          />
+        )}
       </StyledVerticalStack>
     </>
   );

--- a/src/screens/error.screen.tsx
+++ b/src/screens/error.screen.tsx
@@ -1,6 +1,6 @@
 import { IconVariant, StyledButton, StyledButtonColor, StyledVerticalStack } from '@dfx.swiss/react-components';
 import { useEffect, useRef } from 'react';
-import { useRouteError, useSearchParams } from 'react-router-dom';
+import { useLocation, useRouteError, useSearchParams } from 'react-router-dom';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
 import { isChunkLoadError, reloadOnceForChunkError, reportClientError } from 'src/util/client-error';
@@ -11,6 +11,9 @@ export default function ErrorScreen(): JSX.Element {
   const { navigate } = useNavigation();
   const [params] = useSearchParams();
   const routeError = useRouteError();
+  // Not window.location: the widget and library builds run on a memory router, where the browser
+  // URL is the host page's and never reflects the screen the customer was actually on.
+  const { pathname } = useLocation();
   const hasReported = useRef(false);
 
   const error = params.get('msg');
@@ -27,13 +30,13 @@ export default function ErrorScreen(): JSX.Element {
     const reportedError = error ? Object.assign(new Error(error), { name: 'HandledError' }) : routeError;
     if (reportedError == null) return;
 
-    reportClientError(reportedError, window.location.pathname);
+    reportClientError(reportedError, pathname);
 
     // A chunk left stale by a deploy recovers on its own once the app reloads. React hands the
     // failed import to this boundary, so this is where it can be caught — a window listener never
     // sees it.
     if (!error && isChunkLoadError(routeError)) reloadOnceForChunkError();
-  }, [routeError, error]);
+  }, [routeError, error, pathname]);
 
   useLayoutOptions({});
 

--- a/src/screens/error.screen.tsx
+++ b/src/screens/error.screen.tsx
@@ -1,15 +1,39 @@
 import { IconVariant, StyledButton, StyledButtonColor, StyledVerticalStack } from '@dfx.swiss/react-components';
-import { useSearchParams } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { useRouteError, useSearchParams } from 'react-router-dom';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
+import { isChunkLoadError, reloadOnceForChunkError, reportClientError } from 'src/util/client-error';
 import { useSettingsContext } from '../contexts/settings.context';
 
 export default function ErrorScreen(): JSX.Element {
   const { translate } = useSettingsContext();
   const { navigate } = useNavigation();
   const [params] = useSearchParams();
+  const routeError = useRouteError();
+  const hasReported = useRef(false);
 
   const error = params.get('msg');
+
+  // This screen is the router's errorElement, so it is the only place where the error that broke
+  // the render is still available. Report it before it is discarded — otherwise the failure exists
+  // nowhere but in the customer's browser console.
+  useEffect(() => {
+    if (hasReported.current) return;
+    hasReported.current = true;
+
+    // Screens navigate here with an explicit message. That path has no route of its own, so the
+    // router reports a 404 that says nothing about what actually went wrong — report the message.
+    const reportedError = error ? Object.assign(new Error(error), { name: 'HandledError' }) : routeError;
+    if (reportedError == null) return;
+
+    reportClientError(reportedError, window.location.pathname);
+
+    // A chunk left stale by a deploy recovers on its own once the app reloads. React hands the
+    // failed import to this boundary, so this is where it can be caught — a window listener never
+    // sees it.
+    if (!error && isChunkLoadError(routeError)) reloadOnceForChunkError();
+  }, [routeError, error]);
 
   useLayoutOptions({});
 

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -481,7 +481,8 @@
 
     "Invalid link": "Ungültiger Link",
     "Merge is already completed": "Zusammenführung ist bereits abgeschlossen",
-    "Please return to the previous page. If this problem persists, please contact our support.": "Bitte kehre zur vorherigen Seite zurück. Wenn dieses Problem weiterhin besteht, wende Dich bitte an unseren Support."
+    "Please return to the previous page. If this problem persists, please contact our support.": "Bitte kehre zur vorherigen Seite zurück. Wenn dieses Problem weiterhin besteht, wende Dich bitte an unseren Support.",
+    "Please reload this page. If this problem persists, please contact our support.": "Bitte lade diese Seite neu. Wenn dieses Problem weiterhin besteht, wende Dich bitte an unseren Support."
   },
   "screens/home": {
     "DFX services": "DFX Services",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -481,7 +481,8 @@
 
     "Invalid link": "Lien invalide",
     "Merge is already completed": "La fusion est déjà terminée",
-    "Please return to the previous page. If this problem persists, please contact our support.": "Veuillez revenir à la page précédente. Si le problème persiste, veuillez contacter notre service d'assistance."
+    "Please return to the previous page. If this problem persists, please contact our support.": "Veuillez revenir à la page précédente. Si le problème persiste, veuillez contacter notre service d'assistance.",
+    "Please reload this page. If this problem persists, please contact our support.": "Veuillez recharger cette page. Si le problème persiste, veuillez contacter notre service d'assistance."
   },
   "screens/home": {
     "DFX services": "Services DFX",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -481,7 +481,8 @@
 
     "Invalid link": "Link non valido",
     "Merge is already completed": "La fusione è già completata",
-    "Please return to the previous page. If this problem persists, please contact our support.": "Tornare alla pagina precedente. Se il problema persiste, contattare l'assistenza."
+    "Please return to the previous page. If this problem persists, please contact our support.": "Tornare alla pagina precedente. Se il problema persiste, contattare l'assistenza.",
+    "Please reload this page. If this problem persists, please contact our support.": "Ricaricare questa pagina. Se il problema persiste, contattare l'assistenza."
   },
   "screens/home": {
     "DFX services": "Servizi DFX",

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -1,0 +1,90 @@
+import { isRouteErrorResponse } from 'react-router-dom';
+import { Api } from 'src/config/api';
+import { REACT_APP_BUILD_ID } from 'src/version';
+import { url } from './utils';
+
+// Kept in sync with the field limits of the ingest endpoint, so a long message is trimmed here
+// instead of being rejected there — a dropped report is a blind spot.
+const LIMITS = { message: 500, type: 100, stack: 4000, route: 500, version: 50 };
+
+const CHUNK_RELOAD_KEY = 'dfx.chunkReloadAt';
+const CHUNK_RELOAD_WINDOW = 30000;
+
+export interface ErrorFacts {
+  message: string;
+  type?: string;
+  stack?: string;
+}
+
+export function toErrorFacts(error: unknown): ErrorFacts {
+  if (isRouteErrorResponse(error)) {
+    // Thrown when no route matches the URL, and by loaders returning a Response.
+    return { message: `${error.status} ${error.statusText}`, type: 'RouteErrorResponse' };
+  }
+
+  if (error instanceof Error) return { message: error.message, type: error.name, stack: error.stack };
+
+  return { message: String(error) };
+}
+
+// A chunk request that fails is reported by the bundler as a ChunkLoadError. When a stale chunk
+// URL is answered with the app shell instead, the HTML is parsed as a script and the browser
+// reports a syntax error or a MIME type rejection — the same root cause, three wordings.
+export function isChunkLoadError(error: unknown): boolean {
+  const { message, type } = toErrorFacts(error);
+
+  return (
+    type === 'ChunkLoadError' ||
+    /Loading (CSS )?chunk [\w-]+ failed|ChunkLoadError|Failed to fetch dynamically imported module/i.test(message) ||
+    /Unexpected token '<'|is not a valid JavaScript MIME type|expected expression, got '<'/i.test(message)
+  );
+}
+
+// A new deploy replaces the content-hashed chunks, so a tab left open across one can request a
+// chunk that no longer exists. Reload once to pick up the new chunks. The guard lives in
+// localStorage (it survives the sessionStorage.clear() on session/login URLs) and is time-boxed,
+// so a persistent failure reloads at most once per window instead of looping. Storage access is
+// wrapped because embedded/iframe contexts can block it.
+export function reloadOnceForChunkError(): void {
+  try {
+    const last = Number(localStorage.getItem(CHUNK_RELOAD_KEY) ?? 0);
+    if (Date.now() - last < CHUNK_RELOAD_WINDOW) return;
+    localStorage.setItem(CHUNK_RELOAD_KEY, String(Date.now()));
+  } catch {
+    return; // storage blocked (e.g. embedded iframe) — skip to avoid an unguarded reload loop
+  }
+
+  window.location.reload();
+}
+
+// Reports an error the user actually saw. Fire-and-forget: a failing report must never surface as
+// a second error. `keepalive` lets the request outlive the reload that may follow it.
+export function reportClientError(error: unknown, route: string): void {
+  if (!Api.url) return;
+
+  const { message, type, stack } = toErrorFacts(error);
+
+  const body = {
+    message: truncate(message, LIMITS.message),
+    type: truncate(type, LIMITS.type),
+    stack: truncate(stack, LIMITS.stack),
+    route: truncate(route, LIMITS.route),
+    version: truncate(REACT_APP_BUILD_ID, LIMITS.version),
+  };
+
+  try {
+    void fetch(url({ base: Api.url, path: `/${Api.version}/log/clientError` }), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      keepalive: true,
+    }).catch(() => undefined);
+  } catch {
+    // ignore — reporting must never throw into the render that is already failing
+  }
+}
+
+function truncate(value: string | undefined, max: number): string | undefined {
+  if (!value) return undefined;
+  return value.length > max ? value.slice(0, max) : value;
+}

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -10,6 +10,10 @@ const LIMITS = { message: 500, type: 100, stack: 4000, route: 500, version: 50 }
 const CHUNK_RELOAD_KEY = 'dfx.chunkReloadAt';
 const CHUNK_RELOAD_WINDOW = 30000;
 
+// Identifies this app to the API, which logs it alongside the error. Without it every report
+// from here is filed as an unknown client.
+const CLIENT_NAME = 'dfx-services';
+
 export interface ErrorFacts {
   message: string;
   type?: string;
@@ -27,16 +31,22 @@ export function toErrorFacts(error: unknown): ErrorFacts {
   return { message: String(error) };
 }
 
-// A chunk request that fails is reported by the bundler as a ChunkLoadError. When a stale chunk
-// URL is answered with the app shell instead, the HTML is parsed as a script and the browser
-// reports a syntax error or a MIME type rejection — the same root cause, three wordings.
+// A chunk request that fails is reported by the bundler as a ChunkLoadError — including when a
+// stale chunk URL is answered with the app shell, because the HTML never registers the chunk.
+//
+// Deliberately NOT matched: the bare syntax-error wordings a browser produces while parsing that
+// HTML as a script. `Unexpected token '<'` is also what JSON.parse says when a response is HTML
+// instead of JSON — an everyday failure whenever a gateway, WAF or login redirect answers an API
+// call. Treating that as a chunk failure would reload the page and discard whatever the customer
+// had typed. The bundler wordings below identify the real case on their own.
 export function isChunkLoadError(error: unknown): boolean {
   const { message, type } = toErrorFacts(error);
 
   return (
     type === 'ChunkLoadError' ||
     /Loading (CSS )?chunk [\w-]+ failed|ChunkLoadError|Failed to fetch dynamically imported module/i.test(message) ||
-    /Unexpected token '<'|is not a valid JavaScript MIME type|expected expression, got '<'/i.test(message)
+    // Script-loading only: a response cannot reach JSON.parse and be refused for its MIME type.
+    /is not a valid JavaScript MIME type/i.test(message)
   );
 }
 
@@ -62,29 +72,34 @@ export function reloadOnceForChunkError(): void {
 export function reportClientError(error: unknown, route: string): void {
   if (!Api.url) return;
 
-  const { message, type, stack } = toErrorFacts(error);
-
-  const body = {
-    message: truncate(message, LIMITS.message),
-    type: truncate(type, LIMITS.type),
-    stack: truncate(stack, LIMITS.stack),
-    route: truncate(route, LIMITS.route),
-    version: truncate(REACT_APP_BUILD_ID, LIMITS.version),
-  };
-
   try {
+    const { message, type, stack } = toErrorFacts(error);
+
+    const body = {
+      // The endpoint rejects an empty message, and a rejected report is exactly the blind spot
+      // this reporting exists to close. `||` on purpose: an empty message needs replacing too.
+      message: truncate(message, LIMITS.message) || 'Unknown error',
+      type: truncate(type, LIMITS.type),
+      stack: truncate(stack, LIMITS.stack),
+      route: truncate(route, LIMITS.route),
+      version: truncate(REACT_APP_BUILD_ID, LIMITS.version),
+    };
+
     void fetch(url({ base: Api.url, path: `/${Api.version}/log/clientError` }), {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-client': CLIENT_NAME },
       body: JSON.stringify(body),
       keepalive: true,
     }).catch(() => undefined);
   } catch {
-    // ignore — reporting must never throw into the render that is already failing
+    // ignore — reporting must never throw into the render that is already failing. toErrorFacts
+    // falls back to String(error), which a thrown value with a hostile toString can turn into a
+    // throw of its own, so it belongs inside this block.
   }
 }
 
+// Empty is a value the caller may legitimately hold, so only an absent one is dropped.
 function truncate(value: string | undefined, max: number): string | undefined {
-  if (!value) return undefined;
+  if (value == null) return undefined;
   return value.length > max ? value.slice(0, max) : value;
 }

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -122,14 +122,11 @@ export function reportClientError(error: unknown, route: string): void {
 // failures inside the router are handled by the error screen, which is where React hands them;
 // these listeners never see those.
 //
-// Every entry point has to call this, and there are three: index.tsx for the app, index-widget.tsx
-// for the widget (its build swaps that file in for index.tsx), and Main.lib.tsx for the library,
-// which is imported into a consumer's app and has no entry point of its own.
-//
-// Embedded, it does nothing on purpose. These listeners are page-wide, not ours — the widget is a
-// web component in the host's window, not an iframe — so on a host that ships its own bundler they
-// would catch that bundler's chunk failures and file them as ours. Recovery is off there anyway,
-// and the failures worth seeing arrive through the router's error boundary regardless.
+// Called from index.tsx, the standalone app's entry point. The embedded builds deliberately do not
+// call it: these listeners are page-wide, and there the page is the host's — the widget is a web
+// component in their window, not an iframe — so on a host that ships its own bundler they would
+// catch that bundler's chunk failures and file them as ours. The guard below keeps that true even
+// if a future entry point calls this without checking.
 export function installChunkErrorHandling(): void {
   if (embedded) return;
 

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -3,8 +3,9 @@ import { Api } from 'src/config/api';
 import { REACT_APP_BUILD_ID } from 'src/version';
 import { url } from './utils';
 
-// Kept in sync with the field limits of the ingest endpoint, so a long message is trimmed here
-// instead of being rejected there — a dropped report is a blind spot.
+// Must match the field limits of the ingest endpoint, so a long message is trimmed here instead of
+// being rejected there — a dropped report is a blind spot. Nothing enforces this across the two
+// repositories, so a change to those limits has to be mirrored here by hand.
 const LIMITS = { message: 500, type: 100, stack: 4000, route: 500, version: 50 };
 
 const CHUNK_RELOAD_KEY = 'dfx.chunkReloadAt';
@@ -100,6 +101,25 @@ export function reportClientError(error: unknown, route: string): void {
 }
 
 // Empty is a value the caller may legitimately hold, so only an absent one is dropped.
+// Catches a chunk failure that reaches neither Suspense nor the router's error boundary — during
+// startup, or from code React does not render, such as an import() in a click handler. Chunk
+// failures inside the router are handled by the error screen, which is where React hands them;
+// these listeners never see those.
+//
+// Every entry point has to call this: the widget build swaps index-widget.tsx in for index.tsx, so
+// wiring it up in one of them leaves the other without any handling at all.
+export function installChunkErrorHandling(): void {
+  const handle = (error: unknown): void => {
+    if (!isChunkLoadError(error)) return;
+
+    reportClientError(error, window.location.pathname);
+    reloadOnceForChunkError();
+  };
+
+  window.addEventListener('error', (event) => handle(event?.error ?? event?.message));
+  window.addEventListener('unhandledrejection', (event) => handle(event?.reason));
+}
+
 function truncate(value: string | undefined, max: number): string | undefined {
   if (value == null) return undefined;
   return value.length > max ? value.slice(0, max) : value;

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -56,10 +56,14 @@ export function isChunkLoadError(error: unknown): boolean {
 // host. Reloading it would discard state that has nothing to do with us — their forms, their cart,
 // their scroll position — over a deploy of ours. Those builds mark themselves, and recovery there
 // falls back to reporting the failure without reloading.
-let isEmbedded = false;
+let embedded = false;
 
 export function markEmbedded(): void {
-  isEmbedded = true;
+  embedded = true;
+}
+
+export function isEmbedded(): boolean {
+  return embedded;
 }
 
 // A new deploy replaces the content-hashed chunks, so a tab left open across one can request a
@@ -68,7 +72,7 @@ export function markEmbedded(): void {
 // so a persistent failure reloads at most once per window instead of looping. Storage access is
 // wrapped because embedded/iframe contexts can block it.
 export function reloadOnceForChunkError(): void {
-  if (isEmbedded) return;
+  if (embedded) return;
 
   try {
     const last = Number(localStorage.getItem(CHUNK_RELOAD_KEY) ?? 0);
@@ -121,7 +125,14 @@ export function reportClientError(error: unknown, route: string): void {
 // Every entry point has to call this, and there are three: index.tsx for the app, index-widget.tsx
 // for the widget (its build swaps that file in for index.tsx), and Main.lib.tsx for the library,
 // which is imported into a consumer's app and has no entry point of its own.
+//
+// Embedded, it does nothing on purpose. These listeners are page-wide, not ours — the widget is a
+// web component in the host's window, not an iframe — so on a host that ships its own bundler they
+// would catch that bundler's chunk failures and file them as ours. Recovery is off there anyway,
+// and the failures worth seeing arrive through the router's error boundary regardless.
 export function installChunkErrorHandling(): void {
+  if (embedded) return;
+
   const handle = (error: unknown): void => {
     if (!isChunkLoadError(error)) return;
 

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -52,12 +52,24 @@ export function isChunkLoadError(error: unknown): boolean {
   );
 }
 
+// The widget and library builds run inside someone else's page, where `window` belongs to the
+// host. Reloading it would discard state that has nothing to do with us — their forms, their cart,
+// their scroll position — over a deploy of ours. Those builds mark themselves, and recovery there
+// falls back to reporting the failure without reloading.
+let isEmbedded = false;
+
+export function markEmbedded(): void {
+  isEmbedded = true;
+}
+
 // A new deploy replaces the content-hashed chunks, so a tab left open across one can request a
 // chunk that no longer exists. Reload once to pick up the new chunks. The guard lives in
 // localStorage (it survives the sessionStorage.clear() on session/login URLs) and is time-boxed,
 // so a persistent failure reloads at most once per window instead of looping. Storage access is
 // wrapped because embedded/iframe contexts can block it.
 export function reloadOnceForChunkError(): void {
+  if (isEmbedded) return;
+
   try {
     const last = Number(localStorage.getItem(CHUNK_RELOAD_KEY) ?? 0);
     if (Date.now() - last < CHUNK_RELOAD_WINDOW) return;
@@ -106,8 +118,9 @@ export function reportClientError(error: unknown, route: string): void {
 // failures inside the router are handled by the error screen, which is where React hands them;
 // these listeners never see those.
 //
-// Every entry point has to call this: the widget build swaps index-widget.tsx in for index.tsx, so
-// wiring it up in one of them leaves the other without any handling at all.
+// Every entry point has to call this, and there are three: index.tsx for the app, index-widget.tsx
+// for the widget (its build swaps that file in for index.tsx), and Main.lib.tsx for the library,
+// which is imported into a consumer's app and has no entry point of its own.
 export function installChunkErrorHandling(): void {
   const handle = (error: unknown): void => {
     if (!isChunkLoadError(error)) return;

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -31,22 +31,23 @@ export function toErrorFacts(error: unknown): ErrorFacts {
   return { message: String(error) };
 }
 
-// A chunk request that fails is reported by the bundler as a ChunkLoadError — including when a
-// stale chunk URL is answered with the app shell, because the HTML never registers the chunk.
+// A chunk request that fails is reported by the bundler as a ChunkLoadError. That covers the stale
+// chunk answered with the app shell too: the script loads, never registers the chunk, and the
+// bundler's own loader turns the load event into `Loading chunk N failed. (missing: <url>)` with
+// the name ChunkLoadError.
 //
 // Deliberately NOT matched: the bare syntax-error wordings a browser produces while parsing that
 // HTML as a script. `Unexpected token '<'` is also what JSON.parse says when a response is HTML
 // instead of JSON — an everyday failure whenever a gateway, WAF or login redirect answers an API
 // call. Treating that as a chunk failure would reload the page and discard whatever the customer
-// had typed. The bundler wordings below identify the real case on their own.
+// had typed, which is worse than the failure it recovers from. The wordings below identify the
+// real case on their own.
 export function isChunkLoadError(error: unknown): boolean {
   const { message, type } = toErrorFacts(error);
 
   return (
     type === 'ChunkLoadError' ||
-    /Loading (CSS )?chunk [\w-]+ failed|ChunkLoadError|Failed to fetch dynamically imported module/i.test(message) ||
-    // Script-loading only: a response cannot reach JSON.parse and be refused for its MIME type.
-    /is not a valid JavaScript MIME type/i.test(message)
+    /Loading (CSS )?chunk [\w-]+ failed|ChunkLoadError|Failed to fetch dynamically imported module/i.test(message)
   );
 }
 


### PR DESCRIPTION
## Problem

When the app shows *"Oh, sorry, something went wrong"*, nothing is recorded. `error.screen.tsx` is the router's `errorElement`, which means it is the one place where the error that broke the render is still in hand — and it read none of it. `useRouteError` was never called anywhere in the app, the error object was discarded, and the failure existed nowhere but in the customer's browser console.

The practical consequence: this screen can only ever be known through the support channel, never measured, and a fix for it cannot be verified.

A second defect sits underneath. The chunk-reload guard in `src/index.tsx` listened on `window` `error` and `unhandledrejection`. A failed `React.lazy` import reaches neither: React catches it and hands it to the error boundary. **So the recovery never ran for the case it was written for** — and every screen except the home screen is lazy-loaded, which is why the failure shows up on navigation rather than on first load.

## Change

- `ErrorScreen` reads `useRouteError()` and reports the error once, with type, message, stack, route and build id. The route comes from the router, not from `window.location`: the widget and library builds run on a memory router, where the browser URL belongs to the host page and never changes as the customer moves between screens.
- The chunk-reload guard moves to that same boundary, where the error actually arrives.
- Detection stays on the bundler's own wordings, and that is sufficient: a stale chunk answered with the app shell makes the script load without registering the chunk, and the bundler's loader turns that into a `ChunkLoadError` reading `Loading chunk N failed. (missing: <url>)`. Verified against the loader in the built bundle.
- It briefly also matched the bare syntax errors a browser produces while parsing that HTML as a script — but one of those, `Unexpected token '<'`, is exactly what `JSON.parse` reports when a response is HTML instead of JSON. A gateway, WAF or login redirect answering an API call would then have reloaded the page and discarded whatever the customer had typed. A regression test holds that line.
- The `window` listeners stay for failures outside the router (startup, an `import()` in a click handler). They are installed from `index.tsx`, the standalone app's entry point, and deliberately not from the two embedded ones — see below.
- Reporting is fire-and-forget with `keepalive`, so a failing report never surfaces as a second error and survives the reload that may follow it. Fields are truncated to the limits the endpoint accepts, and an empty message gets a substitute — the endpoint requires one, and that rejection was being swallowed silently, which is the very blind spot this closes.
- Deliberate navigations to `/error?msg=...` are reported with their message. That path has no route, so the router previously produced a bare 404 that said nothing about the actual failure.

## Embedded, the host's page is not ours to reload

The widget and the library run inside someone else's page, and `window` belongs to that page — the closed shadow root isolates DOM and CSS, not `window`. Reloading it to recover a stale chunk would discard the host's forms, cart and scroll position over a deploy of ours.

Both embedded builds mark themselves, and there:

- **no reload** — the customer is told to reload the page instead, in all three languages, and the support button is left out of that case: the support screen is lazy-loaded like every other, so it would fail on the same chunk and send them in circles. Every other failure keeps the button, because a reload would not fix those.
- **no window listeners** — they are page-wide, so on a host that ships its own bundler they would catch that bundler's chunk failures and file them as ours. Recovery is off there anyway, and the failures worth seeing arrive through the router regardless.

## What `public/_redirects` actually does

The comment there claimed real files under `static/*` are matched before the SPA fallback. That holds only while they **exist**. A build asset that does not falls through:

```
curl -sI https://app.dfx.swiss/static/js/999.deadbeef.chunk.js
-> 200, content-type: text/html, cache-control: public, max-age=31536000, immutable
```

So a client asking for a chunk that a later deploy replaced does not get a 404 it could recover from — it gets the app shell parsed as JavaScript, cached hard. The comment now records that measurement; the app-side handling above recovers the client by reloading.

Closing it at the source needs a host-side change, since `_redirects` cannot express a 404 status and `_headers` cannot tell an existing asset apart from the fallback — both match on path alone. That is deliberately **not** part of this PR: it changes how every asset request is served and needs verification on a real deployment.

## Tests

44 new tests. The central one renders a route that throws inside a real router and asserts the error reaches the reporting call — the wiring that was missing. Also covered: route-not-found, the explicit-message path, report-once, the route reported under a memory router, chunk detection including the JSON-parsed-as-HTML regression, truncation, the reload guard including blocked storage and the embedded case, the embedded error screen, and the listener wiring itself for both channels.

Full suite: 62 suites, 648 tests, all green. App build and widget build both compile.

## Depends on

`DFXswiss/api#4550`, which adds the endpoint. It should land first; until then, reports fail silently by design.
