### PR TITLE
Stop a wrong asset response from outliving the deploy that caused it

### DIFF
--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -188,10 +188,11 @@ jobs:
           echo "  url: $url"
           if [ -n "$last_error" ]; then
             echo "  last error: $last_error"
+            echo "This means the verify request itself never got a response from the server (a transport failure, not an answer) -- investigate connectivity to app.dfx.swiss or the runner's network before trusting this deploy."
           else
             echo "  last status: $status"
             echo "  last content-type: $content_type"
             echo "  last cache-control: $cache_control"
+            echo "This means an absent /static/* asset is answered with something other than a plain 404 (e.g. the SPA fallback or other HTML) -- the exact failure mode from the cached-fallback incident. Investigate functions/[[path]].js, public/_routes.json and public/_headers before trusting this deploy."
           fi
-          echo "This means an absent /static/* asset is answered with something other than a plain 404 (e.g. the SPA fallback, HTML, or a transport failure) -- the exact failure mode from the cached-fallback incident. Investigate functions/[[path]].js, public/_routes.json and public/_headers before trusting this deploy."
           exit 1

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -80,10 +80,11 @@ jobs:
       - name: Verify missing assets return 404 (not the SPA fallback)
         run: |
           # functions/[[path]].js + public/_routes.json turn a missing /static/* asset into a
-          # plain 404 instead of the SPA fallback (index.html, status 200) that used to get
-          # cached under the asset's own URL for a year (see public/_headers). This step is a
-          # smoke test, run after every PRD deploy, for exactly that regression -- see below
-          # for what it actually proves and what it does not.
+          # plain 404 instead of the SPA fallback (index.html, status 200) that used to be
+          # eligible to stay cached under the asset's own URL for up to a year, until evicted or
+          # cleared (see public/_headers). This step is a smoke test, run after every PRD deploy,
+          # for exactly that regression -- see below for what it actually proves and what it does
+          # not.
           #
           # First wait until THIS deploy is live at the custom domain (build/deploy-id.txt
           # carries this run's id and attempt). Only then is the 404 check meaningful — an
@@ -159,10 +160,12 @@ jobs:
           content_type=""
           cache_control=""
           last_error=""
+          any_response_received=false
 
           while [ "$attempt" -le "$max_attempts" ]; do
             if raw=$(curl -s -D - -o /dev/null --max-time 10 -w 'HTTP_STATUS:%{http_code}\n' "$url"); then
               last_error=''
+              any_response_received=true
               status=$(printf '%s\n' "$raw" | sed -n 's/^HTTP_STATUS://p')
               content_type=$(printf '%s\n' "$raw" | tr -d '\r' | tr '[:upper:]' '[:lower:]' | awk '/^content-type:/{sub(/^[^:]+:[[:space:]]*/,""); sub(/[[:space:]]+$/,""); print; exit}')
               cache_control=$(printf '%s\n' "$raw" | tr -d '\r' | tr '[:upper:]' '[:lower:]' | awk '/^cache-control:/{sub(/^[^:]+:[[:space:]]*/,""); sub(/[[:space:]]+$/,""); print; exit}')
@@ -186,13 +189,20 @@ jobs:
 
           echo "FAIL: missing asset was not answered with a bare 404 after $max_attempts attempts."
           echo "  url: $url"
-          if [ -n "$last_error" ]; then
+          if [ "$any_response_received" = false ]; then
+            # last_error is necessarily set here: every one of the $max_attempts attempts in this
+            # run failed to complete, not just the final one.
             echo "  last error: $last_error"
-            echo "This means the verify request itself never got a response from the server (a transport failure, not an answer) -- investigate connectivity to app.dfx.swiss or the runner's network before trusting this deploy."
+            echo "None of the $max_attempts attempts completed -- the request never received a response to inspect. Investigate connectivity to app.dfx.swiss or the runner's network before trusting this deploy."
+          elif [ -n "$last_error" ]; then
+            # any_response_received is true, so an earlier attempt did get a complete answer; this
+            # is the final attempt failing to complete, not the whole run.
+            echo "  last error: $last_error"
+            echo "The final attempt did not complete -- no response was accepted from it. Earlier attempts did receive a complete response, and none of them satisfied the required contract (status 404, content-type text/plain; charset=utf-8, cache-control no-store). Investigate functions/[[path]].js, public/_routes.json and public/_headers before trusting this deploy."
           else
             echo "  last status: $status"
             echo "  last content-type: $content_type"
             echo "  last cache-control: $cache_control"
-            echo "This means an absent /static/* asset is answered with something other than a plain 404 (e.g. the SPA fallback or other HTML) -- the exact failure mode from the cached-fallback incident. Investigate functions/[[path]].js, public/_routes.json and public/_headers before trusting this deploy."
+            echo "The response received does not satisfy the required contract (status 404, content-type text/plain; charset=utf-8, cache-control no-store) -- which is what a client would see if an absent /static/* asset fell through to the SPA fallback (the cached-fallback incident this check exists for), though a mismatch here does not by itself prove that cause over an unrelated server error. Investigate functions/[[path]].js, public/_routes.json and public/_headers before trusting this deploy."
           fi
           exit 1

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -121,14 +121,14 @@ jobs:
                 echo "OK: deploy marker matches $expected_deploy_id (attempt $attempt)"
                 break
               fi
-              echo "Attempt $attempt/$max_attempts: deploy-id.txt body='$marker_body' expected='$expected_deploy_id' (waiting for new deploy to go live)"
+              echo "Attempt $attempt/$max_attempts: deploy-id.txt body='$marker_body' expected='$expected_deploy_id' (no matching marker observed yet, retrying)"
             else
               marker_body=''
               last_error='transport failure (curl could not complete the request)'
-              echo "Attempt $attempt/$max_attempts: curl failed fetching deploy-id.txt (waiting for new deploy to go live)"
+              echo "Attempt $attempt/$max_attempts: curl failed fetching deploy-id.txt (no marker observed this attempt, retrying)"
             fi
             if [ "$attempt" -eq "$max_attempts" ]; then
-              echo "FAIL: new deploy did not become active at the custom domain within $max_attempts attempts."
+              echo "FAIL: no marker matching this run was observed at the custom domain within $max_attempts attempts."
               echo "  url: ${marker_url}"
               if [ -n "$last_error" ]; then
                 echo "  last error: $last_error"

--- a/.github/workflows/prd.yml
+++ b/.github/workflows/prd.yml
@@ -63,8 +63,135 @@ jobs:
       - name: Install Wrangler
         run: npm install -g wrangler@4
 
+      # Marker file the verify step polls before checking the 404 response. Seeing this
+      # deploy's marker at least once shows the new version is live somewhere at the edge --
+      # it does not prove the 404 check below was answered by that same edge node (see that
+      # step's comment). Includes run_attempt so a re-run of the same workflow run writes a
+      # distinct marker.
+      - name: Write deploy marker
+        run: printf '%s' '${{ github.run_id }}-${{ github.run_attempt }}' > build/deploy-id.txt
+
       - name: Deploy to Cloudflare Pages (PRD)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: wrangler pages deploy build --project-name=dfx-app-prd --branch=main
+
+      - name: Verify missing assets return 404 (not the SPA fallback)
+        run: |
+          # functions/[[path]].js + public/_routes.json turn a missing /static/* asset into a
+          # plain 404 instead of the SPA fallback (index.html, status 200) that used to get
+          # cached under the asset's own URL for a year (see public/_headers). This step is a
+          # smoke test, run after every PRD deploy, for exactly that regression -- see below
+          # for what it actually proves and what it does not.
+          #
+          # First wait until THIS deploy is live at the custom domain (build/deploy-id.txt
+          # carries this run's id and attempt). Only then is the 404 check meaningful — an
+          # older deploy that already had the 404 fix would pass a path-only check without
+          # ever validating the version just uploaded.
+          #
+          # The marker poll and the 404 check are separate HTTP requests. During partial
+          # edge propagation they could in theory be answered by different edge nodes (or
+          # different deploy versions). Pages Functions on a direct-upload deploy
+          # (wrangler pages deploy, as used here) have no reliable deploy identity readable
+          # from the function, so this step cannot prove that the marker poll and the 404
+          # check were answered by the same edge state. What it does prove: a matching deploy
+          # marker was seen at least once, and production answered the missing-asset check
+          # with a correct 404 at least once -- not that both came from the same edge. That
+          # makes this a smoke test, not a per-node proof: it reliably catches a real
+          # regression once the broken behaviour is widespread across the edge, since every
+          # attempt then hits it regardless of which node answers; it gives no guarantee about
+          # a regression still confined to a single node.
+
+          expected_deploy_id='${{ github.run_id }}-${{ github.run_attempt }}'
+          marker_url='https://app.dfx.swiss/deploy-id.txt'
+          max_attempts=12
+          sleep_seconds=5
+          attempt=1
+          marker_body=''
+          last_error=''
+
+          while [ "$attempt" -le "$max_attempts" ]; do
+            cb="$(date +%s)-${attempt}"
+            if marker_body=$(curl -s --max-time 10 "${marker_url}?cb=${cb}"); then
+              last_error=''
+              marker_body=$(printf '%s' "$marker_body" | tr -d '\r\n')
+              if [ "$marker_body" = "$expected_deploy_id" ]; then
+                echo "OK: deploy marker matches $expected_deploy_id (attempt $attempt)"
+                break
+              fi
+              echo "Attempt $attempt/$max_attempts: deploy-id.txt body='$marker_body' expected='$expected_deploy_id' (waiting for new deploy to go live)"
+            else
+              marker_body=''
+              last_error='transport failure (curl could not complete the request)'
+              echo "Attempt $attempt/$max_attempts: curl failed fetching deploy-id.txt (waiting for new deploy to go live)"
+            fi
+            if [ "$attempt" -eq "$max_attempts" ]; then
+              echo "FAIL: new deploy did not become active at the custom domain within $max_attempts attempts."
+              echo "  url: ${marker_url}"
+              if [ -n "$last_error" ]; then
+                echo "  last error: $last_error"
+              else
+                echo "  last body: $marker_body"
+              fi
+              echo "  expected: $expected_deploy_id"
+              echo "Without a matching deploy marker the subsequent 404 check would only prove that SOME deploy answers missing assets correctly — not that this run's deploy does. The new version therefore remains untested."
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            sleep "$sleep_seconds"
+          done
+
+          # The asset name is randomised per run (and attempt): functions/[[path]].js answers a
+          # missing asset with cache-control: no-store, so no prior run's 404 should still be
+          # cached anywhere, but randomising removes any dependency on that holding true for
+          # this check to be valid.
+          asset="/static/js/does-not-exist.${{ github.run_id }}-${{ github.run_attempt }}-$(date +%s).chunk.js"
+          url="https://app.dfx.swiss${asset}"
+
+          # A fresh Cloudflare Pages deploy can take a few seconds to become the version served
+          # at the custom domain, so a non-matching response (or a transport failure) is retried;
+          # it is never accepted as a pass, and running out of attempts fails the build.
+          # Success requires the exact headers functions/[[path]].js notFound() returns:
+          # status 404, content-type text/plain; charset=utf-8, cache-control no-store.
+          attempt=1
+          status=""
+          content_type=""
+          cache_control=""
+          last_error=""
+
+          while [ "$attempt" -le "$max_attempts" ]; do
+            if raw=$(curl -s -D - -o /dev/null --max-time 10 -w 'HTTP_STATUS:%{http_code}\n' "$url"); then
+              last_error=''
+              status=$(printf '%s\n' "$raw" | sed -n 's/^HTTP_STATUS://p')
+              content_type=$(printf '%s\n' "$raw" | tr -d '\r' | tr '[:upper:]' '[:lower:]' | awk '/^content-type:/{sub(/^[^:]+:[[:space:]]*/,""); sub(/[[:space:]]+$/,""); print; exit}')
+              cache_control=$(printf '%s\n' "$raw" | tr -d '\r' | tr '[:upper:]' '[:lower:]' | awk '/^cache-control:/{sub(/^[^:]+:[[:space:]]*/,""); sub(/[[:space:]]+$/,""); print; exit}')
+
+              if [ "$status" = "404" ] && [ "$content_type" = "text/plain; charset=utf-8" ] && [ "$cache_control" = "no-store" ]; then
+                echo "OK: $url -> $status, content-type: $content_type, cache-control: $cache_control"
+                exit 0
+              fi
+
+              echo "Attempt $attempt/$max_attempts: $url -> status=$status content-type=$content_type cache-control=$cache_control (waiting for deploy to go live)"
+            else
+              status=''
+              content_type=''
+              cache_control=''
+              last_error='transport failure (curl could not complete the request)'
+              echo "Attempt $attempt/$max_attempts: curl failed fetching $url (waiting for deploy to go live)"
+            fi
+            attempt=$((attempt + 1))
+            sleep "$sleep_seconds"
+          done
+
+          echo "FAIL: missing asset was not answered with a bare 404 after $max_attempts attempts."
+          echo "  url: $url"
+          if [ -n "$last_error" ]; then
+            echo "  last error: $last_error"
+          else
+            echo "  last status: $status"
+            echo "  last content-type: $content_type"
+            echo "  last cache-control: $cache_control"
+          fi
+          echo "This means an absent /static/* asset is answered with something other than a plain 404 (e.g. the SPA fallback, HTML, or a transport failure) -- the exact failure mode from the cached-fallback incident. Investigate functions/[[path]].js, public/_routes.json and public/_headers before trusting this deploy."
+          exit 1

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -51,13 +51,13 @@ async function resolveConditional(context) {
 function isFallback(response) {
   if (!response.ok) return false;
 
-  // Real assets from ASSETS always carry a platform-set content-type. An ok response
-  // without one has no guarantee it is a real file — treat it like a fallback, not as
-  // safe to pass through.
-  const contentType = response.headers.get('content-type');
-  if (contentType === null) return true;
+  // Real assets from ASSETS always carry a platform-set content-type. An ok response with
+  // none, or with one present but empty, has no guarantee it is a real file — treat both
+  // like a fallback, not as safe to pass through.
+  const contentType = (response.headers.get('content-type') ?? '').split(';')[0].trim().toLowerCase();
+  if (contentType === '') return true;
 
-  return contentType.split(';')[0].trim().toLowerCase() === 'text/html';
+  return contentType === 'text/html';
 }
 
 function notFound() {

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -57,7 +57,7 @@ function isFallback(response) {
   const contentType = response.headers.get('content-type');
   if (contentType === null) return true;
 
-  return contentType.toLowerCase().includes('text/html');
+  return contentType.split(';')[0].trim().toLowerCase() === 'text/html';
 }
 
 function notFound() {

--- a/functions/[[path]].js
+++ b/functions/[[path]].js
@@ -49,7 +49,15 @@ async function resolveConditional(context) {
 }
 
 function isFallback(response) {
-  return response.ok && (response.headers.get('content-type') ?? '').includes('text/html');
+  if (!response.ok) return false;
+
+  // Real assets from ASSETS always carry a platform-set content-type. An ok response
+  // without one has no guarantee it is a real file — treat it like a fallback, not as
+  // safe to pass through.
+  const contentType = response.headers.get('content-type');
+  if (contentType === null) return true;
+
+  return contentType.toLowerCase().includes('text/html');
 }
 
 function notFound() {

--- a/public/_headers
+++ b/public/_headers
@@ -16,9 +16,29 @@
 # outcomes, depending only on whether that particular response gets cached.
 # Changing that is a CDN configuration matter; it cannot be fixed in this file.
 #
-# Fingerprinted build assets (content-hashed filenames) never change -> cache hard.
+# Fingerprinted build assets (content-hashed filenames) never change -> cache hard. The
+# max-age therefore stays at a year, but immutable is deliberately NOT set: immutable stops
+# a normal user-triggered reload from sending a conditional revalidation while max-age is
+# still valid — the case it is designed for — whereas a hard reload (empty cache and hard
+# reload / Ctrl+Shift+R) bypasses the cache entirely, independent of immutable. This rule
+# matches on the /static/* path, not on what actually got served under it, and
+# functions/[[path]].js + public/_routes.json are the only content check in the
+# chain — an incident there (a routing gap, a bad deploy, a fallback that slips through)
+# can still land an app-shell response under an asset URL. With immutable, that single
+# wrong response would be pinned for the full year — for ordinary navigation and a normal
+# reload, not a hard reload — in every browser that already fetched it, for exactly the
+# client it broke. Without it, a user-triggered reload can still send
+# a conditional revalidation request — independent of whether max-age has expired — and
+# correct itself; ordinary navigation (no reload) keeps the stored copy for up to a year
+# without revalidating. max-age=31536000 continues to apply to shared/edge caches either
+# way: dropping immutable only affects the client, and a wrong response already at the
+# edge is cleared only by purging, not by this choice. Since the filename hash only
+# changes when the content actually changes, a revalidation is answered 304 (unchanged)
+# in the normal case, so this costs a conditional round trip, but not a re-transfer of
+# the content, for the common path — it only helps the
+# broken one. Verify with: curl -sI https://app.dfx.swiss/static/js/main.<hash>.js
 /static/*
-  Cache-Control: public, max-age=31536000, immutable
+  Cache-Control: public, max-age=31536000
   Access-Control-Allow-Origin: *
 
 # The embeddable widget is loaded cross-origin from third-party sites -> needs CORS.
@@ -41,7 +61,15 @@
 /robots.txt
   Cache-Control: no-cache, must-revalidate
 
-# Non-fingerprinted root assets — a day of cache is enough.
+# Deploy marker written per CI run and polled by the PRD verify step. Must never be cached:
+# each poll has to reflect the deploy that is currently live, not a previous run's id.
+/deploy-id.txt
+  Cache-Control: no-store
+
+# Non-fingerprinted root assets — a day of cache is enough. Both paths are also listed in
+# public/_routes.json include so functions/[[path]].js content-checks them: a missing
+# favicon.ico/logo.png is answered 404 instead of landing as SPA-fallback HTML under the
+# image URL for 24h — same failure mode as /static/*, only with a shorter cache lifetime.
 /favicon.ico
   Cache-Control: public, max-age=86400
 /logo.png

--- a/public/_headers
+++ b/public/_headers
@@ -63,10 +63,11 @@
 # 304 carries no body), so a missing manifest.json/asset-manifest.json/version.json served as
 # the SPA fallback could be confirmed valid by a later conditional request instead of being
 # refetched — the same failure mode as /static/*, reached through revalidation instead of a
-# long max-age. version.json is rewritten by scripts/generate-version.js before every main-app build
-# (the commit hash as of that build, and a build time that is always fresh), so it is at least as
-# exposed to this as the other two. All three paths are listed in public/_routes.json include so functions/[[path]].js
-# content-checks them and answers 404 instead.
+# long max-age. version.json is rewritten by scripts/generate-version.js before every main-app
+# build (the checked-out commit hash when git metadata is available, 'unknown' otherwise, plus a
+# build time that is always fresh), so it is at least as exposed to this as the other two. All
+# three paths are listed in public/_routes.json include so functions/[[path]].js content-checks
+# them and answers 404 instead.
 /manifest.json
   Cache-Control: no-cache, must-revalidate
 /asset-manifest.json

--- a/public/_headers
+++ b/public/_headers
@@ -60,14 +60,18 @@
   Cache-Control: no-cache, must-revalidate
 
 # no-cache still stores the response and lets a later request reuse it once revalidated (a
-# 304 carries no body), so a missing manifest.json/asset-manifest.json served as the SPA
-# fallback could be confirmed valid by a later conditional request instead of being
+# 304 carries no body), so a missing manifest.json/asset-manifest.json/version.json served as
+# the SPA fallback could be confirmed valid by a later conditional request instead of being
 # refetched — the same failure mode as /static/*, reached through revalidation instead of a
-# long max-age. Both paths are listed in public/_routes.json include so
-# functions/[[path]].js content-checks them and answers 404 instead.
+# long max-age. version.json is written fresh by scripts/generate-version.js before every build
+# (a new commit hash and build time each time), so it is at least as exposed to this as the other
+# two. All three paths are listed in public/_routes.json include so functions/[[path]].js
+# content-checks them and answers 404 instead.
 /manifest.json
   Cache-Control: no-cache, must-revalidate
 /asset-manifest.json
+  Cache-Control: no-cache, must-revalidate
+/version.json
   Cache-Control: no-cache, must-revalidate
 
 # Crawler directives in robots.txt must always revalidate so they take effect on the next

--- a/public/_headers
+++ b/public/_headers
@@ -63,9 +63,9 @@
 # 304 carries no body), so a missing manifest.json/asset-manifest.json/version.json served as
 # the SPA fallback could be confirmed valid by a later conditional request instead of being
 # refetched — the same failure mode as /static/*, reached through revalidation instead of a
-# long max-age. version.json is written fresh by scripts/generate-version.js before every build
-# (a new commit hash and build time each time), so it is at least as exposed to this as the other
-# two. All three paths are listed in public/_routes.json include so functions/[[path]].js
+# long max-age. version.json is rewritten by scripts/generate-version.js before every main-app build
+# (the commit hash as of that build, and a build time that is always fresh), so it is at least as
+# exposed to this as the other two. All three paths are listed in public/_routes.json include so functions/[[path]].js
 # content-checks them and answers 404 instead.
 /manifest.json
   Cache-Control: no-cache, must-revalidate

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,6 @@
-# Cloudflare Pages edge headers — replicate the cache/CORS semantics the previous
-# CDN served, so the Pages deployment behaves identically.
+# Cloudflare Pages edge headers — mostly carry over the cache/CORS semantics the previous
+# CDN served; where matching it exactly would reintroduce a caching bug, this file departs
+# from it on purpose (see the rules below for where and why).
 #
 # Note: for cached responses the CDN edge raises any max-age below four hours to four
 # hours; higher values stay as written. Uncached responses pass through unchanged, and
@@ -20,22 +21,24 @@
 # max-age therefore stays at a year, but immutable is deliberately NOT set: immutable stops
 # a normal user-triggered reload from sending a conditional revalidation while max-age is
 # still valid — the case it is designed for — whereas a hard reload (empty cache and hard
-# reload / Ctrl+Shift+R) bypasses the cache entirely, independent of immutable. This rule
-# matches on the /static/* path, not on what actually got served under it, and
-# functions/[[path]].js + public/_routes.json are the only content check in the
+# reload / Ctrl+Shift+R) bypasses the browser's local cache entirely, independent of
+# immutable. This rule matches on the /static/* path, not on what actually got served under
+# it, and functions/[[path]].js + public/_routes.json are the only content check in the
 # chain — an incident there (a routing gap, a bad deploy, a fallback that slips through)
 # can still land an app-shell response under an asset URL. With immutable, that single
-# wrong response would be pinned for the full year — for ordinary navigation and a normal
-# reload, not a hard reload — in every browser that already fetched it, for exactly the
-# client it broke. Without it, a user-triggered reload can still send
-# a conditional revalidation request — independent of whether max-age has expired — and
-# correct itself; ordinary navigation (no reload) keeps the stored copy for up to a year
-# without revalidating. max-age=31536000 continues to apply to shared/edge caches either
-# way: dropping immutable only affects the client, and a wrong response already at the
-# edge is cleared only by purging, not by this choice. Since the filename hash only
-# changes when the content actually changes, a revalidation is answered 304 (unchanged)
-# in the normal case, so this costs a conditional round trip, but not a re-transfer of
-# the content, for the common path — it only helps the
+# wrong response would stay eligible to be served for up to a year — for ordinary
+# navigation and a normal reload, not a hard reload — in every browser that already fetched
+# it and still holds it (an entry can be evicted under storage pressure, or a user can clear
+# their browser cache, before then). Without immutable, a user-triggered reload can still
+# send a conditional revalidation request — independent of whether max-age has expired —
+# and correct itself; ordinary navigation (no reload) keeps the stored copy for up to a
+# year without revalidating, same as with immutable. max-age=31536000 continues to apply to
+# shared/edge caches either way: dropping immutable only affects the client, and a wrong
+# response already at the edge is not cleared by this choice — only purging it, its own
+# max-age eventually running out, or the edge evicting it under storage pressure removes
+# it. Since the filename hash only changes when the content actually changes, a
+# revalidation is answered 304 (unchanged) in the normal case, so this costs a conditional
+# round trip, but not a re-transfer of the content, for the common path — it only helps the
 # broken one. Verify with: curl -sI https://app.dfx.swiss/static/js/main.<hash>.js
 /static/*
   Cache-Control: public, max-age=31536000
@@ -47,17 +50,32 @@
   Cache-Control: public, max-age=3600
   Access-Control-Allow-Origin: *
 
-# Entry points must always revalidate so a new deploy goes live immediately.
+# Entry points must always revalidate so a new deploy goes live immediately. / and
+# index.html ARE the SPA fallback that functions/[[path]].js exists to catch elsewhere in
+# this file, so they stay out of public/_routes.json include on purpose: adding them would
+# have the Function 404 the app shell itself.
 /
   Cache-Control: no-cache, must-revalidate
 /index.html
   Cache-Control: no-cache, must-revalidate
+
+# no-cache still stores the response and lets a later request reuse it once revalidated (a
+# 304 carries no body), so a missing manifest.json/asset-manifest.json served as the SPA
+# fallback could be confirmed valid by a later conditional request instead of being
+# refetched — the same failure mode as /static/*, reached through revalidation instead of a
+# long max-age. Both paths are listed in public/_routes.json include so
+# functions/[[path]].js content-checks them and answers 404 instead.
 /manifest.json
   Cache-Control: no-cache, must-revalidate
 /asset-manifest.json
   Cache-Control: no-cache, must-revalidate
 
-# Crawler directives in robots.txt must always revalidate so they take effect on the next request.
+# Crawler directives in robots.txt must always revalidate so they take effect on the next
+# request — and, per the file-top note, this specific rule is also one the CDN edge raises
+# to max-age=14400 in practice, so a missing robots.txt served as the SPA fallback would sit
+# cached at the edge for up to four hours under this URL, on top of the client-side risk
+# described above for /manifest.json. Listed in public/_routes.json include for the same
+# reason.
 /robots.txt
   Cache-Control: no-cache, must-revalidate
 

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/static/*", "/widget/*", "/favicon.ico", "/logo.png"],
+  "include": ["/static/*", "/widget/*", "/favicon.ico", "/logo.png", "/robots.txt", "/manifest.json", "/asset-manifest.json"],
   "exclude": []
 }

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/static/*", "/widget/*", "/favicon.ico", "/logo.png", "/robots.txt", "/manifest.json", "/asset-manifest.json"],
+  "include": ["/static/*", "/widget/*", "/favicon.ico", "/logo.png", "/robots.txt", "/manifest.json", "/asset-manifest.json", "/version.json"],
   "exclude": []
 }

--- a/public/_routes.json
+++ b/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/static/*", "/widget/*"],
+  "include": ["/static/*", "/widget/*", "/favicon.ico", "/logo.png"],
   "exclude": []
 }

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -71,6 +71,18 @@ describe('missing asset function', () => {
     expect(result.headers.get('cache-control')).toBe('no-store');
   });
 
+  it('treats a present but empty content type the same as a missing one and fails closed', async () => {
+    // The header has to be emptied after construction: passing '' in the init is discarded and
+    // the platform fills in text/plain, so the constructor route cannot produce this case at all.
+    const emptyType = new Response('data', { status: 200 });
+    emptyType.headers.set('content-type', '');
+
+    const result = await onRequest(contextFor(emptyType));
+
+    expect(result.status).toBe(404);
+    expect(result.headers.get('cache-control')).toBe('no-store');
+  });
+
   it('treats a case-different content-type as the fallback', async () => {
     const fallback = new Response('<!doctype html><html></html>', {
       status: 200,
@@ -173,7 +185,7 @@ describe('missing asset function', () => {
 // unnoticed addition would run the Function's content check against a path public/_headers never
 // justified for it, so both directions have to fail this test, not only a removal.
 describe('public/_routes.json include list', () => {
-  it('content-checks exactly /static/*, /widget/*, /favicon.ico, /logo.png, /robots.txt, /manifest.json and /asset-manifest.json, and excludes nothing', () => {
+  it('content-checks exactly /static/*, /widget/*, /favicon.ico, /logo.png, /robots.txt, /manifest.json, /asset-manifest.json and /version.json, and excludes nothing', () => {
     const expectedInclude = [
       '/static/*',
       '/widget/*',
@@ -182,6 +194,7 @@ describe('public/_routes.json include list', () => {
       '/robots.txt',
       '/manifest.json',
       '/asset-manifest.json',
+      '/version.json',
     ];
 
     expect([...routes.include].sort()).toEqual([...expectedInclude].sort());

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -1,6 +1,5 @@
 import { onRequest } from '../../functions/[[path]].js';
-import { readFileSync } from 'fs';
-import { join } from 'path';
+import routes from '../../public/_routes.json';
 
 // The deployed Pages Function is not part of the app bundle, so nothing else in the test suite
 // reaches it. These cases pin the decision it makes: an asset path answered SUCCESSFULLY with
@@ -70,6 +69,29 @@ describe('missing asset function', () => {
 
     expect(result.status).toBe(404);
     expect(result.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('treats a case-different content-type as the fallback', async () => {
+    const fallback = new Response('<!doctype html><html></html>', {
+      status: 200,
+      headers: { 'content-type': 'Text/HTML; charset=UTF-8' },
+    });
+
+    const result = await onRequest(contextFor(fallback));
+
+    expect(result.status).toBe(404);
+  });
+
+  it('does not treat a content-type with text/html only inside a parameter as the fallback', async () => {
+    const asset = new Response('{"note":"not html"}', {
+      status: 200,
+      headers: { 'content-type': 'application/json; charset=utf-8; description="text/html example"' },
+    });
+
+    const result = await onRequest(contextFor(asset));
+
+    expect(result.status).toBe(200);
+    await expect(result.text()).resolves.toBe('{"note":"not html"}');
   });
 
   it('does not turn a non-HTML error response into a 404', async () => {
@@ -147,12 +169,22 @@ describe('missing asset function', () => {
 // and falls back to index.html on a miss -- the exact cached-fallback bug this file exists to
 // catch, just skipped for that path instead of mishandled by the Function. None of the tests
 // above would notice that regression, since they call onRequest() directly and never consult
-// this file, so its content is pinned here on its own.
+// this file, so its content is pinned here on its own -- exactly, not just as a lower bound: an
+// unnoticed addition would run the Function's content check against a path public/_headers never
+// justified for it, so both directions have to fail this test, not only a removal.
 describe('public/_routes.json include list', () => {
-  it('keeps /static/*, /widget/*, /favicon.ico and /logo.png content-checked', () => {
-    const routesPath = join(__dirname, '../../public/_routes.json');
-    const routes = JSON.parse(readFileSync(routesPath, 'utf8'));
+  it('content-checks exactly /static/*, /widget/*, /favicon.ico, /logo.png, /robots.txt, /manifest.json and /asset-manifest.json, and excludes nothing', () => {
+    const expectedInclude = [
+      '/static/*',
+      '/widget/*',
+      '/favicon.ico',
+      '/logo.png',
+      '/robots.txt',
+      '/manifest.json',
+      '/asset-manifest.json',
+    ];
 
-    expect(routes.include).toEqual(expect.arrayContaining(['/static/*', '/widget/*', '/favicon.ico', '/logo.png']));
+    expect([...routes.include].sort()).toEqual([...expectedInclude].sort());
+    expect(routes.exclude).toEqual([]);
   });
 });

--- a/src/__tests__/missing-asset-function.test.ts
+++ b/src/__tests__/missing-asset-function.test.ts
@@ -1,9 +1,12 @@
 import { onRequest } from '../../functions/[[path]].js';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 // The deployed Pages Function is not part of the app bundle, so nothing else in the test suite
-// reaches it. These cases pin the one decision it makes: an asset path answered SUCCESSFULLY with
-// HTML is the fallback standing in for a file that no longer exists, and must not reach the client
-// as a successful asset. An HTML failure response is a different thing and keeps its status.
+// reaches it. These cases pin the decision it makes: an asset path answered SUCCESSFULLY with
+// HTML — or with no content type at all — is the fallback standing in for a file that no longer
+// exists, and must not reach the client as a successful asset. An HTML failure response is a
+// different thing and keeps its status.
 
 const ASSET_URL = 'https://app.dfx.swiss/static/js/main.abc123.js';
 
@@ -59,10 +62,14 @@ describe('missing asset function', () => {
     await expect(result.text()).resolves.toBe('console.log(1);');
   });
 
-  it('passes a response without a content type through rather than guessing', async () => {
-    const result = await onRequest(contextFor(new Response('data', { status: 200 })));
+  it('treats a response without a content type as the fallback and fails closed', async () => {
+    const untyped = new Response('data', { status: 200 });
+    untyped.headers.delete('content-type');
 
-    expect(result.status).toBe(200);
+    const result = await onRequest(contextFor(untyped));
+
+    expect(result.status).toBe(404);
+    expect(result.headers.get('cache-control')).toBe('no-store');
   });
 
   it('does not turn a non-HTML error response into a 404', async () => {
@@ -130,5 +137,22 @@ describe('missing asset function', () => {
     const result = await onRequest(contextFor(outage));
 
     expect(result.status).toBe(503);
+  });
+});
+
+// public/_routes.json decides whether Cloudflare Pages invokes this Function at all -- it only
+// runs for paths matched by the include list below. The handler tests above prove that once
+// invoked, it tells a real asset apart from the SPA fallback correctly; they say nothing about
+// which paths reach it. A path dropped from include here goes straight to static asset serving
+// and falls back to index.html on a miss -- the exact cached-fallback bug this file exists to
+// catch, just skipped for that path instead of mishandled by the Function. None of the tests
+// above would notice that regression, since they call onRequest() directly and never consult
+// this file, so its content is pinned here on its own.
+describe('public/_routes.json include list', () => {
+  it('keeps /static/*, /widget/*, /favicon.ico and /logo.png content-checked', () => {
+    const routesPath = join(__dirname, '../../public/_routes.json');
+    const routes = JSON.parse(readFileSync(routesPath, 'utf8'));
+
+    expect(routes.include).toEqual(expect.arrayContaining(['/static/*', '/widget/*', '/favicon.ico', '/logo.png']));
   });
 });


### PR DESCRIPTION
## What happened

A request for a missing `/static/*` asset was answered by the SPA fallback with the app shell — HTML, status 200. The header rule for `/static/*` matches on the **path**, not on what was actually served, so that HTML inherited `public, max-age=31536000, immutable`. Since `immutable` forbids revalidation, the wrong answer stayed servable for a year in every cache that had fetched it.

Customers landed on the error screen instead of the buy page. One reported case sat there for roughly 40 minutes on a fixed-line connection — not a flaky mobile link, a cached wrong answer. Clearing it required purging the edge by hand.

Measured before that purge: `ChunkLoadError` on `/buy` was the largest single error class in the backend log at 20–42 per hour. Afterwards it fell to 1 per hour, then to 0.

## Why the existing 404 fix was not enough

Missing assets already answer a real 404 (#1230). That stops **new** poisoning — it does not remove a single **existing** one. Two URLs demonstrated the persistence directly: both returned `200 text/html` from cache, 33 and 37 hours old, with a year still to run, while the same URLs with a cache-busting query returned `404`. The application was answering correctly; only the stored copies were wrong.

## What this changes

- **Drop `immutable` from `/static/*`.** The long `max-age` stays — filename hashes change with content, so a conditional request is answered `304` in the normal case. What changes is that a user-triggered reload can revalidate at all, which `immutable` prevents. Shared/edge caches keep the year-long lifetime either way; the comment says so plainly rather than implying this fixes them.
- **Route every other non-fingerprinted path through the content check**, not just the obvious ones: `/favicon.ico`, `/logo.png`, `/robots.txt`, `/manifest.json`, `/asset-manifest.json` and `/version.json`. `no-cache` still *stores* a response — it only forces revalidation before reuse — so a later `304` can confirm a wrongly stored app shell under those URLs. `/` and `/index.html` stay out on purpose: they are the fallback.
- **Fail closed on an absent *or empty* content-type.** An ok response carrying neither is treated as the fallback instead of being passed through, and the media type is compared before its parameters so a type that merely mentions `text/html` in a parameter is not mistaken for one.
- **Verify after every production deploy** that an absent asset really answers a bare 404 with exactly the headers the function emits. A run-specific marker (run id and attempt) is polled first so the check runs against a live deploy. The step states what it can and cannot prove: marker and asset are separate requests and could, during propagation, be served by different edge nodes — it is a smoke test that reliably catches a widespread regression, not a per-node proof.
- **Pin the route list in a test** — exact `include` and `exclude`, so an entry can neither be dropped nor added unnoticed.

## Verification

- `npm run lint` clean; `npm test` green (63 suites, 684 tests)
- Deploy step order checked by hand: the marker is written after every build step and before the upload, so it cannot be overwritten
- Seven review passes against the complete diff. Findings resolved along the way included two that would have made the new gate ineffective — one where it would have re-proved the *previous* deploy, one where a transport failure could have counted as a pass — plus a test that passed while testing something other than its name, and several statements in comments and failure messages that promised more than the code establishes.

Related: #1226 (root cause), #1230 (the 404 answer this builds on).
