### PR TITLE
fix(kyc): stop offering KYC start to Compliance accounts on the staff clearance screen

### DIFF
--- a/src/screens/staff-kyc-required.screen.tsx
+++ b/src/screens/staff-kyc-required.screen.tsx
@@ -1,3 +1,4 @@
+import { useAuthContext, UserRole } from '@dfx.swiss/react';
 import {
   StyledButton,
   StyledButtonColor,
@@ -22,6 +23,13 @@ export default function StaffKycRequiredScreen(): JSX.Element {
   const { start } = useKycHelper();
   const { navigate } = useNavigation();
   const { setRedirectPath } = useAppHandlingContext();
+  const { session } = useAuthContext();
+
+  // The API refuses self-service KYC for Compliance-role accounts ('KYC not allowed for compliance
+  // accounts'), so for them the start button below is a guaranteed dead end in a raw error. The rule
+  // itself lives in the API; the JWT role is only used to render the instruction that matches the
+  // API's answer: such accounts are cleared by an operator, not by running an identification.
+  const canStartKyc = session?.role !== UserRole.COMPLIANCE;
 
   useLayoutOptions({ title: translate('screens/kyc', 'Identification required') });
 
@@ -35,14 +43,21 @@ export default function StaffKycRequiredScreen(): JSX.Element {
       </StyledInfoText>
 
       <StyledInfoText invertedIcon>
-        {translate(
-          'screens/kyc',
-          'Complete the identification to restore access. This is the same process customers go through and only has to be done once.',
-        )}
+        {canStartKyc
+          ? translate(
+              'screens/kyc',
+              'Complete the identification to restore access. This is the same process customers go through and only has to be done once.',
+            )
+          : translate(
+              'screens/kyc',
+              'On a Compliance account the identification cannot be started here. Please contact your administrator to have your account cleared - access is restored shortly afterwards.',
+            )}
       </StyledInfoText>
 
       <StyledVerticalStack gap={3} full>
-        <StyledButton width={StyledButtonWidth.FULL} label={translate('screens/kyc', 'Start KYC')} onClick={start} />
+        {canStartKyc && (
+          <StyledButton width={StyledButtonWidth.FULL} label={translate('screens/kyc', 'Start KYC')} onClick={start} />
+        )}
         <StyledButton
           width={StyledButtonWidth.FULL}
           color={StyledButtonColor.GRAY_OUTLINE}

--- a/src/translations/languages/de.json
+++ b/src/translations/languages/de.json
@@ -82,6 +82,7 @@
     "Identification required": "Identifikation erforderlich",
     "Access to internal tools now requires an identified person behind the account. Your role is unchanged — what is missing is your identification.": "Der Zugriff auf interne Werkzeuge setzt neu eine identifizierte Person hinter dem Konto voraus. Deine Rolle ist unverändert — es fehlt lediglich deine Identifikation.",
     "Complete the identification to restore access. This is the same process customers go through and only has to be done once.": "Schliesse die Identifikation ab, um den Zugriff wiederherzustellen. Es ist derselbe Prozess wie für Kundinnen und Kunden und muss nur einmal durchlaufen werden.",
+    "On a Compliance account the identification cannot be started here. Please contact your administrator to have your account cleared - access is restored shortly afterwards.": "Auf einem Compliance-Konto kann die Identifikation nicht hier gestartet werden. Bitte wende Dich an Deinen Administrator, damit Dein Konto freigeschaltet wird - der Zugriff ist kurz danach wieder da.",
     "Start KYC": "KYC starten",
     "Is this email address correct?": "Ist diese E-Mail-Adresse korrekt?",
     "This account already has an email address. You can change it in your account settings.": "Dieses Konto hat bereits eine E-Mail-Adresse. Du kannst sie in Deinen Kontoeinstellungen ändern.",

--- a/src/translations/languages/fr.json
+++ b/src/translations/languages/fr.json
@@ -82,6 +82,7 @@
     "Identification required": "Identification requise",
     "Access to internal tools now requires an identified person behind the account. Your role is unchanged — what is missing is your identification.": "L'accès aux outils internes exige désormais une personne identifiée derrière le compte. Votre rôle est inchangé — il ne manque que votre identification.",
     "Complete the identification to restore access. This is the same process customers go through and only has to be done once.": "Terminez l'identification pour rétablir l'accès. Il s'agit du même processus que pour les clients et il ne doit être effectué qu'une seule fois.",
+    "On a Compliance account the identification cannot be started here. Please contact your administrator to have your account cleared - access is restored shortly afterwards.": "Sur un compte Compliance, l'identification ne peut pas être lancée ici. Veuillez contacter votre administrateur pour faire débloquer votre compte - l'accès est rétabli peu après.",
     "Start KYC": "Démarrer le KYC",
     "Is this email address correct?": "Cette adresse e-mail est-elle correcte ?",
     "This account already has an email address. You can change it in your account settings.": "Ce compte possède déjà une adresse e-mail. Vous pouvez la modifier dans les paramètres de votre compte.",

--- a/src/translations/languages/it.json
+++ b/src/translations/languages/it.json
@@ -82,6 +82,7 @@
     "Identification required": "Identificazione necessaria",
     "Access to internal tools now requires an identified person behind the account. Your role is unchanged — what is missing is your identification.": "L'accesso agli strumenti interni richiede ora una persona identificata dietro l'account. Il tuo ruolo non è cambiato — manca soltanto la tua identificazione.",
     "Complete the identification to restore access. This is the same process customers go through and only has to be done once.": "Completa l'identificazione per ripristinare l'accesso. È lo stesso processo previsto per i clienti e va svolto una sola volta.",
+    "On a Compliance account the identification cannot be started here. Please contact your administrator to have your account cleared - access is restored shortly afterwards.": "Su un account Compliance l'identificazione non può essere avviata qui. Contatta il tuo amministratore per far sbloccare il tuo account - l'accesso viene ripristinato poco dopo.",
     "Start KYC": "Avvia il KYC",
     "Is this email address correct?": "Questo indirizzo e-mail è corretto?",
     "This account already has an email address. You can change it in your account settings.": "Questo account ha già un indirizzo e-mail. Puoi modificarlo nelle impostazioni del tuo account.",


### PR DESCRIPTION
## What changed

- The `staff-kyc-required` screen no longer offers "Start KYC" to Compliance-role accounts. For them it renders an instruction to contact an administrator instead; the "Back" button stays.
- New translation key in de/fr/it.

## Why

The API rejects self-service KYC for Compliance-role accounts outright (`KYC not allowed for compliance accounts`, api#3577). For such accounts the start button is a guaranteed dead end: `/staff-kyc-required` → `/kyc` → generic red error with the raw API message. The account is instead cleared by an operator through the reviewed backfill path (`docs/staff-kyc-clearance.md` in the api repo, most recently api#4596).

The rule itself stays in the API; the screen only uses the JWT role to render the instruction matching the API's answer, same as the existing role-based rendering in `guard.hook.ts` and `compliance-user.screen.tsx`.

## Checks

- `npm run lint` clean (`--max-warnings 0`)
- `npm run test`: 63 suites / 684 tests pass (includes the translation-completeness suites)
- No API contract change; UI-only
