### PR TITLE
Answer a missing build asset with 404, not the app shell

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,17 @@ module.exports = {
     },
     // Story files are excluded from tsconfig.json, so the type-aware parser cannot resolve them.
     ignorePatterns: ['.eslintrc.js', '**/*.stories.tsx'],
+    overrides: [
+      {
+        // Cloudflare Pages Functions are deployed but never bundled into the app, so they sit
+        // outside tsconfig.json and the type-aware parser cannot resolve them. Linting them
+        // without type information still catches the failure that matters here: a syntax error in
+        // a file that reaches production without any other check ever reading it.
+        files: ['functions/**/*.js'],
+        parserOptions: { project: null },
+        env: { browser: true, node: false, jest: false },
+      },
+    ],
     rules: {
       '@typescript-eslint/interface-name-prefix': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,8 +20,8 @@ module.exports = {
       {
         // Cloudflare Pages Functions are deployed but never bundled into the app, so they sit
         // outside tsconfig.json and the type-aware parser cannot resolve them. Linting them
-        // without type information still catches the failure that matters here: a syntax error in
-        // a file that reaches production without any other check ever reading it.
+        // without type information still gives this path a static syntax check, which the build
+        // does not provide for files it never compiles.
         files: ['functions/**/*.js'],
         parserOptions: { project: null },
         env: { browser: true, node: false, jest: false },

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -12,19 +12,46 @@
 export async function onRequest(context) {
   const response = await context.env.ASSETS.fetch(context.request);
 
+  // A conditional request can be answered 304 against the fallback's own validator, which would
+  // leave a client that stored the app shell under an asset URL holding on to it. A 304 carries
+  // neither body nor content type, so the only way to see what the path holds is to ask again
+  // without the conditions. This costs a second lookup on revalidation only -- a client whose copy
+  // is still fresh sends no request at all, and never reaches this code.
+  if (response.status === 304) {
+    return await resolveConditional(context);
+  }
+
   // Restricted to successful responses. An HTML error page is a failure with its own status, and
   // reporting it as 404 would state that the asset is permanently gone on the strength of what may
   // be a passing fault. `ok` rather than `=== 200` so a partial response cannot slip past.
-  if (response.ok && (response.headers.get('content-type') ?? '').includes('text/html')) {
-    return new Response('Not found', {
-      status: 404,
-      headers: {
-        'content-type': 'text/plain; charset=utf-8',
-        // The next deploy may add this path back, so the absence must not be cached.
-        'cache-control': 'no-store',
-      },
-    });
-  }
+  if (isFallback(response)) return notFound();
 
   return response;
+}
+
+// Repeats the lookup without the conditions, to find out whether the 304 stood for a real asset or
+// for the fallback. A real asset keeps its 304: the client's copy is valid and needs no body.
+async function resolveConditional(context) {
+  const unconditional = new Request(context.request);
+  unconditional.headers.delete('if-none-match');
+  unconditional.headers.delete('if-modified-since');
+
+  const response = await context.env.ASSETS.fetch(unconditional);
+
+  return isFallback(response) ? notFound() : new Response(null, { status: 304, headers: response.headers });
+}
+
+function isFallback(response) {
+  return response.ok && (response.headers.get('content-type') ?? '').includes('text/html');
+}
+
+function notFound() {
+  return new Response('Not found', {
+    status: 404,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      // The next deploy may add this path back, so the absence must not be cached.
+      'cache-control': 'no-store',
+    },
+  });
 }

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -5,8 +5,7 @@
  * index.html for any path with no file behind it, which public/_headers then stamps with the cache
  * lifetime meant for fingerprinted assets. A client asking for a chunk that a later deploy replaced
  * therefore does not get a failure it can recover from -- it gets an HTML page parsed as
- * JavaScript, cached under the chunk's own URL. See public/_redirects for where that fallback
- * comes from, and where it does not.
+ * JavaScript, cached under the chunk's own URL.
  *
  * Nothing served under the paths this runs on is ever HTML, so the content type of the response is
  * what separates a real asset from that fallback. Both are status 200; only the type differs.
@@ -17,7 +16,11 @@
 export async function onRequest(context) {
   const response = await context.env.ASSETS.fetch(context.request);
 
-  if ((response.headers.get('content-type') ?? '').includes('text/html')) {
+  // Status 200 is part of what identifies the fallback. An HTML error page -- a gateway or origin
+  // failure rendered as HTML -- must pass through as the status it is: rewriting it to 404 would
+  // report a temporary outage as an asset that is gone for good, and send the client off to reload
+  // instead of retry.
+  if (response.status === 200 && (response.headers.get('content-type') ?? '').includes('text/html')) {
     return new Response('Not found', {
       status: 404,
       headers: {

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -1,32 +1,26 @@
 /**
  * Answers a request for a build asset that does not exist with a 404 instead of the app shell.
  *
- * Without this, an absent asset is answered with the app shell and status 200: Pages serves
- * index.html for any path with no file behind it, which public/_headers then stamps with the cache
- * lifetime meant for fingerprinted assets. A client asking for a chunk that a later deploy replaced
- * therefore does not get a failure it can recover from -- it gets an HTML page parsed as
+ * A path with no file behind it is answered with index.html and status 200, and public/_headers
+ * stamps anything under /static/* with the cache lifetime meant for fingerprinted assets. A client
+ * asking for a chunk that a later deploy replaced therefore receives an HTML page to parse as
  * JavaScript, cached under the chunk's own URL.
  *
- * Nothing served under the paths this runs on is ever HTML, so the content type of the response is
- * what separates a real asset from that fallback. Both are status 200; only the type differs.
- *
- * public/_routes.json restricts this to those paths. Every other request -- the app shell, deep
- * links, the root -- is served statically and never reaches this code.
+ * Nothing served under the paths in public/_routes.json is HTML, so the content type separates a
+ * real asset from that fallback. Every other request is served statically and never reaches here.
  */
 export async function onRequest(context) {
   const response = await context.env.ASSETS.fetch(context.request);
 
-  // Status 200 is part of what identifies the fallback. An HTML error page -- a gateway or origin
-  // failure rendered as HTML -- must pass through as the status it is: rewriting it to 404 would
-  // report a temporary outage as an asset that is gone for good, and send the client off to reload
-  // instead of retry.
-  if (response.status === 200 && (response.headers.get('content-type') ?? '').includes('text/html')) {
+  // Restricted to successful responses. An HTML error page is a failure with its own status, and
+  // reporting it as 404 would state that the asset is permanently gone on the strength of what may
+  // be a passing fault. `ok` rather than `=== 200` so a partial response cannot slip past.
+  if (response.ok && (response.headers.get('content-type') ?? '').includes('text/html')) {
     return new Response('Not found', {
       status: 404,
       headers: {
         'content-type': 'text/plain; charset=utf-8',
-        // Never let the absence of an asset be cached: the next deploy may well add it back under
-        // the same URL, and a cached 404 would outlive the problem it reports.
+        // The next deploy may add this path back, so the absence must not be cached.
         'cache-control': 'no-store',
       },
     });

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -1,0 +1,32 @@
+/**
+ * Answers a request for a build asset that does not exist with a 404 instead of the app shell.
+ *
+ * Without this, an absent asset falls through the SPA rule in public/_redirects and is served as
+ * index.html with status 200, which public/_headers then stamps with the cache lifetime meant for
+ * fingerprinted assets. A client asking for a chunk that a later deploy replaced therefore does
+ * not get a failure it can recover from -- it gets an HTML page parsed as JavaScript, cached
+ * under the chunk's own URL.
+ *
+ * Nothing served under the paths this runs on is ever HTML, so the content type of the response is
+ * what separates a real asset from that fallback. Both are status 200; only the type differs.
+ *
+ * public/_routes.json restricts this to those paths. Every other request -- the app shell, deep
+ * links, the root -- is served statically and never reaches this code.
+ */
+export async function onRequest(context) {
+  const response = await context.env.ASSETS.fetch(context.request);
+
+  if ((response.headers.get('content-type') ?? '').includes('text/html')) {
+    return new Response('Not found', {
+      status: 404,
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        // Never let the absence of an asset be cached: the next deploy may well add it back under
+        // the same URL, and a cached 404 would outlive the problem it reports.
+        'cache-control': 'no-store',
+      },
+    });
+  }
+
+  return response;
+}

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -38,7 +38,14 @@ async function resolveConditional(context) {
 
   const response = await context.env.ASSETS.fetch(unconditional);
 
-  return isFallback(response) ? notFound() : new Response(null, { status: 304, headers: response.headers });
+  if (isFallback(response)) return notFound();
+
+  // Only a successful lookup says the client's copy is still good. Anything else -- a failure, a
+  // redirect -- is passed on as itself: answering 304 there would confirm a cached entry on the
+  // strength of a request that never established what the path holds.
+  if (!response.ok) return response;
+
+  return new Response(null, { status: 304, headers: response.headers });
 }
 
 function isFallback(response) {

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -1,11 +1,12 @@
 /**
  * Answers a request for a build asset that does not exist with a 404 instead of the app shell.
  *
- * Without this, an absent asset falls through the SPA rule in public/_redirects and is served as
- * index.html with status 200, which public/_headers then stamps with the cache lifetime meant for
- * fingerprinted assets. A client asking for a chunk that a later deploy replaced therefore does
- * not get a failure it can recover from -- it gets an HTML page parsed as JavaScript, cached
- * under the chunk's own URL.
+ * Without this, an absent asset is answered with the app shell and status 200: Pages serves
+ * index.html for any path with no file behind it, which public/_headers then stamps with the cache
+ * lifetime meant for fingerprinted assets. A client asking for a chunk that a later deploy replaced
+ * therefore does not get a failure it can recover from -- it gets an HTML page parsed as
+ * JavaScript, cached under the chunk's own URL. See public/_redirects for where that fallback
+ * comes from, and where it does not.
  *
  * Nothing served under the paths this runs on is ever HTML, so the content type of the response is
  * what separates a real asset from that fallback. Both are status 200; only the type differs.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "widget": "./scripts/build-widget.sh",
     "widget:dev": "./scripts/build-widget.sh dev",
     "widget:loc": "./scripts/build-widget.sh loc",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.{ts,tsx}\" --no-fix --max-warnings 0",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.{ts,tsx}\" \"functions/**/*.js\" --no-fix --max-warnings 0",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.{ts,tsx}\" --fix",
     "test": "react-app-rewired test --watchAll=false --passWithNoTests",
     "test:e2e": "./scripts/e2e-test.sh",

--- a/public/_redirects
+++ b/public/_redirects
@@ -13,6 +13,6 @@
 #
 # A 404 cannot be expressed in this file: _redirects supports redirects (301, 302, 303, 307, 308)
 # and rewrites with 200, and a rule written with 404 is rejected as invalid. Narrowing the rule
-# below does not work either -- an explicit /static/* rule takes precedence over real files and
-# would shadow the assets themselves, which the catch-all does not do.
+# below is not an option either: Cloudflare documents that redirects apply whether or not an asset
+# matches the request, so an explicit /static/* rule would shadow the assets themselves.
 /*    /index.html    200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,16 +1,10 @@
 # SPA deep-link fallback: unknown paths serve the app shell (client-side routing).
 #
-# The rule below is kept as an explicit statement of that intent, but it is not what produces the
-# fallback: `wrangler pages dev` reports it as an infinite loop and ignores it, and the same
-# directory served with no _redirects file at all still answers an unknown path with index.html.
-# It was left in place because nothing showed that removing it is safe, not because it was shown
-# to do anything.
-#
-# That built-in fallback is also why an absent build asset was answered with index.html and status
-# 200: a path with no file behind it gets the app shell, whatever it looks like. The /static/* rule
-# in _headers then stamped that HTML with the cache lifetime meant for fingerprinted assets, so a
-# client asking for a chunk that a later deploy had replaced received an app shell parsed as
-# JavaScript -- cached under the chunk's own URL.
+# A path with no file behind it is answered with index.html and status 200. That is what makes deep
+# links work, and it is also why an absent build asset was answered with the app shell. The
+# /static/* rule in _headers then stamped that HTML with the cache lifetime meant for fingerprinted
+# assets, so a client asking for a chunk that a later deploy had replaced received an app shell
+# parsed as JavaScript -- cached under the chunk's own URL.
 #
 # functions/[[path]].js now intercepts that case for the asset paths listed in _routes.json and
 # answers 404 with no-store, which is a failure a client can recover from. Verify with a request

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,17 +1,24 @@
 # SPA deep-link fallback: unknown paths serve the app shell (client-side routing).
 #
-# Real files under static/*, widget/*, favicon, ... are matched by the host before this rule --
-# but only while they EXIST. A build asset that does not exist falls through to this rule and is
-# answered with index.html and status 200, and the /static/* rule in _headers then stamps that
-# HTML with a year of immutable cache. Verify with a request for any absent asset:
-#   curl -sI https://app.dfx.swiss/static/js/999.deadbeef.chunk.js
-#   -> 200, content-type: text/html, cache-control: public, max-age=31536000, immutable
+# The rule below is kept as an explicit statement of that intent, but it is not what produces the
+# fallback: `wrangler pages dev` reports it as an infinite loop and ignores it, and the same
+# directory served with no _redirects file at all still answers an unknown path with index.html.
+# It was left in place because nothing showed that removing it is safe, not because it was shown
+# to do anything.
 #
-# This is what a client sees when it requests a chunk that a later deploy replaced: not a 404 it
-# could recover from, but an app shell parsed as JavaScript. The app treats that as a chunk load
-# failure and reloads once (src/util/client-error.ts), which recovers the client as long as the
-# bad response was not cached under a chunk URL that a later build reuses unchanged.
+# That built-in fallback is also why an absent build asset was answered with index.html and status
+# 200: a path with no file behind it gets the app shell, whatever it looks like. The /static/* rule
+# in _headers then stamped that HTML with the cache lifetime meant for fingerprinted assets, so a
+# client asking for a chunk that a later deploy had replaced received an app shell parsed as
+# JavaScript -- cached under the chunk's own URL.
 #
-# Closing that gap needs a host-side change, since _redirects cannot express a status of 404 and
-# _headers cannot tell an existing asset apart from this fallback -- both match on path alone.
+# functions/[[path]].js now intercepts that case for the asset paths listed in _routes.json and
+# answers 404 with no-store, which is a failure a client can recover from. Verify with a request
+# for any absent asset:
+#   curl -sI https://app.dfx.swiss/static/js/999.deadbeef.chunk.js  -> 404
+#
+# A 404 cannot be expressed in this file: _redirects supports redirects (301, 302, 303, 307, 308)
+# and rewrites with 200, and a rule written with 404 is rejected as invalid. Narrowing the rule
+# below does not work either -- an explicit /static/* rule takes precedence over real files and
+# would shadow the assets themselves, which the catch-all does not do.
 /*    /index.html    200

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/static/*", "/widget/*"],
+  "exclude": []
+}

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -46,4 +46,18 @@ describe('missing asset function', () => {
 
     expect(result.status).toBe(503);
   });
+
+  it('leaves an HTML error page as the error it is', async () => {
+    // A gateway or origin failure rendered as HTML is not a missing asset. Reporting it as 404
+    // would turn a temporary outage into a permanent-looking one and send the client to reload
+    // rather than retry.
+    const outage = new Response('<!doctype html><html>gateway error</html>', {
+      status: 503,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+
+    const result = await onRequest(contextFor(outage));
+
+    expect(result.status).toBe(503);
+  });
 });

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -1,0 +1,49 @@
+import { onRequest } from '../../functions/[[path]].js';
+
+// The deployed Pages Function is not part of the app bundle, so nothing else in the test suite
+// reaches it. These cases pin the one decision it makes: an asset path answered with HTML is the
+// SPA fallback standing in for a file that no longer exists, and must not reach the client as a
+// successful asset.
+
+function contextFor(response: Response): any {
+  return { request: new Request('https://app.dfx.swiss/static/js/main.abc123.js'), env: { ASSETS: { fetch: async () => response } } };
+}
+
+describe('missing asset function', () => {
+  it('answers an asset path served as HTML with 404 and forbids caching it', async () => {
+    const fallback = new Response('<!doctype html><html></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'public, max-age=31536000, immutable' },
+    });
+
+    const result = await onRequest(contextFor(fallback));
+
+    expect(result.status).toBe(404);
+    expect(result.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('passes a real asset through untouched, headers included', async () => {
+    const asset = new Response('console.log(1);', {
+      status: 200,
+      headers: { 'content-type': 'application/javascript', 'cache-control': 'public, max-age=31536000, immutable' },
+    });
+
+    const result = await onRequest(contextFor(asset));
+
+    expect(result.status).toBe(200);
+    expect(result.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    await expect(result.text()).resolves.toBe('console.log(1);');
+  });
+
+  it('passes a response without a content type through rather than guessing', async () => {
+    const result = await onRequest(contextFor(new Response('data', { status: 200 })));
+
+    expect(result.status).toBe(200);
+  });
+
+  it('does not turn a non-HTML error response into a 404', async () => {
+    const result = await onRequest(contextFor(new Response('nope', { status: 503, headers: { 'content-type': 'text/plain' } })));
+
+    expect(result.status).toBe(503);
+  });
+});

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -5,8 +5,32 @@ import { onRequest } from '../../functions/[[path]].js';
 // HTML is the fallback standing in for a file that no longer exists, and must not reach the client
 // as a successful asset. An HTML failure response is a different thing and keeps its status.
 
+const ASSET_URL = 'https://app.dfx.swiss/static/js/main.abc123.js';
+
 function contextFor(response: Response): any {
-  return { request: new Request('https://app.dfx.swiss/static/js/main.abc123.js'), env: { ASSETS: { fetch: async () => response } } };
+  return { request: new Request(ASSET_URL), env: { ASSETS: { fetch: async () => response } } };
+}
+
+// A conditional request needs two answers: the 304, then whatever the unconditional retry finds.
+// The recorder also captures the second request, so the test can assert the conditions were dropped
+// rather than merely assume it.
+function conditionalContext(retry: Response): { context: any; retried: () => Request | undefined } {
+  const responses = [new Response(null, { status: 304 }), retry];
+  let secondRequest: Request | undefined;
+
+  const context = {
+    request: new Request(ASSET_URL, { headers: { 'if-none-match': '"shell-etag"', 'if-modified-since': 'Wed, 30 Jul 2026 00:00:00 GMT' } }),
+    env: {
+      ASSETS: {
+        fetch: async (request: Request) => {
+          if (responses.length === 1) secondRequest = request;
+          return responses.shift() as Response;
+        },
+      },
+    },
+  };
+
+  return { context, retried: () => secondRequest };
 }
 
 describe('missing asset function', () => {
@@ -58,6 +82,31 @@ describe('missing asset function', () => {
     const result = await onRequest(contextFor(partial));
 
     expect(result.status).toBe(404);
+  });
+
+  it('does not let a conditional request revalidate a cached app shell', async () => {
+    // The client stored the app shell under an asset URL before this function existed. Revalidating
+    // must not confirm it as valid, or the poisoned entry lives on.
+    const { context, retried } = conditionalContext(
+      new Response('<!doctype html><html></html>', { status: 200, headers: { 'content-type': 'text/html; charset=utf-8' } }),
+    );
+
+    const result = await onRequest(context);
+
+    expect(result.status).toBe(404);
+    expect(retried()?.headers.get('if-none-match')).toBeNull();
+    expect(retried()?.headers.get('if-modified-since')).toBeNull();
+  });
+
+  it('still confirms a cached copy of an asset that really exists', async () => {
+    const { context } = conditionalContext(
+      new Response('console.log(1);', { status: 200, headers: { 'content-type': 'application/javascript' } }),
+    );
+
+    const result = await onRequest(context);
+
+    expect(result.status).toBe(304);
+    await expect(result.text()).resolves.toBe('');
   });
 
   it('leaves an HTML error page as the error it is', async () => {

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -1,9 +1,9 @@
 import { onRequest } from '../../functions/[[path]].js';
 
 // The deployed Pages Function is not part of the app bundle, so nothing else in the test suite
-// reaches it. These cases pin the one decision it makes: an asset path answered with HTML is the
-// SPA fallback standing in for a file that no longer exists, and must not reach the client as a
-// successful asset.
+// reaches it. These cases pin the one decision it makes: an asset path answered SUCCESSFULLY with
+// HTML is the fallback standing in for a file that no longer exists, and must not reach the client
+// as a successful asset. An HTML failure response is a different thing and keeps its status.
 
 function contextFor(response: Response): any {
   return { request: new Request('https://app.dfx.swiss/static/js/main.abc123.js'), env: { ASSETS: { fetch: async () => response } } };
@@ -47,10 +47,22 @@ describe('missing asset function', () => {
     expect(result.status).toBe(503);
   });
 
+  it('catches the fallback on a successful status other than 200', async () => {
+    // The check is on success, not on 200 alone, so a partial response carrying the fallback
+    // cannot slip past as a valid asset.
+    const partial = new Response('<!doctype html><html></html>', {
+      status: 206,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+
+    const result = await onRequest(contextFor(partial));
+
+    expect(result.status).toBe(404);
+  });
+
   it('leaves an HTML error page as the error it is', async () => {
-    // A gateway or origin failure rendered as HTML is not a missing asset. Reporting it as 404
-    // would turn a temporary outage into a permanent-looking one and send the client to reload
-    // rather than retry.
+    // An HTML failure page is not a missing asset. Reporting it as 404 would state permanent
+    // absence on the strength of what may be a passing fault.
     const outage = new Response('<!doctype html><html>gateway error</html>', {
       status: 503,
       headers: { 'content-type': 'text/html; charset=utf-8' },

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -109,6 +109,16 @@ describe('missing asset function', () => {
     await expect(result.text()).resolves.toBe('');
   });
 
+  it('does not confirm a cached copy when the retry itself fails', async () => {
+    // A failure on the second lookup establishes nothing about the path. Answering 304 there would
+    // renew whatever the client holds -- including the app shell this exists to get rid of.
+    const { context } = conditionalContext(new Response('upstream down', { status: 503, headers: { 'content-type': 'text/plain' } }));
+
+    const result = await onRequest(context);
+
+    expect(result.status).toBe(503);
+  });
+
   it('leaves an HTML error page as the error it is', async () => {
     // An HTML failure page is not a missing asset. Reporting it as 404 would state permanent
     // absence on the strength of what may be a passing fault.


### PR DESCRIPTION
## Problem

A request for a build asset that no longer exists is answered with the app shell and status 200:

```
curl -sI https://app.dfx.swiss/static/js/999.deadbeef.chunk.js
-> 200, content-type: text/html, cache-control: public, max-age=31536000, immutable
```

The client asked for JavaScript and received an HTML page — then cached it under the chunk's own URL
for a year, because the `/static/*` rule in `_headers` matches on path alone and cannot tell an
asset apart from the fallback.

This is what a customer hits after a deploy replaces the content-hashed chunks while their tab is
still open. #1227 made the app recover from it and made the failure visible; this closes it at the
source.

The widget is affected the same way, and worse in kind — its chunks load inside third-party pages:

```
curl -sI https://app.dfx.swiss/widget/v1.0-chunks/999.deadbeef.chunk.js
-> 200, content-type: text/html
```

## Change

A Pages Function on the asset paths asks for the asset and inspects what comes back. Nothing served
under those paths is HTML, so the content type is what separates a real asset from the fallback —
both are successful responses. A successful HTML response means the asset is gone, and the request
is answered `404` with `no-store`.

`public/_routes.json` restricts the Function to `/static/*` and `/widget/*`. Every other request —
the app shell, deep links, the root — is served statically and never reaches it.

**Conditional requests get the same treatment.** A client that stored the app shell under an asset
URL before this existed would otherwise have had that entry confirmed on revalidation: the binding
answers `304` against the fallback's own validator, and a `304` carries neither body nor content
type. On `304` the lookup is repeated without the conditional headers, so the path can be judged by
what it actually holds. A real asset keeps its `304` and the client keeps its valid copy; the
fallback becomes `404`; a failed retry passes through as the failure it is. The extra lookup happens
on revalidation only — a client whose copy is still fresh sends no request at all.

That last part matters beyond tidiness: it is the one case the app-side recovery in #1227 could not
reach.

## Measured, not assumed

Against a real `npm run build` output under `wrangler pages dev`:

| Request | Before | After |
|---|---|---|
| `main.<hash>.js`, a `.chunk.js`, a `.chunk.css` | 200 js/css | 200 js/css |
| **absent `/static/*` asset** | **200 text/html** | **404, no-store** |
| existing widget chunk | 200 js | 200 js |
| **absent widget chunk** | **200 text/html** | **404, no-store** |
| widget entry point | 200 | 200 |
| `/buy`, `/`, favicon, manifest | 200 | 200 |
| conditional GET, existing asset | 304 | 304 |
| **conditional GET, absent asset** | **304** | **404** |

Two approaches were tried first and rejected on evidence:

- **A 404 in `_redirects`.** Rejected by Cloudflare as an invalid rule; the absent asset still came
  back as HTML with 200.
- **Narrowing the fallback with an explicit `/static/*` rule.** This broke the site in the emulator:
  an explicit rule takes precedence over real files, so *existing* assets were served as HTML too.
  It would have been a full outage on deploy.

## Checks

The Function is deployed but was outside everything CI runs — a syntax error in it would have
reached production with a green build. ESLint now covers `functions/**/*.js`; the type-aware parser
cannot resolve files outside `tsconfig.json`, so that path is linted without type information, which
still catches what matters. Verified by introducing a syntax error and confirming the lint run fails
on it.

Nine tests pin every branch: the fallback becoming 404, a real asset passing through with its
headers, a missing content type, a non-HTML error status, a successful non-200 fallback, the
conditional path in all three of its outcomes, and an HTML error page keeping its status. Full
suite green. The Function stays out of the app bundle — the built output contains no reference to
it.

## What this costs

Cloudflare bills requests that invoke a Function; static asset requests are free. `_routes.json`
keeps that scope as small as the fix allows — the app shell and all navigation stay static — but
asset requests that were previously free now count. There is no way to have Pages return a 404 for a
missing asset without a Function.

## Before main

The emulator is not the edge. **This should go to DEV first** — `dfx-app-dev.pages.dev` reproduces
the defect identically today, so the same `curl` calls there confirm or refute the fix on real
infrastructure. Worth checking explicitly, because it is the one way this change could do real harm:
that an *existing* asset still returns `200 application/javascript` and not the app shell.
