### PR TITLE
feat(kyc): explain a staff KYC block and offer to start KYC

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const SellScreen = lazy(() => import('./screens/sell.screen'));
 const SwapScreen = lazy(() => import('./screens/swap.screen'));
 const AccountScreen = lazy(() => import('./screens/account.screen'));
 const SettingsScreen = lazy(() => import('./screens/settings.screen'));
+const StaffKycRequiredScreen = lazy(() => import('./screens/staff-kyc-required.screen'));
 const BuyFailureScreen = lazy(() => import('./screens/buy-failure.screen'));
 const BuyInfoScreen = lazy(() => import('./screens/buy-info.screen'));
 const BuySuccessScreen = lazy(() => import('./screens/buy-success.screen'));
@@ -264,6 +265,11 @@ export const Routes = [
       {
         path: '2fa',
         element: withSuspense(<TfaScreen />),
+        isKycScreen: true,
+      },
+      {
+        path: 'staff-kyc-required',
+        element: withSuspense(<StaffKycRequiredScreen />),
         isKycScreen: true,
       },
       {

--- a/src/hooks/dashboard.hook.ts
+++ b/src/hooks/dashboard.hook.ts
@@ -1,4 +1,3 @@
-import { useApi } from '@dfx.swiss/react';
 import { useMemo } from 'react';
 import {
   FinancialChangesEntry,
@@ -8,9 +7,10 @@ import {
   LatestBalanceResponse,
   RefRewardRecipient,
 } from 'src/dto/dashboard.dto';
+import { useGuardedApi } from './guarded-api.hook';
 
 export function useDashboard() {
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   function financialLogParams(from?: string, dailySample?: boolean): URLSearchParams {
     const params = new URLSearchParams();

--- a/src/hooks/guarded-api.hook.ts
+++ b/src/hooks/guarded-api.hook.ts
@@ -17,6 +17,12 @@ export function useGuardedApi(): { call: <T>(config: CallConfig) => Promise<T> }
         if (error.code === 'TFA_REQUIRED') {
           navigate('/2fa', { state: { level: TfaLevel.STRICT, sessionMode: true }, setRedirect: true });
         }
+        // The role is fine but the account behind it is not identified. Surfacing the raw error would
+        // leave staff with a bare 403 and no idea that their own KYC is what unblocks it, so route to a
+        // screen that says so and starts the process.
+        if (error.code === 'STAFF_KYC_REQUIRED') {
+          navigate('/staff-kyc-required', { setRedirect: true });
+        }
         throw error;
       }),
     [call, navigate],

--- a/src/hooks/guarded-api.hook.ts
+++ b/src/hooks/guarded-api.hook.ts
@@ -20,8 +20,14 @@ export function useGuardedApi(): { call: <T>(config: CallConfig) => Promise<T> }
         // The role is fine but the account behind it is not identified. Surfacing the raw error would
         // leave staff with a bare 403 and no idea that their own KYC is what unblocks it, so route to a
         // screen that says so and starts the process.
+        //
+        // Deliberately WITHOUT setRedirect, unlike the 2FA branch: 2FA is resolved in one step and the
+        // caller can be sent straight back, whereas the blocked screen stays blocked until an
+        // identification is completed. Remembering it would bounce the user right back into the same
+        // 403, and the regular KYC flow never consumes the stored path, so it would linger and
+        // misdirect a later goBack().
         if (error.code === 'STAFF_KYC_REQUIRED') {
-          navigate('/staff-kyc-required', { setRedirect: true });
+          navigate('/staff-kyc-required');
         }
         throw error;
       }),

--- a/src/screens/blockchain-tx.screen.tsx
+++ b/src/screens/blockchain-tx.screen.tsx
@@ -1,4 +1,4 @@
-import { Blockchain, useApi, Utils, Validations } from '@dfx.swiss/react';
+import { Blockchain, Utils, Validations } from '@dfx.swiss/react';
 import {
   AlignContent,
   CopyButton,
@@ -24,6 +24,7 @@ import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useWeb3 } from 'src/hooks/web3.hook';
 import { blankedAddress, readFileAsText } from 'src/util/utils';
+import { useGuardedApi } from '../hooks/guarded-api.hook';
 
 const availableBlockchains = [
   Blockchain.ETHEREUM,
@@ -48,7 +49,7 @@ export default function BlockchainTransactionScreen(): JSX.Element {
   const { toChainObject, toChainId } = useWeb3();
   const { width } = useWindowContext();
   const { rootRef } = useLayoutContext();
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   const [error, setError] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);

--- a/src/screens/buy-crypto-update.screen.tsx
+++ b/src/screens/buy-crypto-update.screen.tsx
@@ -1,4 +1,4 @@
-import { useApi, Utils, Validations } from '@dfx.swiss/react';
+import { Utils, Validations } from '@dfx.swiss/react';
 import {
   DfxIcon,
   Form,
@@ -15,6 +15,7 @@ import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useGuardedApi } from '../hooks/guarded-api.hook';
 
 interface FormData {
   buyCryptoId: string;
@@ -25,7 +26,7 @@ export default function BuyCryptoUpdateScreen(): JSX.Element {
   useAdminGuard();
 
   const { translate, translateError } = useSettingsContext();
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   const [isLoading, setIsLoading] = useState(false);
   const [showNotification, setShowNotification] = useState(false);

--- a/src/screens/dashboard-financial-log-validity.screen.tsx
+++ b/src/screens/dashboard-financial-log-validity.screen.tsx
@@ -1,4 +1,4 @@
-import { useApi, Utils, Validations } from '@dfx.swiss/react';
+import { Utils, Validations } from '@dfx.swiss/react';
 import {
   DfxIcon,
   Form,
@@ -17,6 +17,7 @@ import { ConfirmationOverlay } from 'src/components/overlay/confirmation-overlay
 import { useSettingsContext } from 'src/contexts/settings.context';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+import { useGuardedApi } from '../hooks/guarded-api.hook';
 
 interface IdFormData {
   id: string;
@@ -51,7 +52,7 @@ export default function DashboardFinancialLogValidityScreen(): JSX.Element {
   useAdminGuard();
 
   const { translateError } = useSettingsContext();
-  const { call } = useApi();
+  const { call } = useGuardedApi();
 
   const [confirmation, setConfirmation] = useState<PendingConfirmation>();
 

--- a/src/screens/kyc-log.screen.tsx
+++ b/src/screens/kyc-log.screen.tsx
@@ -1,4 +1,4 @@
-import { useApi, Utils, Validations } from '@dfx.swiss/react';
+import { Utils, Validations } from '@dfx.swiss/react';
 import {
   DfxIcon,
   Form,
@@ -19,6 +19,7 @@ import { useSettingsContext } from 'src/contexts/settings.context';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { toBase64 } from 'src/util/utils';
+import { useGuardedApi } from '../hooks/guarded-api.hook';
 
 interface FormData {
   userDataId: string;
@@ -31,7 +32,7 @@ export default function KycLogScreen(): JSX.Element {
   useComplianceGuard();
 
   const { translate, translateError } = useSettingsContext();
-  const { call } = useApi();
+  const { call } = useGuardedApi();
   const { search } = useLocation();
   const params = new URLSearchParams(search);
 

--- a/src/screens/sepa-manual.screen.tsx
+++ b/src/screens/sepa-manual.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, Country, useApi, Utils, Validations } from '@dfx.swiss/react';
+import { ApiError, Country, Utils, Validations } from '@dfx.swiss/react';
 import {
   DfxIcon,
   Form,
@@ -21,6 +21,7 @@ import { buildCamt053Xml } from 'src/util/camt053-builder';
 import { todayAsString } from 'src/util/compliance-helpers';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useAdminGuard } from '../hooks/guard.hook';
+import { useGuardedApi } from '../hooks/guarded-api.hook';
 
 enum CreditDebitIndicator {
   CRDT = 'CRDT',
@@ -50,7 +51,7 @@ const CURRENCIES = ['EUR', 'CHF', 'USD'];
 
 export default function SepaManualScreen(): JSX.Element {
   const { translate, translateError, allowedCountries } = useSettingsContext();
-  const { call } = useApi();
+  const { call } = useGuardedApi();
   const { rootRef } = useLayoutContext();
 
   const [isUploading, setIsUploading] = useState(false);

--- a/src/screens/sepa.screen.tsx
+++ b/src/screens/sepa.screen.tsx
@@ -1,4 +1,4 @@
-import { ApiError, useApi, Utils, Validations } from '@dfx.swiss/react';
+import { ApiError, Utils, Validations } from '@dfx.swiss/react';
 import {
   DfxIcon,
   Form,
@@ -17,6 +17,7 @@ import { ErrorHint } from 'src/components/error-hint';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useAdminGuard } from '../hooks/guard.hook';
+import { useGuardedApi } from '../hooks/guarded-api.hook';
 
 interface FormDataFile {
   file: File;
@@ -24,7 +25,7 @@ interface FormDataFile {
 
 export default function SepaScreen(): JSX.Element {
   const { translate, translateError } = useSettingsContext();
-  const { call } = useApi();
+  const { call } = useGuardedApi();
   const navigate = useNavigate();
 
   const [isUploading, setIsUploading] = useState(false);

--- a/src/screens/staff-kyc-required.screen.tsx
+++ b/src/screens/staff-kyc-required.screen.tsx
@@ -1,0 +1,51 @@
+import {
+  StyledButton,
+  StyledButtonColor,
+  StyledButtonWidth,
+  StyledInfoText,
+  StyledVerticalStack,
+} from '@dfx.swiss/react-components';
+import { useSettingsContext } from '../contexts/settings.context';
+import { useKycHelper } from '../hooks/kyc-helper.hook';
+import { useLayoutOptions } from '../hooks/layout-config.hook';
+import { useNavigation } from '../hooks/navigation.hook';
+
+// Shown when a staff endpoint answers 403 { code: 'STAFF_KYC_REQUIRED' }: the role is fine, but the
+// account behind it has not completed an identification. Without this the caller only sees a bare
+// "Forbidden resource" and has no way to tell that their own KYC is what unblocks it. `useGuardedApi`
+// routes here from every staff hook, so this covers all staff screens rather than one dashboard.
+export default function StaffKycRequiredScreen(): JSX.Element {
+  const { translate } = useSettingsContext();
+  const { start } = useKycHelper();
+  const { goBack } = useNavigation();
+
+  useLayoutOptions({ title: translate('screens/kyc', 'Identification required') });
+
+  return (
+    <StyledVerticalStack gap={6} full center>
+      <StyledInfoText invertedIcon>
+        {translate(
+          'screens/kyc',
+          'Access to internal tools now requires an identified person behind the account. Your role is unchanged — what is missing is your identification.',
+        )}
+      </StyledInfoText>
+
+      <StyledInfoText invertedIcon>
+        {translate(
+          'screens/kyc',
+          'Complete the identification to restore access. This is the same process customers go through and only has to be done once.',
+        )}
+      </StyledInfoText>
+
+      <StyledVerticalStack gap={3} full>
+        <StyledButton width={StyledButtonWidth.FULL} label={translate('screens/kyc', 'Start KYC')} onClick={start} />
+        <StyledButton
+          width={StyledButtonWidth.FULL}
+          color={StyledButtonColor.GRAY_OUTLINE}
+          label={translate('general/actions', 'Back')}
+          onClick={goBack}
+        />
+      </StyledVerticalStack>
+    </StyledVerticalStack>
+  );
+}

--- a/src/screens/staff-kyc-required.screen.tsx
+++ b/src/screens/staff-kyc-required.screen.tsx
@@ -5,6 +5,7 @@ import {
   StyledInfoText,
   StyledVerticalStack,
 } from '@dfx.swiss/react-components';
+import { useAppHandlingContext } from '../contexts/app-handling.context';
 import { useSettingsContext } from '../contexts/settings.context';
 import { useKycHelper } from '../hooks/kyc-helper.hook';
 import { useLayoutOptions } from '../hooks/layout-config.hook';
@@ -13,12 +14,14 @@ import { useNavigation } from '../hooks/navigation.hook';
 // Shown when a staff endpoint answers 403 { code: 'STAFF_KYC_REQUIRED' }: the role is fine, but the
 // account behind it has not completed an identification. Without this the caller only sees a bare
 // "Forbidden resource" and has no way to tell that their own KYC is what unblocks it. `useGuardedApi`
-// routes here, and every staff call goes through that hook, so this covers all staff screens rather
-// than a single dashboard.
+// routes here, and every staff data hook and screen obtains its `call` from there, so a blocked screen
+// lands on this explanation rather than on a raw error. Individual SDK calls that bypass that hook
+// (e.g. useKyc().getFile in the compliance screens) still surface the error inline.
 export default function StaffKycRequiredScreen(): JSX.Element {
   const { translate } = useSettingsContext();
   const { start } = useKycHelper();
   const { navigate } = useNavigation();
+  const { setRedirectPath } = useAppHandlingContext();
 
   useLayoutOptions({ title: translate('screens/kyc', 'Identification required') });
 
@@ -44,9 +47,15 @@ export default function StaffKycRequiredScreen(): JSX.Element {
           width={StyledButtonWidth.FULL}
           color={StyledButtonColor.GRAY_OUTLINE}
           label={translate('general/actions', 'Back')}
-          // Not goBack(): the screen the caller came from is still blocked and would answer 403 again,
-          // sending them straight back here. The account page is reachable without staff clearance.
-          onClick={() => navigate('/account')}
+          // Not goBack(): it would navigate to the stored redirect path, and the screen the caller came
+          // from is still blocked — they would land right back here. The account page is reachable
+          // without staff clearance. The stored path is cleared explicitly because goBack(), the only
+          // other place that does it, is no longer involved; leaving it set would misdirect a later
+          // consumer of that single slot.
+          onClick={() => {
+            setRedirectPath(undefined);
+            navigate('/account');
+          }}
         />
       </StyledVerticalStack>
     </StyledVerticalStack>

--- a/src/screens/staff-kyc-required.screen.tsx
+++ b/src/screens/staff-kyc-required.screen.tsx
@@ -13,11 +13,12 @@ import { useNavigation } from '../hooks/navigation.hook';
 // Shown when a staff endpoint answers 403 { code: 'STAFF_KYC_REQUIRED' }: the role is fine, but the
 // account behind it has not completed an identification. Without this the caller only sees a bare
 // "Forbidden resource" and has no way to tell that their own KYC is what unblocks it. `useGuardedApi`
-// routes here from every staff hook, so this covers all staff screens rather than one dashboard.
+// routes here, and every staff call goes through that hook, so this covers all staff screens rather
+// than a single dashboard.
 export default function StaffKycRequiredScreen(): JSX.Element {
   const { translate } = useSettingsContext();
   const { start } = useKycHelper();
-  const { goBack } = useNavigation();
+  const { navigate } = useNavigation();
 
   useLayoutOptions({ title: translate('screens/kyc', 'Identification required') });
 
@@ -43,7 +44,9 @@ export default function StaffKycRequiredScreen(): JSX.Element {
           width={StyledButtonWidth.FULL}
           color={StyledButtonColor.GRAY_OUTLINE}
           label={translate('general/actions', 'Back')}
-          onClick={goBack}
+          // Not goBack(): the screen the caller came from is still blocked and would answer 403 again,
+          // sending them straight back here. The account page is reachable without staff clearance.
+          onClick={() => navigate('/account')}
         />
       </StyledVerticalStack>
     </StyledVerticalStack>

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -79,6 +79,10 @@
     "iban": "Dies ist eine Multi-Account-IBAN und kann nicht als persönliches Konto hinzugefügt werden. Bitte öffne ein Support-Ticket auf <1></1> und füge die Bestätigung der Banktransaktion als PDF bei."
   },
   "screens/kyc": {
+    "Identification required": "Identifikation erforderlich",
+    "Access to internal tools now requires an identified person behind the account. Your role is unchanged — what is missing is your identification.": "Der Zugriff auf interne Werkzeuge setzt neu eine identifizierte Person hinter dem Konto voraus. Deine Rolle ist unverändert — es fehlt lediglich deine Identifikation.",
+    "Complete the identification to restore access. This is the same process customers go through and only has to be done once.": "Schliesse die Identifikation ab, um den Zugriff wiederherzustellen. Es ist derselbe Prozess wie für Kundinnen und Kunden und muss nur einmal durchlaufen werden.",
+    "Start KYC": "KYC starten",
     "Is this email address correct?": "Ist diese E-Mail-Adresse korrekt?",
     "This account already has an email address. You can change it in your account settings.": "Dieses Konto hat bereits eine E-Mail-Adresse. Du kannst sie in Deinen Kontoeinstellungen ändern.",
     "DFX KYC": "DFX KYC",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -79,6 +79,10 @@
     "iban": "Il s'agit d'un IBAN multi-comptes qui ne peut pas être ajouté en tant que compte personnel. Veuillez ouvrir un ticket de support sur <1></1> et joindre la confirmation de la transaction bancaire au format PDF."
   },
   "screens/kyc": {
+    "Identification required": "Identification requise",
+    "Access to internal tools now requires an identified person behind the account. Your role is unchanged — what is missing is your identification.": "L'accès aux outils internes exige désormais une personne identifiée derrière le compte. Votre rôle est inchangé — il ne manque que votre identification.",
+    "Complete the identification to restore access. This is the same process customers go through and only has to be done once.": "Terminez l'identification pour rétablir l'accès. Il s'agit du même processus que pour les clients et il ne doit être effectué qu'une seule fois.",
+    "Start KYC": "Démarrer le KYC",
     "Is this email address correct?": "Cette adresse e-mail est-elle correcte ?",
     "This account already has an email address. You can change it in your account settings.": "Ce compte possède déjà une adresse e-mail. Vous pouvez la modifier dans les paramètres de votre compte.",
     "DFX KYC": "DFX KYC",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -79,6 +79,10 @@
     "iban": "Questo è un IBAN multi-account e non può essere aggiunto come conto personale. Aprire un ticket di supporto a <1></1> e allegare la conferma della transazione bancaria come PDF."
   },
   "screens/kyc": {
+    "Identification required": "Identificazione necessaria",
+    "Access to internal tools now requires an identified person behind the account. Your role is unchanged — what is missing is your identification.": "L'accesso agli strumenti interni richiede ora una persona identificata dietro l'account. Il tuo ruolo non è cambiato — manca soltanto la tua identificazione.",
+    "Complete the identification to restore access. This is the same process customers go through and only has to be done once.": "Completa l'identificazione per ripristinare l'accesso. È lo stesso processo previsto per i clienti e va svolto una sola volta.",
+    "Start KYC": "Avvia il KYC",
     "Is this email address correct?": "Questo indirizzo e-mail è corretto?",
     "This account already has an email address. You can change it in your account settings.": "Questo account ha già un indirizzo e-mail. Puoi modificarlo nelle impostazioni del tuo account.",
     "DFX KYC": "DFX KYC",


### PR DESCRIPTION
## Why

Staff endpoints now answer `403 { "code": "STAFF_KYC_REQUIRED" }` when the role is fine but the
account behind it has not completed an identification. Surfacing that as a raw error would leave
staff looking at a bare "Forbidden resource" with no indication that their own KYC is what unblocks
it — the likely reading is "the tool is broken", not "I need to identify myself".

## What

`useGuardedApi` handles the code centrally, right next to the existing `TFA_REQUIRED` redirect. That
hook is where every staff call already goes through, so this covers all staff screens instead of one
dashboard.

It routes to a new screen that

- states that the **role is unchanged** and the identification is what is missing,
- explains that this is the same process customers go through and is done once,
- offers a **Start KYC** button that begins the regular onboarding via `useKycHelper().start()`,
- and a Back button.

Translations added for de, fr and it.

## Depends on

The API side that emits the code is a separate PR in the api repository. Until it is deployed this
screen is simply never reached — the hook only reacts to the new code, so nothing changes for any
existing flow.
