### PR TITLE
Report a failure once, and repair the stored answer that caused it

### DIFF
--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -507,6 +507,27 @@ describe('installChunkErrorHandling', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
+  // Asserted through the event, not by calling the recovery directly: classification runs first in
+  // this path, and a value whose string conversion throws used to stop the handler there — leaving
+  // the customer on the broken page while a direct unit test of the recovery still passed.
+  it('recovers a chunk failure whose value resists string conversion', () => {
+    install();
+
+    const hostile = {
+      name: 'ChunkLoadError',
+      get message(): string {
+        throw new Error('nope');
+      },
+      toString: () => {
+        throw new Error('nope');
+      },
+    };
+
+    fire('error', { error: hostile });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
   // Some engines deliver only the message, with no error object attached.
   it('recovers a chunk failure carried as a bare message', () => {
     install();

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -2,7 +2,13 @@
 jest.mock('@dfx.swiss/react', () => ({}));
 jest.mock('src/dto/safe.dto', () => ({}));
 
-import { isChunkLoadError, reloadOnceForChunkError, reportClientError, toErrorFacts } from '../util/client-error';
+import {
+  forgetReportedErrors,
+  isChunkLoadError,
+  reloadOnceForChunkError,
+  reportClientError,
+  toErrorFacts,
+} from '../util/client-error';
 
 jest.mock('src/config/api', () => ({ Api: { url: 'https://api.example.com', version: 'v1' } }));
 jest.mock('src/version', () => ({ REACT_APP_BUILD_ID: '42-99' }));
@@ -91,6 +97,7 @@ describe('isChunkLoadError', () => {
 
 describe('reportClientError', () => {
   beforeEach(() => {
+    forgetReportedErrors();
     global.fetch = jest.fn().mockResolvedValue({ ok: true }) as jest.Mock;
   });
 
@@ -229,6 +236,104 @@ describe('reloadOnceForChunkError', () => {
 
       expect(reload).toHaveBeenCalledTimes(1);
     });
+  });
+
+  // A reload alone re-reads index.html but not the stored answer for the chunk, and the chunk URL
+  // is stable across builds. Without replacing that stored copy the customer gets the same bad
+  // answer back on every attempt, for as long as it is considered fresh.
+  it('replaces the stored copy of the failing chunk before reloading', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(new Response('', { status: 404 }));
+    global.fetch = fetchMock as any;
+
+    reloadOnceForChunkError(
+      Object.assign(new Error('Loading chunk 2688 failed.\n(error: http://localhost/static/js/2688.abc.chunk.js)'), {
+        name: 'ChunkLoadError',
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost/static/js/2688.abc.chunk.js', {
+      cache: 'reload',
+      credentials: 'omit',
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads even when replacing the stored copy fails', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('offline')) as any;
+
+    reloadOnceForChunkError(
+      Object.assign(new Error('Loading chunk 7 failed.\n(error: http://localhost/static/js/7.abc.chunk.js)'), {
+        name: 'ChunkLoadError',
+      }),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  // The message is derived from an error object, which an embedded or third-party bundler could
+  // supply. Repairing an address on someone else's host is not ours to do.
+  it('ignores a chunk address on another origin and just reloads', () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as any;
+
+    reloadOnceForChunkError(new Error('Loading chunk 9 failed.\n(error: https://evil.example/x.chunk.js)'));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The router can remount the same route repeatedly, and each remount is a fresh component. A guard
+// that lives in the component therefore cannot hold -- measured in a real browser, one page
+// produced 19-30 reports per second this way, while the customer saw a single broken screen.
+describe('repeat reports', () => {
+  beforeEach(() => {
+    forgetReportedErrors();
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-01T10:00:00Z'));
+  });
+
+  afterEach(() => jest.useRealTimers());
+
+  it('reports the same failure only once within the window', () => {
+    const error = Object.assign(new Error('Loading chunk 2688 failed.'), { name: 'ChunkLoadError' });
+
+    reportClientError(error, '/buy');
+    reportClientError(error, '/buy');
+    reportClientError(error, '/buy');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports the same failure on a different route', () => {
+    const error = Object.assign(new Error('Loading chunk 2688 failed.'), { name: 'ChunkLoadError' });
+
+    reportClientError(error, '/buy');
+    reportClientError(error, '/sell');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a different failure on the same route', () => {
+    reportClientError(new Error('one'), '/buy');
+    reportClientError(new Error('two'), '/buy');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports again once the window has passed', () => {
+    const error = new Error('same');
+
+    reportClientError(error, '/buy');
+    jest.setSystemTime(new Date('2026-08-01T10:01:01Z'));
+    reportClientError(error, '/buy');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -358,6 +358,37 @@ describe('reloadOnceForChunkError', () => {
     await Promise.resolve();
   });
 
+  // The reload guard is written before the address is looked up, so a throw while looking it up
+  // would leave the customer with neither a repair nor a reload until the guard expires.
+  it('still reloads when reading the address throws', () => {
+    const hostile = Object.assign(new Error('Loading chunk 1 failed.'), { name: 'ChunkLoadError' });
+    Object.defineProperty(hostile, 'request', {
+      get() {
+        throw new Error('nope');
+      },
+    });
+
+    reloadOnceForChunkError(hostile);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reloads when the error resists string conversion', () => {
+    const hostile = {
+      name: 'ChunkLoadError',
+      get message(): string {
+        throw new Error('nope');
+      },
+      toString: () => {
+        throw new Error('nope');
+      },
+    };
+
+    reloadOnceForChunkError(hostile);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
   // The message is derived from an error object, which an embedded or third-party bundler could
   // supply. Repairing an address on someone else's host is not ours to do.
   it('ignores a chunk address on another origin and just reloads', () => {

--- a/src/__tests__/client-error.test.ts
+++ b/src/__tests__/client-error.test.ts
@@ -275,6 +275,89 @@ describe('reloadOnceForChunkError', () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
+  // Before the repair existed the reload was immediate. A request that never settles must not cost
+  // the customer their recovery, so the reload is bounded by a timer as well.
+  it('reloads even if the repair request never settles', () => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn().mockReturnValue(new Promise(() => undefined)) as any;
+
+    reloadOnceForChunkError(
+      Object.assign(new Error('Loading chunk 1 failed.\n(error: http://localhost/static/js/1.abc.chunk.js)'), {
+        name: 'ChunkLoadError',
+      }),
+    );
+
+    expect(reload).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(2000);
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+  });
+
+  it('reloads only once when the repair settles after the timer already fired', async () => {
+    jest.useFakeTimers();
+    let settle: (value: unknown) => void = () => undefined;
+    global.fetch = jest.fn().mockReturnValue(new Promise((resolve) => (settle = resolve))) as any;
+
+    reloadOnceForChunkError(
+      Object.assign(new Error('Loading chunk 1 failed.\n(error: http://localhost/static/js/1.abc.chunk.js)'), {
+        name: 'ChunkLoadError',
+      }),
+    );
+
+    jest.advanceTimersByTime(2000);
+    settle(new Response(''));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  // webpack puts the address on the error itself; reading it there beats parsing prose.
+  it('prefers the address webpack puts on the error over the message', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(new Response(''));
+    global.fetch = fetchMock as any;
+
+    reloadOnceForChunkError(
+      Object.assign(new Error('Loading chunk 5 failed.\n(error: http://localhost/static/js/from-message.js)'), {
+        name: 'ChunkLoadError',
+        request: 'http://localhost/static/js/from-request.js',
+      }),
+    );
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost/static/js/from-request.js');
+    await Promise.resolve();
+  });
+
+  // What a build with a relative public path emits.
+  it('resolves a relative chunk address against the current document', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(new Response(''));
+    global.fetch = fetchMock as any;
+
+    reloadOnceForChunkError(
+      Object.assign(new Error('Loading chunk 3 failed.\n(error: /static/js/3.abc.chunk.js)'), {
+        name: 'ChunkLoadError',
+      }),
+    );
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost/static/js/3.abc.chunk.js');
+    await Promise.resolve();
+  });
+
+  // isChunkLoadError accepts this wording too, so the repair has to understand it as well.
+  it('reads the address out of a failed dynamic import', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(new Response(''));
+    global.fetch = fetchMock as any;
+
+    reloadOnceForChunkError(
+      new Error('Failed to fetch dynamically imported module: http://localhost/static/js/lazy.js'),
+    );
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost/static/js/lazy.js');
+    await Promise.resolve();
+  });
+
   // The message is derived from an error object, which an embedded or third-party bundler could
   // supply. Repairing an address on someone else's host is not ours to do.
   it('ignores a chunk address on another origin and just reloads', () => {

--- a/src/screens/error.screen.tsx
+++ b/src/screens/error.screen.tsx
@@ -40,7 +40,7 @@ export default function ErrorScreen(): JSX.Element {
     // A chunk left stale by a deploy recovers on its own once the app reloads. React hands the
     // failed import to this boundary, so this is where it can be caught — a window listener never
     // sees it.
-    if (!error && isChunkLoadError(routeError)) reloadOnceForChunkError();
+    if (!error && isChunkLoadError(routeError)) reloadOnceForChunkError(routeError);
   }, [routeError, error, pathname]);
 
   useLayoutOptions({});

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -60,12 +60,28 @@ export function toErrorFacts(error: unknown): ErrorFacts {
 // had typed, which is worse than the failure it recovers from. The wordings below identify the
 // real case on their own.
 export function isChunkLoadError(error: unknown): boolean {
-  const { message, type } = toErrorFacts(error);
+  // The name first: reading it cannot run code of the value's own choosing, while deriving the
+  // message calls String() on it. This is the first thing the global handler does with a thrown
+  // value, so a throw here would cost the recovery that follows — the failure would be classified
+  // as nothing at all and the customer would be left on the broken page.
+  if (nameOf(error) === 'ChunkLoadError') return true;
 
-  return (
-    type === 'ChunkLoadError' ||
-    /Loading (CSS )?chunk [\w-]+ failed|ChunkLoadError|Failed to fetch dynamically imported module/i.test(message)
-  );
+  try {
+    return /Loading (CSS )?chunk [\w-]+ failed|ChunkLoadError|Failed to fetch dynamically imported module/i.test(
+      toErrorFacts(error).message,
+    );
+  } catch {
+    return false;
+  }
+}
+
+function nameOf(error: unknown): string | undefined {
+  try {
+    const name = (error as { name?: unknown })?.name;
+    return typeof name === 'string' ? name : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // The widget and library builds run inside someone else's page, where `window` belongs to the

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -11,8 +11,15 @@ const LIMITS = { message: 500, type: 100, stack: 4000, route: 500, version: 50 }
 const CHUNK_RELOAD_KEY = 'dfx.chunkReloadAt';
 const CHUNK_RELOAD_WINDOW = 30000;
 
-// The bundler names the failing asset in its message, as `(error: <url>)` or `(missing: <url>)`.
-const CHUNK_URL_REGEX = /\((?:error|missing):\s*(https?:\/\/[^\s)]+)\)/i;
+// The bundler names the failing asset in its message: `(error: <url>)` or `(missing: <url>)` for a
+// chunk, and a trailing address for a dynamic import. Both forms allow a relative address, since
+// what appears here is whatever the build was configured to request.
+const CHUNK_URL_PATTERNS = [/\((?:error|missing):\s*([^\s)]+)\)/i, /imported module:\s*([^\s]+)/i];
+
+// How long the repair may take before the reload goes ahead regardless. A request that never
+// settles must not cost the customer their recovery — before this existed, the reload was
+// immediate, and it has to stay at least as reliable as that.
+const REPAIR_BUDGET = 2000;
 
 // Reporting the same failure again tells us nothing and costs the customer a request. The router
 // can remount a route repeatedly, and every remount builds a fresh component instance -- so a
@@ -107,26 +114,53 @@ export function reloadOnceForChunkError(error?: unknown): void {
     return;
   }
 
+  // The reload must happen even if the repair hangs, so it is bounded by a timer as well as by the
+  // request settling — whichever comes first, and only once.
+  let reloaded = false;
+  const reloadOnce = (): void => {
+    if (reloaded) return;
+    reloaded = true;
+    window.location.reload();
+  };
+
+  window.setTimeout(reloadOnce, REPAIR_BUDGET);
+
   void fetch(chunkUrl, { cache: 'reload', credentials: 'omit' })
     .catch(() => undefined)
-    .then(() => window.location.reload());
+    .then(reloadOnce);
 }
 
-// The URL of the asset a bundler chunk failure names, if the message carries one.
+// The address of the asset a bundler failure names, resolved and confined to our own origin.
 export function chunkUrlOf(error: unknown): string | undefined {
   if (error == null) return undefined;
 
-  const { message } = toErrorFacts(error);
-  const match = CHUNK_URL_REGEX.exec(message);
-  if (!match) return undefined;
+  // webpack puts the address on the error itself, which beats reading it back out of prose.
+  const request = (error as { request?: unknown }).request;
+  const raw = typeof request === 'string' && request ? request : addressInMessage(error);
+  if (!raw) return undefined;
 
-  // Only our own origin: the message is derived from an error object, and a report from an
-  // embedded or third-party bundler could otherwise point this at someone else's host.
   try {
-    return new URL(match[1]).origin === window.location.origin ? match[1] : undefined;
+    // Resolved against the current document, so a relative address — which is what a build with a
+    // relative public path emits — is handled like an absolute one.
+    const resolved = new URL(raw, window.location.href);
+
+    // Own origin only: this address comes out of an error object, and an embedded or third-party
+    // bundler could otherwise point the repair at someone else's host.
+    return resolved.origin === window.location.origin ? resolved.href : undefined;
   } catch {
     return undefined;
   }
+}
+
+function addressInMessage(error: unknown): string | undefined {
+  const { message } = toErrorFacts(error);
+
+  for (const pattern of CHUNK_URL_PATTERNS) {
+    const match = pattern.exec(message);
+    if (match) return match[1];
+  }
+
+  return undefined;
 }
 
 // Clears what this module remembers between reports. Only a test needs this: in a document the
@@ -207,7 +241,7 @@ export function installChunkErrorHandling(): void {
     if (!isChunkLoadError(error)) return;
 
     reportClientError(error, window.location.pathname);
-    reloadOnceForChunkError();
+    reloadOnceForChunkError(error);
   };
 
   window.addEventListener('error', (event) => handle(event?.error ?? event?.message));

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -134,12 +134,17 @@ export function reloadOnceForChunkError(error?: unknown): void {
 export function chunkUrlOf(error: unknown): string | undefined {
   if (error == null) return undefined;
 
-  // webpack puts the address on the error itself, which beats reading it back out of prose.
-  const request = (error as { request?: unknown }).request;
-  const raw = typeof request === 'string' && request ? request : addressInMessage(error);
-  if (!raw) return undefined;
-
+  // Every step here reads from a value we were handed: the property can be a getter that throws,
+  // and deriving the message runs String() on it, which a hostile toString can turn into a throw.
+  // Failing to find an address is fine -- the caller reloads without repairing -- but throwing is
+  // not: the reload guard has already been written by then, so the customer would be left with
+  // neither a repair nor a reload until it expires.
   try {
+    // webpack puts the address on the error itself, which beats reading it back out of prose.
+    const request = (error as { request?: unknown }).request;
+    const raw = typeof request === 'string' && request ? request : addressInMessage(error);
+    if (!raw) return undefined;
+
     // Resolved against the current document, so a relative address — which is what a build with a
     // relative public path emits — is handled like an absolute one.
     const resolved = new URL(raw, window.location.href);

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -11,6 +11,15 @@ const LIMITS = { message: 500, type: 100, stack: 4000, route: 500, version: 50 }
 const CHUNK_RELOAD_KEY = 'dfx.chunkReloadAt';
 const CHUNK_RELOAD_WINDOW = 30000;
 
+// The bundler names the failing asset in its message, as `(error: <url>)` or `(missing: <url>)`.
+const CHUNK_URL_REGEX = /\((?:error|missing):\s*(https?:\/\/[^\s)]+)\)/i;
+
+// Reporting the same failure again tells us nothing and costs the customer a request. The router
+// can remount a route repeatedly, and every remount builds a fresh component instance -- so a
+// guard that lives in the component cannot hold. This one outlives the mount.
+const RECENT_REPORTS = new Map<string, number>();
+const REPORT_DEDUP_WINDOW = 60000;
+
 // Identifies this app to the API, which logs it alongside the error. Without it every report
 // from here is filed as an unknown client.
 const CLIENT_NAME = 'dfx-services';
@@ -71,7 +80,7 @@ export function isEmbedded(): boolean {
 // localStorage (it survives the sessionStorage.clear() on session/login URLs) and is time-boxed,
 // so a persistent failure reloads at most once per window instead of looping. Storage access is
 // wrapped because embedded/iframe contexts can block it.
-export function reloadOnceForChunkError(): void {
+export function reloadOnceForChunkError(error?: unknown): void {
   if (embedded) return;
 
   try {
@@ -82,7 +91,65 @@ export function reloadOnceForChunkError(): void {
     return; // storage blocked (e.g. embedded iframe) — skip to avoid an unguarded reload loop
   }
 
-  window.location.reload();
+  const chunkUrl = chunkUrlOf(error);
+
+  // A plain reload fetches index.html anew but leaves the stored answer for the chunk itself
+  // untouched, and a chunk URL stays the same as long as its content does. A customer holding a
+  // bad answer under that URL therefore gets it back on every attempt, for as long as the stored
+  // copy is considered fresh -- which for these assets is a year.
+  //
+  // Requesting it with `cache: 'reload'` replaces the stored copy: the browser must go to the
+  // network, and the request carries no-cache, so intermediate caches revalidate too. Reload only
+  // after that has settled, whichever way it went -- the reload is the recovery, and it must not
+  // be skipped because the repair failed.
+  if (!chunkUrl) {
+    window.location.reload();
+    return;
+  }
+
+  void fetch(chunkUrl, { cache: 'reload', credentials: 'omit' })
+    .catch(() => undefined)
+    .then(() => window.location.reload());
+}
+
+// The URL of the asset a bundler chunk failure names, if the message carries one.
+export function chunkUrlOf(error: unknown): string | undefined {
+  if (error == null) return undefined;
+
+  const { message } = toErrorFacts(error);
+  const match = CHUNK_URL_REGEX.exec(message);
+  if (!match) return undefined;
+
+  // Only our own origin: the message is derived from an error object, and a report from an
+  // embedded or third-party bundler could otherwise point this at someone else's host.
+  try {
+    return new URL(match[1]).origin === window.location.origin ? match[1] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Clears what this module remembers between reports. Only a test needs this: in a document the
+// state is meant to live for as long as the document does, which is the whole point of it.
+export function forgetReportedErrors(): void {
+  RECENT_REPORTS.clear();
+}
+
+// True when this exact failure was already reported from this document within the window. Keeps
+// the map bounded by dropping expired entries on the way through, so a long session cannot grow it
+// without limit.
+function isRepeatReport(signature: string): boolean {
+  const now = Date.now();
+
+  RECENT_REPORTS.forEach((at, key) => {
+    if (now - at >= REPORT_DEDUP_WINDOW) RECENT_REPORTS.delete(key);
+  });
+
+  const last = RECENT_REPORTS.get(signature);
+  if (last != null && now - last < REPORT_DEDUP_WINDOW) return true;
+
+  RECENT_REPORTS.set(signature, now);
+  return false;
 }
 
 // Reports an error the user actually saw. Fire-and-forget: a failing report must never surface as
@@ -92,6 +159,12 @@ export function reportClientError(error: unknown, route: string): void {
 
   try {
     const { message, type, stack } = toErrorFacts(error);
+
+    // Deduplicated here rather than at the call site, so every caller is covered by the same rule.
+    // Without it a remount loop reports the same failure tens of times per second: the customer
+    // sees one broken page while the API sees a flood, and the rate limit then hides the very
+    // reports this exists to collect.
+    if (isRepeatReport(`${type ?? ''}|${message}|${route}`)) return;
 
     const body = {
       // The endpoint rejects an empty message, and a rejected report is exactly the blind spot

--- a/src/util/client-error.ts
+++ b/src/util/client-error.ts
@@ -60,10 +60,11 @@ export function toErrorFacts(error: unknown): ErrorFacts {
 // had typed, which is worse than the failure it recovers from. The wordings below identify the
 // real case on their own.
 export function isChunkLoadError(error: unknown): boolean {
-  // The name first: reading it cannot run code of the value's own choosing, while deriving the
-  // message calls String() on it. This is the first thing the global handler does with a thrown
-  // value, so a throw here would cost the recovery that follows — the failure would be classified
-  // as nothing at all and the customer would be left on the broken page.
+  // The name first, read in isolation: it is the cheaper signal, and a getter or proxy trap behind
+  // it is contained rather than left to escape. Deriving the message is the riskier step, since it
+  // calls String() on the value. Classification is the first thing the global handler does with a
+  // thrown value, so a throw here would cost the recovery that follows — the failure would be
+  // classified as nothing at all and the customer left on the broken page.
   if (nameOf(error) === 'ChunkLoadError') return true;
 
   try {


### PR DESCRIPTION
## What is happening in production

Since the reporting from #1227 went live, the ingest endpoint takes **~68 requests per second**,
around the clock. 99.9% of them are rejected by its rate limit — of 5'000 sampled requests, 4'998
came back `429`. The rest of the API sees ~1'100 requests per 10 minutes, so this one endpoint
carries roughly 40× the entire real traffic of the platform.

Reproduced in a real browser: **a single open page produces 19–30 reports per second**, indefinitely.
The customer sees one broken screen. We receive ~68'000 reports an hour from them.

## Defect 1 — the guard could not hold

`ErrorScreen` guarded against repeat reports with a `useRef`, which lives and dies with the mount.
The router remounts the same route repeatedly — measured as 357 × `history.replaceState('/buy')`
during 12 seconds of the loop — and every remount builds a fresh component with a fresh ref. React
then re-throws the cached chunk failure, the boundary mounts again, and the report goes out again.

The guard now lives in the module, keyed on type + message + route for one minute. It survives the
remount, because that is the thing it has to survive.

This matters beyond the noise: while the loop fills the rate limit, it **pushes out the reports of
every other customer**. The flood blinds exactly what it floods.

## Defect 2 — reload repeated the failure instead of ending it

A reload re-reads `index.html`, but not the stored answer for the chunk itself — and a chunk URL is
stable for as long as its content is. `2688.57cddf4b.chunk.js` is byte-identical across builds and
therefore keeps its name. A customer who once stored an app shell under that URL is served it again
on every single attempt, for the year `_headers` marks those assets fresh.

That is why the same customers kept failing on a file that demonstrably exists:

```
curl -sI https://app.dfx.swiss/static/js/2688.57cddf4b.chunk.js  ->  200, application/javascript
```

The failing address is now re-requested with `cache: 'reload'` before the reload. That forces the
browser to the network and makes intermediate caches revalidate, replacing the stored copy. The
reload then happens either way — it is the recovery, and it must not be skipped because the repair
failed.

Only same-origin addresses are touched. The address comes out of an error message, and an embedded
or third-party bundler could put someone else's host there.

## While we are here: `(error:` versus `(missing:`

Worth recording, because it sent this investigation down the wrong path once. Cloudflare sets
`x-content-type-options: nosniff` on every response. When HTML arrives under a `.js` URL the browser
therefore **refuses to execute it** and the script tag fires `error`, not `load` — which webpack
turns into `(error: <url>)`. Verified three ways: in the webpack source
(`JsonpChunkLoadingRuntimeModule.js:188`, `event.type === 'load' ? 'missing' : event.type`), in the
built production bundle, and by reproducing it in a browser.

So `(error:` does **not** rule out "HTML instead of JavaScript" — with `nosniff` it is that case's
signature. `(missing:` would only appear without `nosniff`.

## Tests

672 tests pass, 63 suites. New cases cover: the repair request and its exact options, the reload
still happening when the repair fails, a foreign-origin address being ignored, and all four
behaviours of the repeat guard (same failure suppressed, different route reported, different failure
reported, reported again after the window).

## What this does not fix

Entries already held in the **CDN edge cache**. A hit there never reaches the origin — measured on a
poisoned URL: `cf-cache-status: HIT`, `age: 22609`, a year of freshness. Those entries have to be
purged out of band, otherwise new visitors can still pick one up.
