### PR TITLE
feat(compliance): decide limit requests in the support dashboard

### DIFF
--- a/src/__tests__/limit-request-decision.hook.test.ts
+++ b/src/__tests__/limit-request-decision.hook.test.ts
@@ -173,6 +173,39 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(callsTo('support/397328/limit-request-pdf')[0].data.note).toBe('Unterlagen nicht nachgereicht');
   });
 
+  // The customer's proof of funds is filed with the note in one call: the API stores the file under the
+  // account's UserNotes and links it to this log entry, so document and explanation stay together.
+  it('files the customer document together with the note', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      grantedLimit: 500000,
+      currentDepositLimit: 100000,
+      comment: 'Hausverkauf',
+      attachment: { data: 'data:application/pdf;base64,QQ==', name: 'Kaufvertrag.pdf' },
+    });
+
+    const log = callsTo('kyc/admin/log')[0].data;
+    expect(log.file).toBe('data:application/pdf;base64,QQ==');
+    expect(log.fileName).toBe('Kaufvertrag.pdf');
+    expect(log.comment).toContain('comment: Hausverkauf');
+  });
+
+  it('omits the file fields entirely when no document is attached', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+    });
+
+    const log = callsTo('kyc/admin/log')[0].data;
+    expect(log).not.toHaveProperty('file');
+    expect(log).not.toHaveProperty('fileName');
+  });
+
   // The failure contract: stop at the first failing step and report what already landed, so a retry
   // cannot silently raise the limit twice or leave a decision recorded against an unchanged account.
   it('stops and reports when the decision call fails after the limit was raised', async () => {

--- a/src/__tests__/limit-request-decision.hook.test.ts
+++ b/src/__tests__/limit-request-decision.hook.test.ts
@@ -1,0 +1,253 @@
+import { renderHook } from '@testing-library/react';
+
+// capture the api call args; call() resolves to the value we set per test
+const mockCall = jest.fn();
+
+// Same shape as the other compliance hook tests: `call` comes from useGuardedApi (→ useApi), and the
+// module reads Department at import time.
+jest.mock('@dfx.swiss/react', () => ({
+  useApi: () => ({ call: mockCall }),
+  Department: { SUPPORT: 'Support', COMPLIANCE: 'Compliance', MARKETING: 'Marketing' },
+  TfaLevel: { STRICT: 'Strict' },
+  ResponseType: { BLOB: 'blob' },
+  // compliance.hook builds a CallOutcome → PhoneCallStatus map at module scope.
+  PhoneCallStatus: {
+    COMPLETED: 'Completed',
+    UNAVAILABLE: 'Unavailable',
+    SUSPICIOUS: 'Suspicious',
+    FAILED: 'Failed',
+  },
+  CheckStatus: { PASS: 'Pass', FAIL: 'Fail' },
+  AmlReason: { MANUAL_CHECK_PHONE_FAILED: 'ManualCheckPhoneFailed' },
+  CallQueue: {
+    MANUAL_CHECK_PHONE: 'ManualCheckPhone',
+    MANUAL_CHECK_IP_PHONE: 'ManualCheckIpPhone',
+    MANUAL_CHECK_IP_COUNTRY_PHONE: 'ManualCheckIpCountryPhone',
+    MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE: 'ManualCheckExternalAccountPhone',
+    UNAVAILABLE_SUSPICIOUS: 'UnavailableSuspicious',
+  },
+}));
+
+// useGuardedApi calls useNavigation (react-router hooks); stub it so renderHook works without a Router.
+jest.mock('../hooks/navigation.hook', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+import { LimitRequestDecision, useCompliance } from '../hooks/compliance.hook';
+
+const CONTEXT = { limitRequestId: 855, userDataId: 397328 };
+
+function callsTo(url: string) {
+  return mockCall.mock.calls.map(([args]) => args).filter((a) => a.url === url);
+}
+
+describe('useCompliance().decideLimitRequest', () => {
+  beforeEach(() => {
+    mockCall.mockReset().mockResolvedValue(undefined);
+  });
+
+  // Mirrors the sheet's accept sequence: userData/{id} carries the new depositLimit, limitRequest/{id}
+  // carries the decision. Nothing in the API derives the annual limit from the request, so dropping the
+  // first call would record an acceptance that leaves the customer on the old limit.
+  it('raises the annual limit, then records an acceptance, then files the note', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      grantedLimit: 500000,
+      currentDepositLimit: 100000,
+      fundOrigin: 'Savings',
+      investmentDate: 'Now',
+    });
+
+    expect(outcome).toEqual({
+      success: true,
+      completedSteps: ['depositLimit', 'limitRequest', 'report', 'log'],
+    });
+
+    const urls = mockCall.mock.calls.map(([a]) => `${a.method} ${a.url}`);
+    expect(urls).toEqual([
+      'PUT userData/397328',
+      'PUT limitRequest/855',
+      'POST support/397328/limit-request-pdf',
+      'POST kyc/admin/log',
+    ]);
+
+    // The report is the file record the sheet produced for every final decision.
+    expect(callsTo('support/397328/limit-request-pdf')[0].data).toEqual({
+      decision: 'Accepted',
+      clerk: 'JR',
+      requestedLimit: 500000,
+      grantedLimit: 500000,
+      previousLimit: 100000,
+      fundOrigin: 'Savings',
+      investmentDate: 'Now',
+      note: undefined,
+    });
+
+    expect(callsTo('userData/397328')[0].data).toEqual({ depositLimit: 500000 });
+
+    const decision = callsTo('limitRequest/855')[0].data;
+    expect(decision).toMatchObject({ decision: 'Accepted', acceptedLimit: 500000, clerk: 'JR' });
+    expect(typeof decision.edited).toBe('string');
+
+    const log = callsTo('kyc/admin/log')[0].data;
+    expect(log).toMatchObject({ type: 'ManualLog', userData: { id: 397328 } });
+    expect(log.comment).toContain('Services - LimitRequest');
+    expect(log.comment).toContain('Editor: JR');
+    expect(log.comment).toContain('userData-depositLimit-500000');
+    expect(log.comment).toContain('limitRequest-decision-Accepted');
+  });
+
+  it('uses the edited amount for a partial acceptance', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.PARTIALLY_ACCEPTED, {
+      clerk: 'VR',
+      requestedLimit: 500000,
+      grantedLimit: 200000,
+      currentDepositLimit: 100000,
+    });
+
+    expect(callsTo('userData/397328')[0].data).toEqual({ depositLimit: 200000 });
+    expect(callsTo('limitRequest/855')[0].data).toMatchObject({
+      decision: 'PartiallyAccepted',
+      acceptedLimit: 200000,
+    });
+  });
+
+  // A rejection must not touch the account. The sheet records the limit that stays in force on the
+  // request itself (its rejected rows carry the account's existing limit), which is what makes a
+  // rejected request readable afterwards.
+  it('leaves the account untouched on a rejection and records the limit that stays in force', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      currentDepositLimit: 100000,
+    });
+
+    expect(outcome.completedSteps).toEqual(['limitRequest', 'report', 'log']);
+    // A rejection is filed too: it is exactly the case someone asks about later.
+    expect(callsTo('support/397328/limit-request-pdf')[0].data).toMatchObject({
+      decision: 'Rejected',
+      previousLimit: 100000,
+      grantedLimit: undefined,
+    });
+    expect(callsTo('userData/397328')).toHaveLength(0);
+    expect(callsTo('limitRequest/855')[0].data).toMatchObject({
+      decision: 'Rejected',
+      acceptedLimit: 100000,
+      clerk: 'JR',
+    });
+    expect(callsTo('kyc/admin/log')[0].data.comment).not.toContain('depositLimit');
+  });
+
+  it('omits acceptedLimit entirely when no limit is known for a rejection', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+    });
+
+    // Absent rather than null: the API validator rejects a null and keeps the stored value when the
+    // field is missing.
+    expect(callsTo('limitRequest/855')[0].data).not.toHaveProperty('acceptedLimit');
+  });
+
+  it('carries the file note into the log comment', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      currentDepositLimit: 100000,
+      comment: 'Unterlagen nicht nachgereicht',
+    });
+
+    expect(callsTo('kyc/admin/log')[0].data.comment).toContain('comment: Unterlagen nicht nachgereicht');
+    // The same note becomes the body of the filed report ("Interne Aktennotiz" in the sheet).
+    expect(callsTo('support/397328/limit-request-pdf')[0].data.note).toBe('Unterlagen nicht nachgereicht');
+  });
+
+  // The failure contract: stop at the first failing step and report what already landed, so a retry
+  // cannot silently raise the limit twice or leave a decision recorded against an unchanged account.
+  it('stops and reports when the decision call fails after the limit was raised', async () => {
+    mockCall.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Limit request already final'));
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      grantedLimit: 500000,
+    });
+
+    expect(outcome).toEqual({
+      success: false,
+      failedStep: 'limitRequest',
+      completedSteps: ['depositLimit'],
+      message: 'Limit request already final',
+    });
+    expect(callsTo('support/397328/limit-request-pdf')).toHaveLength(0);
+    expect(callsTo('kyc/admin/log')).toHaveLength(0);
+  });
+
+  it('does not record a decision when raising the limit fails', async () => {
+    mockCall.mockRejectedValueOnce(new Error('nope'));
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      grantedLimit: 500000,
+    });
+
+    expect(outcome).toMatchObject({ success: false, failedStep: 'depositLimit', completedSteps: [] });
+    expect(callsTo('limitRequest/855')).toHaveLength(0);
+  });
+
+  it('reports a failed report without undoing the decision', async () => {
+    mockCall
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('storage down'));
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      grantedLimit: 500000,
+    });
+
+    expect(outcome).toMatchObject({
+      success: false,
+      failedStep: 'report',
+      completedSteps: ['depositLimit', 'limitRequest'],
+    });
+    expect(callsTo('kyc/admin/log')).toHaveLength(0);
+  });
+
+  it('reports a failed note last, with everything before it recorded', async () => {
+    mockCall
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('log down'));
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      grantedLimit: 500000,
+    });
+
+    expect(outcome).toMatchObject({
+      success: false,
+      failedStep: 'log',
+      completedSteps: ['depositLimit', 'limitRequest', 'report'],
+    });
+  });
+});

--- a/src/__tests__/limit-request-decision.hook.test.ts
+++ b/src/__tests__/limit-request-decision.hook.test.ts
@@ -83,10 +83,11 @@ describe('useCompliance().decideLimitRequest', () => {
     mockCall.mockReset().mockResolvedValue(undefined);
   });
 
-  // Mirrors the sheet's accept sequence: userData/{id} carries the new depositLimit, limitRequest/{id}
-  // carries the decision. Nothing in the API derives the annual limit from the request, so dropping the
-  // first call would record an acceptance that leaves the customer on the old limit.
-  it('raises the annual limit, then records an acceptance, then files the note', async () => {
+  // The account first, then the report, then the decision, then the note. The decision is last of the
+  // three writes on purpose: it is the only one the API refuses to repeat, so anything failing before
+  // it leaves the request retryable. Nothing in the API derives the annual limit from the request, so
+  // dropping the userData call would record an acceptance that leaves the customer on the old limit.
+  it('raises the annual limit, files the report, records the acceptance, then files the note', async () => {
     const { result } = renderHook(() => useCompliance());
 
     const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
@@ -100,14 +101,14 @@ describe('useCompliance().decideLimitRequest', () => {
 
     expect(outcome).toEqual({
       success: true,
-      completedSteps: ['depositLimit', 'limitRequest', 'report', 'log'],
+      completedSteps: ['depositLimit', 'report', 'limitRequest', 'log'],
     });
 
     const urls = mockCall.mock.calls.map(([a]) => `${a.method} ${a.url}`);
     expect(urls).toEqual([
       'PUT userData/397328',
-      'PUT limitRequest/855',
       'POST support/397328/limit-request-pdf',
+      'PUT limitRequest/855',
       'POST kyc/admin/log',
     ]);
 
@@ -127,7 +128,8 @@ describe('useCompliance().decideLimitRequest', () => {
 
     const decision = callsTo('limitRequest/855')[0].data;
     expect(decision).toMatchObject({ decision: 'Accepted', acceptedLimit: 500000, clerk: 'JR' });
-    expect(typeof decision.edited).toBe('string');
+    // @IsDate on the API side: the value has to parse as a date, not merely be a string.
+    expect(Number.isNaN(Date.parse(decision.edited))).toBe(false);
 
     const log = callsTo('kyc/admin/log')[0].data;
     expect(log).toMatchObject({ type: 'ManualLog', userData: { id: 397328 } });
@@ -154,10 +156,9 @@ describe('useCompliance().decideLimitRequest', () => {
     });
   });
 
-  // A rejection must not touch the account. The sheet records the limit that stays in force on the
-  // request itself (its rejected rows carry the account's existing limit), which is what makes a
-  // rejected request readable afterwards.
-  it('leaves the account untouched on a rejection and records the limit that stays in force', async () => {
+  // A rejection must not touch the account, and must not write an acceptedLimit: every view that shows
+  // that field labels it "Accepted", so a rejected request would read as an accepted amount.
+  it('leaves the account untouched on a rejection and grants no limit', async () => {
     const { result } = renderHook(() => useCompliance());
 
     const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
@@ -166,7 +167,7 @@ describe('useCompliance().decideLimitRequest', () => {
       currentDepositLimit: 100000,
     });
 
-    expect(outcome.completedSteps).toEqual(['limitRequest', 'report', 'log']);
+    expect(outcome.completedSteps).toEqual(['report', 'limitRequest', 'log']);
     // A rejection is filed too: it is exactly the case someone asks about later.
     expect(callsTo('support/397328/limit-request-pdf')[0].data).toMatchObject({
       decision: 'Rejected',
@@ -174,15 +175,14 @@ describe('useCompliance().decideLimitRequest', () => {
       grantedLimit: undefined,
     });
     expect(callsTo('userData/397328')).toHaveLength(0);
-    expect(callsTo('limitRequest/855')[0].data).toMatchObject({
-      decision: 'Rejected',
-      acceptedLimit: 100000,
-      clerk: 'JR',
-    });
+    expect(callsTo('limitRequest/855')[0].data).toMatchObject({ decision: 'Rejected', clerk: 'JR' });
+    expect(callsTo('limitRequest/855')[0].data).not.toHaveProperty('acceptedLimit');
     expect(callsTo('kyc/admin/log')[0].data.comment).not.toContain('depositLimit');
   });
 
-  it('omits acceptedLimit entirely when no limit is known for a rejection', async () => {
+  // Absent rather than null: the API validator rejects a null and keeps the stored value when the field
+  // is missing.
+  it('omits acceptedLimit entirely on a rejection', async () => {
     const { result } = renderHook(() => useCompliance());
 
     await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
@@ -190,9 +190,35 @@ describe('useCompliance().decideLimitRequest', () => {
       requestedLimit: 500000,
     });
 
-    // Absent rather than null: the API validator rejects a null and keeps the stored value when the
-    // field is missing.
     expect(callsTo('limitRequest/855')[0].data).not.toHaveProperty('acceptedLimit');
+  });
+
+  // Without the amount the first step would silently do nothing while the decision still went in, and
+  // the notification cron would then mail the customer their old limit as if it had been raised.
+  it('refuses a granting decision that carries no amount, before touching anything', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+    });
+
+    expect(outcome).toMatchObject({ success: false, failedStep: 'depositLimit', completedSteps: [] });
+    expect(outcome.message).toContain('needs the limit it grants');
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it('trims the clerk before it reaches the API and the log', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
+      clerk: '  JR  ',
+      requestedLimit: 500000,
+    });
+
+    expect(callsTo('limitRequest/855')[0].data.clerk).toBe('JR');
+    expect(callsTo('support/397328/limit-request-pdf')[0].data.clerk).toBe('JR');
+    expect(callsTo('kyc/admin/log')[0].data.comment).toContain('Editor: JR');
   });
 
   it('carries the file note into the log comment', async () => {
@@ -245,8 +271,11 @@ describe('useCompliance().decideLimitRequest', () => {
 
   // The failure contract: stop at the first failing step and report what already landed, so a retry
   // cannot silently raise the limit twice or leave a decision recorded against an unchanged account.
-  it('stops and reports when the decision call fails after the limit was raised', async () => {
-    mockCall.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Limit request already final'));
+  it('stops and reports when the decision call fails after the limit and report landed', async () => {
+    mockCall
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Limit request already final'));
     const { result } = renderHook(() => useCompliance());
 
     const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
@@ -258,10 +287,9 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(outcome).toEqual({
       success: false,
       failedStep: 'limitRequest',
-      completedSteps: ['depositLimit'],
+      completedSteps: ['depositLimit', 'report'],
       message: 'Limit request already final',
     });
-    expect(callsTo('support/397328/limit-request-pdf')).toHaveLength(0);
     expect(callsTo('kyc/admin/log')).toHaveLength(0);
   });
 
@@ -279,11 +307,10 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(callsTo('limitRequest/855')).toHaveLength(0);
   });
 
-  it('reports a failed report without undoing the decision', async () => {
-    mockCall
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('storage down'));
+  // The reason the report goes before the decision: a failing report leaves the request undecided, so
+  // the clerk can simply try again once the report endpoint is reachable.
+  it('leaves the request undecided when the report fails', async () => {
+    mockCall.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('storage down'));
     const { result } = renderHook(() => useCompliance());
 
     const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
@@ -295,8 +322,9 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(outcome).toMatchObject({
       success: false,
       failedStep: 'report',
-      completedSteps: ['depositLimit', 'limitRequest'],
+      completedSteps: ['depositLimit'],
     });
+    expect(callsTo('limitRequest/855')).toHaveLength(0);
     expect(callsTo('kyc/admin/log')).toHaveLength(0);
   });
 
@@ -317,7 +345,7 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(outcome).toMatchObject({
       success: false,
       failedStep: 'log',
-      completedSteps: ['depositLimit', 'limitRequest', 'report'],
+      completedSteps: ['depositLimit', 'report', 'limitRequest'],
     });
   });
 });

--- a/src/__tests__/limit-request-decision.hook.test.ts
+++ b/src/__tests__/limit-request-decision.hook.test.ts
@@ -41,6 +41,43 @@ function callsTo(url: string) {
   return mockCall.mock.calls.map(([args]) => args).filter((a) => a.url === url);
 }
 
+describe('useCompliance().fileLimitRequestNote', () => {
+  beforeEach(() => {
+    mockCall.mockReset().mockResolvedValue(undefined);
+  });
+
+  // The way back into a request whose decision is recorded but whose report or note failed, and the way
+  // a document arriving after the decision reaches the file. It must never touch the decision itself.
+  it('writes only the log entry, anchored to the recorded decision', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.fileLimitRequestNote(CONTEXT, {
+      clerk: 'JR',
+      decision: 'Accepted',
+      comment: 'Beleg nachgereicht',
+      attachment: { data: 'data:application/pdf;base64,QQ==', name: 'Kaufvertrag.pdf' },
+    });
+
+    expect(outcome).toEqual({ success: true, completedSteps: ['log'] });
+    expect(mockCall.mock.calls.map(([a]) => `${a.method} ${a.url}`)).toEqual(['POST kyc/admin/log']);
+
+    const log = callsTo('kyc/admin/log')[0].data;
+    expect(log.comment).toContain('Services - LimitRequest');
+    expect(log.comment).toContain('limitRequest-decision-Accepted');
+    expect(log.comment).toContain('comment: Beleg nachgereicht');
+    expect(log.fileName).toBe('Kaufvertrag.pdf');
+  });
+
+  it('reports a failure without claiming the note was filed', async () => {
+    mockCall.mockRejectedValueOnce(new Error('log down'));
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.fileLimitRequestNote(CONTEXT, { clerk: 'JR', decision: 'Rejected' });
+
+    expect(outcome).toMatchObject({ success: false, failedStep: 'log', completedSteps: [] });
+  });
+});
+
 describe('useCompliance().decideLimitRequest', () => {
   beforeEach(() => {
     mockCall.mockReset().mockResolvedValue(undefined);

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -1,27 +1,19 @@
 // jest.mock factories may only reference variables whose name starts with `mock`.
-const mockUpdateLimitRequest = jest.fn();
-const mockGetCallQueueClerks = jest.fn();
+const mockDecideLimitRequest = jest.fn();
 
 // Mocked wholesale rather than via requireActual: the real module pulls in @dfx.swiss/react, which
-// ships ESM that this Jest setup cannot parse. The decision enum is restated here because the
-// component reads it at runtime; the string values are the API's and are asserted below.
+// ships ESM that this Jest setup cannot parse. The two exports the component reads at runtime are
+// restated here; their values are the API's and are pinned by the hook test next to this one, which
+// covers the call sequence itself. This file covers what the form is responsible for: which values
+// reach the hook, and what the clerk is shown afterwards.
 jest.mock('src/hooks/compliance.hook', () => ({
   LimitRequestDecision: { ACCEPTED: 'Accepted', PARTIALLY_ACCEPTED: 'PartiallyAccepted', REJECTED: 'Rejected' },
-  useCompliance: () => ({ updateLimitRequest: mockUpdateLimitRequest, getCallQueueClerks: mockGetCallQueueClerks }),
+  LimitRequestGrantingDecisions: ['Accepted', 'PartiallyAccepted'],
+  useCompliance: () => ({ decideLimitRequest: mockDecideLimitRequest }),
 }));
 
-jest.mock('@dfx.swiss/react-components', () => {
-  // The factory runs before this file's imports, so React has to be required here.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const React = require('react');
-  return {
-    StyledButtonWidth: { FULL: 'FULL' },
-    StyledButton: ({ label, onClick, disabled }: { label: string; onClick: () => void; disabled?: boolean }) =>
-      React.createElement('button', { onClick, disabled }, label),
-  };
-});
-
 jest.mock('src/components/error-hint', () => {
+  // The factory runs before this file's imports, so React has to be required here.
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const React = require('react');
   return {
@@ -30,14 +22,31 @@ jest.mock('src/components/error-hint', () => {
   };
 });
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { LimitRequestDecisionForm } from 'src/components/compliance/limit-request-decision-form';
-import type { LimitRequestInfo } from 'src/hooks/compliance.hook';
 
-const LIMIT_REQUEST: LimitRequestInfo = { id: 42, limit: 50000, fundOrigin: 'Savings' };
+const LIMIT_REQUEST_ID = 42;
+const USER_DATA_ID = 397328;
+const REQUESTED = 500000;
+const CURRENT_LIMIT = 100000;
+const CONTEXT = { limitRequestId: LIMIT_REQUEST_ID, userDataId: USER_DATA_ID };
 
-function renderForm(onDecided = jest.fn()) {
-  render(<LimitRequestDecisionForm limitRequest={LIMIT_REQUEST} onDecided={onDecided} />);
+function renderForm(overrides: Partial<Parameters<typeof LimitRequestDecisionForm>[0]> = {}) {
+  const onDecided = jest.fn();
+  render(
+    <LimitRequestDecisionForm
+      limitRequestId={LIMIT_REQUEST_ID}
+      userDataId={USER_DATA_ID}
+      requestedLimit={REQUESTED}
+      fundOrigin="Savings"
+      investmentDate="Now"
+      currentDepositLimit={CURRENT_LIMIT}
+      clerks={['JR', 'VR']}
+      defaultClerk="JR"
+      onDecided={onDecided}
+      {...overrides}
+    />,
+  );
   return onDecided;
 }
 
@@ -45,120 +54,156 @@ function selectDecision(value: string) {
   fireEvent.change(screen.getByLabelText('Decision', { selector: 'select' }), { target: { value } });
 }
 
-function getSaveButton(): HTMLButtonElement {
+function saveButton(): HTMLButtonElement {
   return screen.getByRole('button', { name: 'Save decision' }) as HTMLButtonElement;
+}
+
+async function clickSave() {
+  await act(async () => {
+    fireEvent.click(saveButton());
+  });
 }
 
 describe('LimitRequestDecisionForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetCallQueueClerks.mockResolvedValue(['JR', 'CT']);
-    mockUpdateLimitRequest.mockResolvedValue(undefined);
+    mockDecideLimitRequest.mockResolvedValue({ success: true, completedSteps: [] });
   });
 
-  it('preselects the first clerk and requires a decision before saving', async () => {
+  it('requires a decision before it can be saved', () => {
     renderForm();
-    await waitFor(() => expect(screen.getByDisplayValue('JR')).toBeInTheDocument());
 
-    expect(getSaveButton()).toBeDisabled();
+    expect(saveButton()).toBeDisabled();
 
     selectDecision('Rejected');
-    expect(getSaveButton()).not.toBeDisabled();
+    expect(saveButton()).not.toBeDisabled();
   });
 
-  it('sends a rejection without an accepted limit', async () => {
+  it('submits an acceptance with the requested amount prefilled', async () => {
     const onDecided = renderForm();
-    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
 
-    selectDecision('Rejected');
-    // The accepted-limit field only belongs to a decision that grants one.
-    expect(screen.queryByLabelText('Accepted limit (CHF)', { selector: 'input' })).not.toBeInTheDocument();
+    selectDecision('Accepted');
+    await clickSave();
 
-    await act(async () => {
-      fireEvent.click(getSaveButton());
-    });
-
-    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
-      decision: 'Rejected',
-      acceptedLimit: undefined,
+    expect(mockDecideLimitRequest).toHaveBeenCalledWith(CONTEXT, 'Accepted', {
       clerk: 'JR',
+      requestedLimit: REQUESTED,
+      grantedLimit: REQUESTED,
+      currentDepositLimit: CURRENT_LIMIT,
+      comment: undefined,
+      fundOrigin: 'Savings',
+      investmentDate: 'Now',
     });
     expect(onDecided).toHaveBeenCalledTimes(1);
   });
 
-  it('defaults the accepted limit to the requested amount when accepting', async () => {
+  it('submits the edited amount for a partial acceptance', async () => {
     renderForm();
-    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
-
-    selectDecision('Accepted');
-
-    await act(async () => {
-      fireEvent.click(getSaveButton());
-    });
-
-    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
-      decision: 'Accepted',
-      acceptedLimit: 50000,
-      clerk: 'JR',
-    });
-  });
-
-  it('sends the edited amount for a partial acceptance and blocks an empty one', async () => {
-    renderForm();
-    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
 
     selectDecision('PartiallyAccepted');
-    const limitInput = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' });
-
-    fireEvent.change(limitInput, { target: { value: '' } });
-    expect(getSaveButton()).toBeDisabled();
-
-    fireEvent.change(limitInput, { target: { value: '20000' } });
-    await act(async () => {
-      fireEvent.click(getSaveButton());
+    fireEvent.change(screen.getByLabelText('New annual limit (CHF)', { selector: 'input' }), {
+      target: { value: '200000' },
     });
+    await clickSave();
 
-    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
-      decision: 'PartiallyAccepted',
-      acceptedLimit: 20000,
-      clerk: 'JR',
-    });
+    expect(mockDecideLimitRequest).toHaveBeenCalledWith(
+      CONTEXT,
+      'PartiallyAccepted',
+      expect.objectContaining({ grantedLimit: 200000 }),
+    );
   });
 
-  it('surfaces a failed save and does not report the request as decided', async () => {
-    const onDecided = renderForm();
-    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
-    mockUpdateLimitRequest.mockRejectedValue(new Error('Limit request already final'));
-
+  it('blocks an empty or non-positive amount on a granting decision', () => {
+    renderForm();
     selectDecision('Accepted');
-    await act(async () => {
-      fireEvent.click(getSaveButton());
-    });
+    const input = screen.getByLabelText('New annual limit (CHF)', { selector: 'input' });
 
-    expect(screen.getByTestId('error-hint')).toHaveTextContent('Limit request already final');
-    expect(onDecided).not.toHaveBeenCalled();
-    // The form stays usable so the clerk can retry or pick another decision.
-    expect(getSaveButton()).not.toBeDisabled();
+    fireEvent.change(input, { target: { value: '' } });
+    expect(saveButton()).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '0' } });
+    expect(saveButton()).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '150000' } });
+    expect(saveButton()).not.toBeDisabled();
   });
 
-  it('falls back to a free-text signature when the clerk list cannot be loaded', async () => {
-    mockGetCallQueueClerks.mockRejectedValue(new Error('nope'));
+  // A rejection grants nothing, so the amount field has no meaning there and must not travel with it.
+  it('hides the amount and grants none on a rejection', async () => {
     renderForm();
 
-    const signature = await screen.findByPlaceholderText('Your sign');
-    expect(getSaveButton()).toBeDisabled();
-
-    fireEvent.change(signature, { target: { value: 'JR' } });
     selectDecision('Rejected');
+    expect(screen.queryByLabelText('New annual limit (CHF)', { selector: 'input' })).not.toBeInTheDocument();
+    await clickSave();
 
-    await act(async () => {
-      fireEvent.click(getSaveButton());
+    expect(mockDecideLimitRequest).toHaveBeenCalledWith(
+      CONTEXT,
+      'Rejected',
+      expect.objectContaining({ grantedLimit: undefined, currentDepositLimit: CURRENT_LIMIT }),
+    );
+  });
+
+  it('passes the optional file note along', async () => {
+    renderForm();
+
+    selectDecision('Rejected');
+    fireEvent.change(screen.getByLabelText('File note (optional)', { selector: 'input' }), {
+      target: { value: 'Unterlagen nicht nachgereicht' },
+    });
+    await clickSave();
+
+    expect(mockDecideLimitRequest).toHaveBeenCalledWith(
+      CONTEXT,
+      'Rejected',
+      expect.objectContaining({ comment: 'Unterlagen nicht nachgereicht' }),
+    );
+  });
+
+  // Partial application is the dangerous state: the limit is already raised while the decision is not
+  // recorded. The clerk has to see that before retrying, or they raise it a second time blind.
+  it('names the steps that already landed when the sequence fails midway', async () => {
+    const onDecided = renderForm();
+    mockDecideLimitRequest.mockResolvedValue({
+      success: false,
+      failedStep: 'limitRequest',
+      completedSteps: ['depositLimit'],
+      message: 'Limit request already final',
     });
 
-    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
-      decision: 'Rejected',
-      acceptedLimit: undefined,
-      clerk: 'JR',
+    selectDecision('Accepted');
+    await clickSave();
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('Limit request already final');
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('already applied: depositLimit');
+    expect(onDecided).not.toHaveBeenCalled();
+    // The form stays usable so the clerk can retry or pick another decision.
+    expect(saveButton()).not.toBeDisabled();
+  });
+
+  it('reports a failure that landed nothing without naming any step', async () => {
+    renderForm();
+    mockDecideLimitRequest.mockResolvedValue({
+      success: false,
+      failedStep: 'depositLimit',
+      completedSteps: [],
+      message: 'nope',
     });
+
+    selectDecision('Accepted');
+    await clickSave();
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('nope');
+    expect(screen.getByTestId('error-hint')).not.toHaveTextContent('already applied');
+  });
+
+  it('falls back to a free-text clerk field when no clerk list is available', async () => {
+    renderForm({ clerks: [], defaultClerk: undefined });
+
+    expect(saveButton()).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText('Sign'), { target: { value: 'JR' } });
+    selectDecision('Rejected');
+    await clickSave();
+
+    expect(mockDecideLimitRequest).toHaveBeenCalledWith(CONTEXT, 'Rejected', expect.objectContaining({ clerk: 'JR' }));
   });
 });

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -1,0 +1,164 @@
+// jest.mock factories may only reference variables whose name starts with `mock`.
+const mockUpdateLimitRequest = jest.fn();
+const mockGetCallQueueClerks = jest.fn();
+
+// Mocked wholesale rather than via requireActual: the real module pulls in @dfx.swiss/react, which
+// ships ESM that this Jest setup cannot parse. The decision enum is restated here because the
+// component reads it at runtime; the string values are the API's and are asserted below.
+jest.mock('src/hooks/compliance.hook', () => ({
+  LimitRequestDecision: { ACCEPTED: 'Accepted', PARTIALLY_ACCEPTED: 'PartiallyAccepted', REJECTED: 'Rejected' },
+  useCompliance: () => ({ updateLimitRequest: mockUpdateLimitRequest, getCallQueueClerks: mockGetCallQueueClerks }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => {
+  // The factory runs before this file's imports, so React has to be required here.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  return {
+    StyledButtonWidth: { FULL: 'FULL' },
+    StyledButton: ({ label, onClick, disabled }: { label: string; onClick: () => void; disabled?: boolean }) =>
+      React.createElement('button', { onClick, disabled }, label),
+  };
+});
+
+jest.mock('src/components/error-hint', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  return {
+    ErrorHint: ({ message }: { message: string }) =>
+      React.createElement('div', { 'data-testid': 'error-hint' }, message),
+  };
+});
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { LimitRequestDecisionForm } from 'src/components/compliance/limit-request-decision-form';
+import type { LimitRequestInfo } from 'src/hooks/compliance.hook';
+
+const LIMIT_REQUEST: LimitRequestInfo = { id: 42, limit: 50000, fundOrigin: 'Savings' };
+
+function renderForm(onDecided = jest.fn()) {
+  render(<LimitRequestDecisionForm limitRequest={LIMIT_REQUEST} onDecided={onDecided} />);
+  return onDecided;
+}
+
+function selectDecision(value: string) {
+  fireEvent.change(screen.getByLabelText('Decision', { selector: 'select' }), { target: { value } });
+}
+
+function getSaveButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: 'Save decision' }) as HTMLButtonElement;
+}
+
+describe('LimitRequestDecisionForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCallQueueClerks.mockResolvedValue(['JR', 'CT']);
+    mockUpdateLimitRequest.mockResolvedValue(undefined);
+  });
+
+  it('preselects the first clerk and requires a decision before saving', async () => {
+    renderForm();
+    await waitFor(() => expect(screen.getByDisplayValue('JR')).toBeInTheDocument());
+
+    expect(getSaveButton()).toBeDisabled();
+
+    selectDecision('Rejected');
+    expect(getSaveButton()).not.toBeDisabled();
+  });
+
+  it('sends a rejection without an accepted limit', async () => {
+    const onDecided = renderForm();
+    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
+
+    selectDecision('Rejected');
+    // The accepted-limit field only belongs to a decision that grants one.
+    expect(screen.queryByLabelText('Accepted limit (CHF)', { selector: 'input' })).not.toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(getSaveButton());
+    });
+
+    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
+      decision: 'Rejected',
+      acceptedLimit: undefined,
+      clerk: 'JR',
+    });
+    expect(onDecided).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults the accepted limit to the requested amount when accepting', async () => {
+    renderForm();
+    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
+
+    selectDecision('Accepted');
+
+    await act(async () => {
+      fireEvent.click(getSaveButton());
+    });
+
+    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
+      decision: 'Accepted',
+      acceptedLimit: 50000,
+      clerk: 'JR',
+    });
+  });
+
+  it('sends the edited amount for a partial acceptance and blocks an empty one', async () => {
+    renderForm();
+    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
+
+    selectDecision('PartiallyAccepted');
+    const limitInput = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' });
+
+    fireEvent.change(limitInput, { target: { value: '' } });
+    expect(getSaveButton()).toBeDisabled();
+
+    fireEvent.change(limitInput, { target: { value: '20000' } });
+    await act(async () => {
+      fireEvent.click(getSaveButton());
+    });
+
+    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
+      decision: 'PartiallyAccepted',
+      acceptedLimit: 20000,
+      clerk: 'JR',
+    });
+  });
+
+  it('surfaces a failed save and does not report the request as decided', async () => {
+    const onDecided = renderForm();
+    await waitFor(() => expect(mockGetCallQueueClerks).toHaveBeenCalled());
+    mockUpdateLimitRequest.mockRejectedValue(new Error('Limit request already final'));
+
+    selectDecision('Accepted');
+    await act(async () => {
+      fireEvent.click(getSaveButton());
+    });
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('Limit request already final');
+    expect(onDecided).not.toHaveBeenCalled();
+    // The form stays usable so the clerk can retry or pick another decision.
+    expect(getSaveButton()).not.toBeDisabled();
+  });
+
+  it('falls back to a free-text signature when the clerk list cannot be loaded', async () => {
+    mockGetCallQueueClerks.mockRejectedValue(new Error('nope'));
+    renderForm();
+
+    const signature = await screen.findByPlaceholderText('Your sign');
+    expect(getSaveButton()).toBeDisabled();
+
+    fireEvent.change(signature, { target: { value: 'JR' } });
+    selectDecision('Rejected');
+
+    await act(async () => {
+      fireEvent.click(getSaveButton());
+    });
+
+    expect(mockUpdateLimitRequest).toHaveBeenCalledWith(42, {
+      decision: 'Rejected',
+      acceptedLimit: undefined,
+      clerk: 'JR',
+    });
+  });
+});

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -1,5 +1,6 @@
 // jest.mock factories may only reference variables whose name starts with `mock`.
 const mockDecideLimitRequest = jest.fn();
+const mockFileLimitRequestNote = jest.fn();
 const mockToBase64 = jest.fn();
 
 // Mocked wholesale rather than via requireActual: the real module pulls in @dfx.swiss/react, which
@@ -10,7 +11,10 @@ const mockToBase64 = jest.fn();
 jest.mock('src/hooks/compliance.hook', () => ({
   LimitRequestDecision: { ACCEPTED: 'Accepted', PARTIALLY_ACCEPTED: 'PartiallyAccepted', REJECTED: 'Rejected' },
   LimitRequestGrantingDecisions: ['Accepted', 'PartiallyAccepted'],
-  useCompliance: () => ({ decideLimitRequest: mockDecideLimitRequest }),
+  useCompliance: () => ({
+    decideLimitRequest: mockDecideLimitRequest,
+    fileLimitRequestNote: mockFileLimitRequestNote,
+  }),
 }));
 
 // The component reads the picked file through this helper; jsdom's FileReader is stubbed out here so
@@ -59,8 +63,8 @@ function selectDecision(value: string) {
   fireEvent.change(screen.getByLabelText('Decision', { selector: 'select' }), { target: { value } });
 }
 
-function saveButton(): HTMLButtonElement {
-  return screen.getByRole('button', { name: 'Save decision' }) as HTMLButtonElement;
+function saveButton(name = 'Save decision'): HTMLButtonElement {
+  return screen.getByRole('button', { name }) as HTMLButtonElement;
 }
 
 async function clickSave() {
@@ -73,6 +77,7 @@ describe('LimitRequestDecisionForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDecideLimitRequest.mockResolvedValue({ success: true, completedSteps: [] });
+    mockFileLimitRequestNote.mockResolvedValue({ success: true, completedSteps: ['log'] });
     mockToBase64.mockImplementation(async (file: File) =>
       file.name === 'Kaufvertrag.pdf' ? 'data:application/pdf;base64,Y29udHJhY3Q=' : 'data:text/plain;base64,eA==',
     );
@@ -239,6 +244,74 @@ describe('LimitRequestDecisionForm', () => {
 
     expect(screen.getByTestId('error-hint')).toHaveTextContent('could not be read');
     expect(mockDecideLimitRequest).not.toHaveBeenCalled();
+  });
+
+  // The API validates both target columns with @IsInt, so a decimal would come back as a 400 rather
+  // than being rounded. The form has to refuse it before the call.
+  it('refuses a decimal amount', () => {
+    renderForm();
+    selectDecision('Accepted');
+    const input = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' });
+
+    fireEvent.change(input, { target: { value: '150000.5' } });
+    expect(saveButton()).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '150000' } });
+    expect(saveButton()).not.toBeDisabled();
+  });
+
+  describe('when the request is already decided', () => {
+    // The API refuses to change a final decision. Without this mode a decision whose report or note
+    // failed halfway could never be completed, and a document arriving later would have nowhere to go.
+    it('offers filing a note instead of a decision', () => {
+      renderForm({ decidedAs: 'Accepted' });
+
+      expect(screen.queryByLabelText('Decision', { selector: 'select' })).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Accepted limit (CHF)', { selector: 'input' })).not.toBeInTheDocument();
+      expect(screen.getByText(/already decided \(Accepted\)/)).toBeInTheDocument();
+      // Nothing to file yet: neither a note nor a document.
+      expect(saveButton('Save file note')).toBeDisabled();
+    });
+
+    it('files a note against the recorded decision', async () => {
+      const onDecided = renderForm({ decidedAs: 'Rejected' });
+
+      fireEvent.change(screen.getByLabelText('Internal file note', { selector: 'input' }), {
+        target: { value: 'Beleg nachgereicht' },
+      });
+      await act(async () => {
+        fireEvent.click(saveButton('Save file note'));
+      });
+
+      expect(mockFileLimitRequestNote).toHaveBeenCalledWith(CONTEXT, {
+        clerk: 'JR',
+        decision: 'Rejected',
+        comment: 'Beleg nachgereicht',
+        attachment: undefined,
+      });
+      expect(mockDecideLimitRequest).not.toHaveBeenCalled();
+      expect(onDecided).toHaveBeenCalledTimes(1);
+    });
+
+    it('files a document alone, without a note', async () => {
+      renderForm({ decidedAs: 'Accepted' });
+
+      fireEvent.change(screen.getByLabelText('Customer document (optional)', { selector: 'input' }), {
+        target: { files: [new File(['contract'], 'Kaufvertrag.pdf', { type: 'application/pdf' })] },
+      });
+      expect(saveButton('Save file note')).not.toBeDisabled();
+
+      await act(async () => {
+        fireEvent.click(saveButton('Save file note'));
+      });
+
+      expect(mockFileLimitRequestNote).toHaveBeenCalledWith(
+        CONTEXT,
+        expect.objectContaining({
+          attachment: { data: 'data:application/pdf;base64,Y29udHJhY3Q=', name: 'Kaufvertrag.pdf' },
+        }),
+      );
+    });
   });
 
   it('falls back to a free-text clerk field when no clerk list is available', async () => {

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -1,5 +1,6 @@
 // jest.mock factories may only reference variables whose name starts with `mock`.
 const mockDecideLimitRequest = jest.fn();
+const mockToBase64 = jest.fn();
 
 // Mocked wholesale rather than via requireActual: the real module pulls in @dfx.swiss/react, which
 // ships ESM that this Jest setup cannot parse. The two exports the component reads at runtime are
@@ -11,6 +12,10 @@ jest.mock('src/hooks/compliance.hook', () => ({
   LimitRequestGrantingDecisions: ['Accepted', 'PartiallyAccepted'],
   useCompliance: () => ({ decideLimitRequest: mockDecideLimitRequest }),
 }));
+
+// The component reads the picked file through this helper; jsdom's FileReader is stubbed out here so
+// the test controls the encoded result.
+jest.mock('src/util/utils', () => ({ toBase64: (file: File) => mockToBase64(file) }));
 
 jest.mock('src/components/error-hint', () => {
   // The factory runs before this file's imports, so React has to be required here.
@@ -68,6 +73,9 @@ describe('LimitRequestDecisionForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDecideLimitRequest.mockResolvedValue({ success: true, completedSteps: [] });
+    mockToBase64.mockImplementation(async (file: File) =>
+      file.name === 'Kaufvertrag.pdf' ? 'data:application/pdf;base64,Y29udHJhY3Q=' : 'data:text/plain;base64,eA==',
+    );
   });
 
   it('requires a decision before it can be saved', () => {
@@ -101,7 +109,7 @@ describe('LimitRequestDecisionForm', () => {
     renderForm();
 
     selectDecision('PartiallyAccepted');
-    fireEvent.change(screen.getByLabelText('New annual limit (CHF)', { selector: 'input' }), {
+    fireEvent.change(screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' }), {
       target: { value: '200000' },
     });
     await clickSave();
@@ -116,7 +124,7 @@ describe('LimitRequestDecisionForm', () => {
   it('blocks an empty or non-positive amount on a granting decision', () => {
     renderForm();
     selectDecision('Accepted');
-    const input = screen.getByLabelText('New annual limit (CHF)', { selector: 'input' });
+    const input = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' });
 
     fireEvent.change(input, { target: { value: '' } });
     expect(saveButton()).toBeDisabled();
@@ -133,7 +141,7 @@ describe('LimitRequestDecisionForm', () => {
     renderForm();
 
     selectDecision('Rejected');
-    expect(screen.queryByLabelText('New annual limit (CHF)', { selector: 'input' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Accepted limit (CHF)', { selector: 'input' })).not.toBeInTheDocument();
     await clickSave();
 
     expect(mockDecideLimitRequest).toHaveBeenCalledWith(
@@ -147,7 +155,7 @@ describe('LimitRequestDecisionForm', () => {
     renderForm();
 
     selectDecision('Rejected');
-    fireEvent.change(screen.getByLabelText('File note (optional)', { selector: 'input' }), {
+    fireEvent.change(screen.getByLabelText('Internal file note', { selector: 'input' }), {
       target: { value: 'Unterlagen nicht nachgereicht' },
     });
     await clickSave();
@@ -194,6 +202,43 @@ describe('LimitRequestDecisionForm', () => {
 
     expect(screen.getByTestId('error-hint')).toHaveTextContent('nope');
     expect(screen.getByTestId('error-hint')).not.toHaveTextContent('already applied');
+  });
+
+  it('reads the selected customer document and passes it along', async () => {
+    renderForm();
+
+    const file = new File(['contract'], 'Kaufvertrag.pdf', { type: 'application/pdf' });
+    fireEvent.change(screen.getByLabelText('Customer document (optional)', { selector: 'input' }), {
+      target: { files: [file] },
+    });
+    expect(screen.getByText(/Kaufvertrag\.pdf/)).toBeInTheDocument();
+
+    selectDecision('Accepted');
+    await clickSave();
+
+    expect(mockDecideLimitRequest).toHaveBeenCalledWith(
+      CONTEXT,
+      'Accepted',
+      expect.objectContaining({
+        attachment: { data: 'data:application/pdf;base64,Y29udHJhY3Q=', name: 'Kaufvertrag.pdf' },
+      }),
+    );
+  });
+
+  // A document that cannot be read must stop the decision rather than record it without the proof the
+  // clerk meant to file.
+  it('reports an unreadable document and decides nothing', async () => {
+    mockToBase64.mockResolvedValueOnce(undefined);
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText('Customer document (optional)', { selector: 'input' }), {
+      target: { files: [new File(['x'], 'broken.pdf', { type: 'application/pdf' })] },
+    });
+    selectDecision('Accepted');
+    await clickSave();
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('could not be read');
+    expect(mockDecideLimitRequest).not.toHaveBeenCalled();
   });
 
   it('falls back to a free-text clerk field when no clerk list is available', async () => {

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -314,6 +314,111 @@ describe('LimitRequestDecisionForm', () => {
     });
   });
 
+  // FileReader can reject as well as resolve empty; an escaping rejection would leave the button stuck
+  // on "Saving..." with no error and no way back except reloading the page.
+  it('recovers when reading the document throws', async () => {
+    mockToBase64.mockRejectedValueOnce(new Error('read failed'));
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText('Customer document (optional)', { selector: 'input' }), {
+      target: { files: [new File(['x'], 'broken.pdf', { type: 'application/pdf' })] },
+    });
+    selectDecision('Accepted');
+    await clickSave();
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('could not be read');
+    expect(mockDecideLimitRequest).not.toHaveBeenCalled();
+    expect(saveButton()).not.toBeDisabled();
+  });
+
+  it('clears the note and the document after a successful decision', async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByLabelText('Internal file note', { selector: 'input' }), {
+      target: { value: 'Hausverkauf' },
+    });
+    fireEvent.change(screen.getByLabelText('Customer document (optional)', { selector: 'input' }), {
+      target: { files: [new File(['contract'], 'Kaufvertrag.pdf', { type: 'application/pdf' })] },
+    });
+    selectDecision('Accepted');
+    await clickSave();
+
+    expect(screen.getByLabelText('Internal file note', { selector: 'input' })).toHaveValue('');
+    expect(screen.queryByText(/Kaufvertrag\.pdf/)).not.toBeInTheDocument();
+  });
+
+  it('blocks a second submit while the first is still running', async () => {
+    let release: (v: unknown) => void = () => undefined;
+    mockDecideLimitRequest.mockReturnValue(new Promise((resolve) => (release = resolve)));
+    renderForm();
+
+    selectDecision('Rejected');
+    await act(async () => {
+      fireEvent.click(saveButton());
+    });
+
+    expect(saveButton('Saving...')).toBeDisabled();
+
+    await act(async () => {
+      release({ success: true, completedSteps: [] });
+    });
+    expect(mockDecideLimitRequest).toHaveBeenCalledTimes(1);
+  });
+
+  // Once the decision is recorded the API refuses to change it. Without switching modes right away, a
+  // retry would re-write the deposit limit with whatever is in the amount field and fail again.
+  it('switches to note mode when the decision landed but a later step failed', async () => {
+    renderForm();
+    mockDecideLimitRequest.mockResolvedValue({
+      success: false,
+      failedStep: 'log',
+      completedSteps: ['depositLimit', 'report', 'limitRequest'],
+      message: 'log down',
+    });
+
+    selectDecision('Accepted');
+    await clickSave();
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('log down');
+    expect(screen.queryByLabelText('Decision', { selector: 'select' })).not.toBeInTheDocument();
+    expect(screen.getByText(/already decided \(Accepted\)/)).toBeInTheDocument();
+  });
+
+  // The clerk list arrives after the first render; a name typed before that must not stay in state
+  // behind a select that shows something else.
+  it('adopts a clerk from the list once it arrives', async () => {
+    const { rerender } = render(
+      <LimitRequestDecisionForm
+        limitRequestId={LIMIT_REQUEST_ID}
+        userDataId={USER_DATA_ID}
+        requestedLimit={REQUESTED}
+        currentDepositLimit={CURRENT_LIMIT}
+        clerks={[]}
+        onDecided={jest.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('Sign'), { target: { value: 'typed-before-load' } });
+
+    rerender(
+      <LimitRequestDecisionForm
+        limitRequestId={LIMIT_REQUEST_ID}
+        userDataId={USER_DATA_ID}
+        requestedLimit={REQUESTED}
+        currentDepositLimit={CURRENT_LIMIT}
+        clerks={['JR', 'VR']}
+        defaultClerk="VR"
+        onDecided={jest.fn()}
+      />,
+    );
+
+    const select = screen.getByLabelText('Clerk', { selector: 'select' }) as HTMLSelectElement;
+    expect(select.value).toBe('VR');
+
+    selectDecision('Rejected');
+    await clickSave();
+    expect(mockDecideLimitRequest).toHaveBeenCalledWith(CONTEXT, 'Rejected', expect.objectContaining({ clerk: 'VR' }));
+  });
+
   it('falls back to a free-text clerk field when no clerk list is available', async () => {
     renderForm({ clerks: [], defaultClerk: undefined });
 

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -16,14 +16,20 @@ interface Props {
   investmentDate?: string;
   /** The account's annual limit as it stands today — what a rejection leaves in force. */
   currentDepositLimit?: number;
+  /**
+   * The decision already on the request, if it is final. The API refuses to change one, so the form
+   * then drops to filing a note and a document: that is the only way to complete a decision whose
+   * report or note failed halfway, and it is how a document arriving later gets into the file.
+   */
+  decidedAs?: string;
   clerks: string[];
   defaultClerk?: string;
   onDecided: () => void;
 }
 
 // Collects the decision and hands it to `useCompliance().decideLimitRequest`, which performs the same
-// steps in the same order as the Google Sheet (raise the annual limit, record the decision, file a
-// note, file the report document) and reports how far it got. The customer message stays where it
+// steps in the same order as the Google Sheet (raise the annual limit, record the decision, file the
+// report document, file the note) and reports how far it got. The customer message stays where it
 // already lives on this screen.
 export function LimitRequestDecisionForm({
   limitRequestId,
@@ -32,11 +38,14 @@ export function LimitRequestDecisionForm({
   fundOrigin,
   investmentDate,
   currentDepositLimit,
+  decidedAs,
   clerks,
   defaultClerk,
   onDecided,
 }: Props): JSX.Element {
-  const { decideLimitRequest } = useCompliance();
+  const { decideLimitRequest, fileLimitRequestNote } = useCompliance();
+
+  const isDecided = !!decidedAs;
 
   const [clerk, setClerk] = useState(defaultClerk ?? '');
   const [decision, setDecision] = useState<LimitRequestDecision | ''>('');
@@ -58,44 +67,62 @@ export function LimitRequestDecisionForm({
   const commentId = `limit-request-${limitRequestId}-comment`;
   const documentId = `limit-request-${limitRequestId}-document`;
 
-  const grantsLimit = !!decision && LimitRequestGrantingDecisions.includes(decision);
+  const grantsLimit = !isDecided && !!decision && LimitRequestGrantingDecisions.includes(decision);
   const parsedLimit = Number(acceptedLimit);
-  const isLimitValid = !grantsLimit || (acceptedLimit.trim() !== '' && Number.isFinite(parsedLimit) && parsedLimit > 0);
-  const canSubmit = !!clerk.trim() && !!decision && isLimitValid && !isSaving;
+  // Both target columns are integers (`user_data.depositLimit`, `limit_request.acceptedLimit`) and both
+  // DTOs validate with @IsInt, so a decimal would be refused by the API rather than rounded silently.
+  const isLimitValid =
+    !grantsLimit || (acceptedLimit.trim() !== '' && Number.isInteger(parsedLimit) && parsedLimit > 0);
+  const canSubmit = isDecided
+    ? !!clerk.trim() && (!!comment.trim() || !!document) && !isSaving
+    : !!clerk.trim() && !!decision && isLimitValid && !isSaving;
+
+  function resetDocument(): void {
+    setDocument(undefined);
+    if (documentInputRef.current) documentInputRef.current.value = '';
+  }
+
+  async function readDocument(): Promise<{ data: string; name: string } | undefined | 'failed'> {
+    if (!document) return undefined;
+    const data = await toBase64(document);
+    if (!data) return 'failed';
+    return { data, name: document.name };
+  }
 
   async function handleSubmit(): Promise<void> {
-    if (!decision || !clerk.trim() || !isLimitValid) return;
+    if (!canSubmit) return;
 
     setIsSaving(true);
     setError(undefined);
     setDoneSteps([]);
 
-    let attachment: { data: string; name: string } | undefined;
-    if (document) {
-      const data = await toBase64(document);
-      if (!data) {
-        setIsSaving(false);
-        setError('The selected document could not be read');
-        return;
-      }
-      attachment = { data, name: document.name };
+    const attachment = await readDocument();
+    if (attachment === 'failed') {
+      setIsSaving(false);
+      setError('The selected document could not be read');
+      return;
     }
 
-    const result = await decideLimitRequest({ limitRequestId, userDataId }, decision, {
-      clerk,
-      requestedLimit,
-      grantedLimit: grantsLimit ? parsedLimit : undefined,
-      currentDepositLimit,
-      comment: comment.trim() || undefined,
-      fundOrigin,
-      investmentDate,
-      attachment,
-    });
+    const result = isDecided
+      ? await fileLimitRequestNote(
+          { limitRequestId, userDataId },
+          { clerk, decision: decidedAs as string, comment: comment.trim() || undefined, attachment },
+        )
+      : await decideLimitRequest({ limitRequestId, userDataId }, decision as LimitRequestDecision, {
+          clerk,
+          requestedLimit,
+          grantedLimit: grantsLimit ? parsedLimit : undefined,
+          currentDepositLimit,
+          comment: comment.trim() || undefined,
+          fundOrigin,
+          investmentDate,
+          attachment,
+        });
 
     setIsSaving(false);
     if (result.success) {
-      setDocument(undefined);
-      if (documentInputRef.current) documentInputRef.current.value = '';
+      setComment('');
+      resetDocument();
       onDecided();
     } else {
       // Naming the steps that did land matters: after a failure in between, the operator has to know
@@ -107,25 +134,29 @@ export function LimitRequestDecisionForm({
 
   return (
     <div className="mt-4 border-t border-dfxGray-300 pt-4">
-      <h3 className="text-sm font-semibold text-dfxBlue-800 mb-3">Decide Limit Request</h3>
+      <h3 className="text-sm font-semibold text-dfxBlue-800 mb-3">
+        {isDecided ? 'File note for this limit request' : 'Decide Limit Request'}
+      </h3>
 
       <div className="flex gap-3 flex-wrap items-end">
-        <div className="flex flex-col gap-1">
-          <label htmlFor={decisionId} className="text-xs text-dfxGray-700">
-            Decision
-          </label>
-          <select
-            id={decisionId}
-            className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[150px]"
-            value={decision}
-            onChange={(e) => setDecision(e.target.value as LimitRequestDecision | '')}
-          >
-            <option value="">-</option>
-            <option value={LimitRequestDecision.ACCEPTED}>Accepted</option>
-            <option value={LimitRequestDecision.PARTIALLY_ACCEPTED}>PartiallyAccepted</option>
-            <option value={LimitRequestDecision.REJECTED}>Rejected</option>
-          </select>
-        </div>
+        {!isDecided && (
+          <div className="flex flex-col gap-1">
+            <label htmlFor={decisionId} className="text-xs text-dfxGray-700">
+              Decision
+            </label>
+            <select
+              id={decisionId}
+              className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[150px]"
+              value={decision}
+              onChange={(e) => setDecision(e.target.value as LimitRequestDecision | '')}
+            >
+              <option value="">-</option>
+              <option value={LimitRequestDecision.ACCEPTED}>Accepted</option>
+              <option value={LimitRequestDecision.PARTIALLY_ACCEPTED}>PartiallyAccepted</option>
+              <option value={LimitRequestDecision.REJECTED}>Rejected</option>
+            </select>
+          </div>
+        )}
 
         {grantsLimit && (
           <div className="flex flex-col gap-1">
@@ -136,6 +167,7 @@ export function LimitRequestDecisionForm({
               id={acceptedLimitId}
               type="number"
               min={1}
+              step={1}
               className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
               value={acceptedLimit}
               onChange={(e) => setAcceptedLimit(e.target.value)}
@@ -202,7 +234,7 @@ export function LimitRequestDecisionForm({
           onClick={handleSubmit}
           disabled={!canSubmit}
         >
-          {isSaving ? 'Saving...' : 'Save decision'}
+          {isSaving ? 'Saving...' : isDecided ? 'Save file note' : 'Save decision'}
         </button>
       </div>
 
@@ -213,15 +245,17 @@ export function LimitRequestDecisionForm({
       )}
 
       <p className="mt-2 text-xs text-dfxGray-700">
-        {grantsLimit
-          ? `Sets the annual limit to ${
-              isLimitValid ? parsedLimit.toLocaleString() : '-'
-            } CHF and records the decision.`
-          : decision
-            ? `Keeps the current annual limit${
-                currentDepositLimit != null ? ` of ${currentDepositLimit.toLocaleString()} CHF` : ''
-              } and records the decision.`
-            : 'The customer message is sent separately below, as before.'}
+        {isDecided
+          ? `This request is already decided (${decidedAs}) and cannot be changed. A note or a document can still be filed.`
+          : grantsLimit
+            ? `Sets the annual limit to ${
+                isLimitValid ? parsedLimit.toLocaleString() : '-'
+              } CHF and records the decision.`
+            : decision
+              ? `Keeps the current annual limit${
+                  currentDepositLimit != null ? ` of ${currentDepositLimit.toLocaleString()} CHF` : ''
+                } and records the decision.`
+              : 'The customer message is sent separately below, as before.'}
       </p>
 
       {error && (

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -1,86 +1,140 @@
-import { StyledButton, StyledButtonWidth } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
-import { LimitRequestDecision, LimitRequestInfo, useCompliance } from 'src/hooks/compliance.hook';
+import {
+  LimitRequestDecision,
+  LimitRequestDecisionStep,
+  LimitRequestGrantingDecisions,
+  useCompliance,
+} from 'src/hooks/compliance.hook';
 
 interface Props {
-  limitRequest: LimitRequestInfo;
+  limitRequestId: number;
+  userDataId: number;
+  requestedLimit: number;
+  fundOrigin?: string;
+  investmentDate?: string;
+  /** The account's annual limit as it stands today — what a rejection leaves in force. */
+  currentDepositLimit?: number;
+  clerks: string[];
+  defaultClerk?: string;
   onDecided: () => void;
 }
 
-// Decides a pending limit request in the compliance tool. Until this existed the decision had to be
-// made in the Google Sheet, because the API endpoint (PUT /limitRequest/:id) had no UI at all.
-export function LimitRequestDecisionForm({ limitRequest, onDecided }: Props): JSX.Element {
-  const { updateLimitRequest, getCallQueueClerks } = useCompliance();
+// Collects the decision and hands it to `useCompliance().decideLimitRequest`, which performs the same
+// steps in the same order as the Google Sheet (raise the annual limit, record the decision, file a
+// note, file the report document) and reports how far it got. The customer message stays where it
+// already lives on this screen.
+export function LimitRequestDecisionForm({
+  limitRequestId,
+  userDataId,
+  requestedLimit,
+  fundOrigin,
+  investmentDate,
+  currentDepositLimit,
+  clerks,
+  defaultClerk,
+  onDecided,
+}: Props): JSX.Element {
+  const { decideLimitRequest } = useCompliance();
 
-  const [clerks, setClerks] = useState<string[]>([]);
-  const [signature, setSignature] = useState('');
+  const [clerk, setClerk] = useState(defaultClerk ?? '');
   const [decision, setDecision] = useState<LimitRequestDecision | ''>('');
   // Prefilled with the requested amount: accepting in full is the common case, and a partial accept is
   // an edit of that number rather than an entry from scratch.
-  const [acceptedLimit, setAcceptedLimit] = useState<string>(String(limitRequest.limit));
+  const [acceptedLimit, setAcceptedLimit] = useState<string>(String(requestedLimit));
+  const [comment, setComment] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string>();
+  const [doneSteps, setDoneSteps] = useState<LimitRequestDecisionStep[]>([]);
 
-  // Ids are derived from the request so the labels stay associated even if a screen ever renders more
-  // than one of these forms.
-  const signatureId = `limit-request-${limitRequest.id}-signature`;
-  const decisionId = `limit-request-${limitRequest.id}-decision`;
-  const acceptedLimitId = `limit-request-${limitRequest.id}-accepted-limit`;
+  const clerkId = `limit-request-${limitRequestId}-clerk`;
+  const decisionId = `limit-request-${limitRequestId}-decision`;
+  const acceptedLimitId = `limit-request-${limitRequestId}-accepted-limit`;
+  const commentId = `limit-request-${limitRequestId}-comment`;
 
-  useEffect(() => {
-    getCallQueueClerks()
-      .then((list) => {
-        setClerks(list);
-        setSignature((prev) => prev || list[0] || '');
-      })
-      // The clerk list is a convenience; failing to load it must not block the decision, so the field
-      // falls back to free text below.
-      .catch(() => setClerks([]));
-  }, []);
-
-  const grantsLimit =
-    decision === LimitRequestDecision.ACCEPTED || decision === LimitRequestDecision.PARTIALLY_ACCEPTED;
+  const grantsLimit = !!decision && LimitRequestGrantingDecisions.includes(decision);
   const parsedLimit = Number(acceptedLimit);
   const isLimitValid = !grantsLimit || (acceptedLimit.trim() !== '' && Number.isFinite(parsedLimit) && parsedLimit > 0);
-  const canSubmit = !!signature.trim() && !!decision && isLimitValid && !isSaving;
+  const canSubmit = !!clerk.trim() && !!decision && isLimitValid && !isSaving;
 
   async function handleSubmit(): Promise<void> {
-    if (!decision || !signature.trim() || !isLimitValid) return;
+    if (!decision || !clerk.trim() || !isLimitValid) return;
 
     setIsSaving(true);
     setError(undefined);
-    try {
-      await updateLimitRequest(limitRequest.id, {
-        decision,
-        acceptedLimit: grantsLimit ? parsedLimit : undefined,
-        clerk: signature.trim(),
-      });
+    setDoneSteps([]);
+
+    const result = await decideLimitRequest({ limitRequestId, userDataId }, decision, {
+      clerk,
+      requestedLimit,
+      grantedLimit: grantsLimit ? parsedLimit : undefined,
+      currentDepositLimit,
+      comment: comment.trim() || undefined,
+      fundOrigin,
+      investmentDate,
+    });
+
+    setIsSaving(false);
+    if (result.success) {
       onDecided();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Unknown error');
-    } finally {
-      setIsSaving(false);
+    } else {
+      // Naming the steps that did land matters: after a failure in between, the operator has to know
+      // whether the limit was already raised before retrying.
+      setDoneSteps(result.completedSteps);
+      setError(result.message ?? 'Unknown error');
     }
   }
 
   return (
     <div className="mt-4 border-t border-dfxGray-300 pt-4">
-      <h3 className="text-sm font-semibold text-dfxBlue-800 mb-3">Decision</h3>
+      <h3 className="text-sm font-semibold text-dfxBlue-800 mb-3">Decide Limit Request</h3>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label htmlFor={signatureId} className="block text-sm font-medium text-dfxBlue-800 mb-1">
-            Signature
+      <div className="flex gap-3 flex-wrap items-end">
+        <div className="flex flex-col gap-1">
+          <label htmlFor={decisionId} className="text-xs text-dfxGray-700">
+            Decision
+          </label>
+          <select
+            id={decisionId}
+            className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[150px]"
+            value={decision}
+            onChange={(e) => setDecision(e.target.value as LimitRequestDecision | '')}
+          >
+            <option value="">-</option>
+            <option value={LimitRequestDecision.ACCEPTED}>Accepted</option>
+            <option value={LimitRequestDecision.PARTIALLY_ACCEPTED}>PartiallyAccepted</option>
+            <option value={LimitRequestDecision.REJECTED}>Rejected</option>
+          </select>
+        </div>
+
+        {grantsLimit && (
+          <div className="flex flex-col gap-1">
+            <label htmlFor={acceptedLimitId} className="text-xs text-dfxGray-700">
+              New annual limit (CHF)
+            </label>
+            <input
+              id={acceptedLimitId}
+              type="number"
+              min={1}
+              className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+              value={acceptedLimit}
+              onChange={(e) => setAcceptedLimit(e.target.value)}
+            />
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor={clerkId} className="text-xs text-dfxGray-700">
+            Clerk
           </label>
           {clerks.length ? (
             <select
-              id={signatureId}
-              className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
-              value={signature}
-              onChange={(e) => setSignature(e.target.value)}
+              id={clerkId}
+              className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+              value={clerk}
+              onChange={(e) => setClerk(e.target.value)}
             >
-              <option value="">—</option>
+              <option value="">-</option>
               {clerks.map((c) => (
                 <option key={c} value={c}>
                   {c}
@@ -89,63 +143,53 @@ export function LimitRequestDecisionForm({ limitRequest, onDecided }: Props): JS
             </select>
           ) : (
             <input
-              id={signatureId}
-              className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
-              value={signature}
-              onChange={(e) => setSignature(e.target.value)}
-              placeholder="Your sign"
+              id={clerkId}
+              className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+              value={clerk}
+              onChange={(e) => setClerk(e.target.value)}
+              placeholder="Sign"
             />
           )}
         </div>
 
-        <div>
-          <label htmlFor={decisionId} className="block text-sm font-medium text-dfxBlue-800 mb-1">
-            Decision
-          </label>
-          <select
-            id={decisionId}
-            className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
-            value={decision}
-            onChange={(e) => setDecision(e.target.value as LimitRequestDecision | '')}
-          >
-            <option value="">—</option>
-            <option value={LimitRequestDecision.ACCEPTED}>Accept</option>
-            <option value={LimitRequestDecision.PARTIALLY_ACCEPTED}>Partially accept</option>
-            <option value={LimitRequestDecision.REJECTED}>Reject</option>
-          </select>
-        </div>
-      </div>
-
-      {grantsLimit && (
-        <div className="mt-4 max-w-xs">
-          <label htmlFor={acceptedLimitId} className="block text-sm font-medium text-dfxBlue-800 mb-1">
-            Accepted limit (CHF)
+        <div className="flex flex-col gap-1 flex-1 min-w-[200px]">
+          <label htmlFor={commentId} className="text-xs text-dfxGray-700">
+            File note (optional)
           </label>
           <input
-            id={acceptedLimitId}
-            type="number"
-            min={1}
-            className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
-            value={acceptedLimit}
-            onChange={(e) => setAcceptedLimit(e.target.value)}
+            id={commentId}
+            className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 w-full"
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
           />
         </div>
-      )}
+
+        <button
+          className="px-4 py-1.5 bg-dfxBlue-400 text-white rounded text-xs hover:bg-dfxBlue-800 transition-colors disabled:opacity-50"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        >
+          {isSaving ? 'Saving...' : 'Save decision'}
+        </button>
+      </div>
+
+      <p className="mt-2 text-xs text-dfxGray-700">
+        {grantsLimit
+          ? `Sets the annual limit to ${
+              isLimitValid ? parsedLimit.toLocaleString() : '-'
+            } CHF and records the decision.`
+          : decision
+            ? `Keeps the current annual limit${
+                currentDepositLimit != null ? ` of ${currentDepositLimit.toLocaleString()} CHF` : ''
+              } and records the decision.`
+            : 'The customer message is sent separately below, as before.'}
+      </p>
 
       {error && (
         <div className="mt-3">
-          <ErrorHint message={error} />
+          <ErrorHint message={`${error}${doneSteps.length ? ` (already applied: ${doneSteps.join(', ')})` : ''}`} />
         </div>
       )}
-
-      <div className="mt-4 max-w-xs">
-        <StyledButton
-          width={StyledButtonWidth.FULL}
-          label={isSaving ? 'Saving...' : 'Save decision'}
-          onClick={handleSubmit}
-          disabled={!canSubmit}
-        />
-      </div>
     </div>
   );
 }

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
 import {
   LimitRequestDecision,
@@ -6,6 +6,7 @@ import {
   LimitRequestGrantingDecisions,
   useCompliance,
 } from 'src/hooks/compliance.hook';
+import { toBase64 } from 'src/util/utils';
 
 interface Props {
   limitRequestId: number;
@@ -43,6 +44,10 @@ export function LimitRequestDecisionForm({
   // an edit of that number rather than an entry from scratch.
   const [acceptedLimit, setAcceptedLimit] = useState<string>(String(requestedLimit));
   const [comment, setComment] = useState('');
+  // The customer's proof of funds, filed with the note in the same step — in the sheet the clerk had to
+  // pull it out of the message thread and file it by hand.
+  const [document, setDocument] = useState<File>();
+  const documentInputRef = useRef<HTMLInputElement>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string>();
   const [doneSteps, setDoneSteps] = useState<LimitRequestDecisionStep[]>([]);
@@ -51,6 +56,7 @@ export function LimitRequestDecisionForm({
   const decisionId = `limit-request-${limitRequestId}-decision`;
   const acceptedLimitId = `limit-request-${limitRequestId}-accepted-limit`;
   const commentId = `limit-request-${limitRequestId}-comment`;
+  const documentId = `limit-request-${limitRequestId}-document`;
 
   const grantsLimit = !!decision && LimitRequestGrantingDecisions.includes(decision);
   const parsedLimit = Number(acceptedLimit);
@@ -64,6 +70,17 @@ export function LimitRequestDecisionForm({
     setError(undefined);
     setDoneSteps([]);
 
+    let attachment: { data: string; name: string } | undefined;
+    if (document) {
+      const data = await toBase64(document);
+      if (!data) {
+        setIsSaving(false);
+        setError('The selected document could not be read');
+        return;
+      }
+      attachment = { data, name: document.name };
+    }
+
     const result = await decideLimitRequest({ limitRequestId, userDataId }, decision, {
       clerk,
       requestedLimit,
@@ -72,10 +89,13 @@ export function LimitRequestDecisionForm({
       comment: comment.trim() || undefined,
       fundOrigin,
       investmentDate,
+      attachment,
     });
 
     setIsSaving(false);
     if (result.success) {
+      setDocument(undefined);
+      if (documentInputRef.current) documentInputRef.current.value = '';
       onDecided();
     } else {
       // Naming the steps that did land matters: after a failure in between, the operator has to know
@@ -110,7 +130,7 @@ export function LimitRequestDecisionForm({
         {grantsLimit && (
           <div className="flex flex-col gap-1">
             <label htmlFor={acceptedLimitId} className="text-xs text-dfxGray-700">
-              New annual limit (CHF)
+              Accepted limit (CHF)
             </label>
             <input
               id={acceptedLimitId}
@@ -154,13 +174,26 @@ export function LimitRequestDecisionForm({
 
         <div className="flex flex-col gap-1 flex-1 min-w-[200px]">
           <label htmlFor={commentId} className="text-xs text-dfxGray-700">
-            File note (optional)
+            Internal file note
           </label>
           <input
             id={commentId}
             className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 w-full"
             value={comment}
             onChange={(e) => setComment(e.target.value)}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor={documentId} className="text-xs text-dfxGray-700">
+            Customer document (optional)
+          </label>
+          <input
+            id={documentId}
+            ref={documentInputRef}
+            type="file"
+            className="px-2 py-1 text-xs text-dfxBlue-800"
+            onChange={(e) => setDocument(e.target.files?.[0])}
           />
         </div>
 
@@ -172,6 +205,12 @@ export function LimitRequestDecisionForm({
           {isSaving ? 'Saving...' : 'Save decision'}
         </button>
       </div>
+
+      {document && (
+        <p className="mt-2 text-xs text-dfxGray-700">
+          {`"${document.name}" is filed with the note under the customer's documents.`}
+        </p>
+      )}
 
       <p className="mt-2 text-xs text-dfxGray-700">
         {grantsLimit

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
 import {
   LimitRequestDecision,
@@ -45,9 +45,22 @@ export function LimitRequestDecisionForm({
 }: Props): JSX.Element {
   const { decideLimitRequest, fileLimitRequestNote } = useCompliance();
 
-  const isDecided = !!decidedAs;
+  // A decision recorded by this very attempt whose later step failed: the request is final from then
+  // on, so the form must stop offering a decision before the clerk retries and re-writes the deposit
+  // limit with whatever is in the amount field. The screen only learns this on its next reload.
+  const [recordedDecision, setRecordedDecision] = useState<string>();
+  const isDecided = !!decidedAs || !!recordedDecision;
+  const effectiveDecision = decidedAs ?? recordedDecision;
 
   const [clerk, setClerk] = useState(defaultClerk ?? '');
+  // The clerk list arrives after the first render. A name typed into the free-text fallback before it
+  // does would survive in state while the select shows "-", signing the decision with a name the clerk
+  // can no longer see.
+  useEffect(() => {
+    if (clerks.length && !clerks.includes(clerk))
+      setClerk(defaultClerk && clerks.includes(defaultClerk) ? defaultClerk : (clerks[0] ?? ''));
+  }, [clerks]);
+
   const [decision, setDecision] = useState<LimitRequestDecision | ''>('');
   // Prefilled with the requested amount: accepting in full is the common case, and a partial accept is
   // an edit of that number rather than an entry from scratch.
@@ -84,9 +97,14 @@ export function LimitRequestDecisionForm({
 
   async function readDocument(): Promise<{ data: string; name: string } | undefined | 'failed'> {
     if (!document) return undefined;
-    const data = await toBase64(document);
-    if (!data) return 'failed';
-    return { data, name: document.name };
+    try {
+      // `toBase64` rejects on a FileReader error and resolves undefined on an empty result — both mean
+      // the same thing here, and neither may escape and leave the form stuck on "Saving...".
+      const data = await toBase64(document);
+      return data ? { data, name: document.name } : 'failed';
+    } catch {
+      return 'failed';
+    }
   }
 
   async function handleSubmit(): Promise<void> {
@@ -106,7 +124,7 @@ export function LimitRequestDecisionForm({
     const result = isDecided
       ? await fileLimitRequestNote(
           { limitRequestId, userDataId },
-          { clerk, decision: decidedAs as string, comment: comment.trim() || undefined, attachment },
+          { clerk, decision: effectiveDecision as string, comment: comment.trim() || undefined, attachment },
         )
       : await decideLimitRequest({ limitRequestId, userDataId }, decision as LimitRequestDecision, {
           clerk,
@@ -129,6 +147,7 @@ export function LimitRequestDecisionForm({
       // whether the limit was already raised before retrying.
       setDoneSteps(result.completedSteps);
       setError(result.message ?? 'Unknown error');
+      if (result.completedSteps.includes('limitRequest') && decision) setRecordedDecision(decision);
     }
   }
 
@@ -246,16 +265,16 @@ export function LimitRequestDecisionForm({
 
       <p className="mt-2 text-xs text-dfxGray-700">
         {isDecided
-          ? `This request is already decided (${decidedAs}) and cannot be changed. A note or a document can still be filed.`
+          ? `This request is already decided (${effectiveDecision}) and cannot be changed. A note or a document can still be filed.`
           : grantsLimit
             ? `Sets the annual limit to ${
                 isLimitValid ? parsedLimit.toLocaleString() : '-'
-              } CHF and records the decision.`
+              } CHF, records the decision and files the report. The customer is mailed automatically within a few minutes.`
             : decision
               ? `Keeps the current annual limit${
                   currentDepositLimit != null ? ` of ${currentDepositLimit.toLocaleString()} CHF` : ''
                 } and records the decision.`
-              : 'The customer message is sent separately below, as before.'}
+              : 'An accepted request also mails the customer automatically within a few minutes.'}
       </p>
 
       {error && (

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -1,0 +1,151 @@
+import { StyledButton, StyledButtonWidth } from '@dfx.swiss/react-components';
+import { useEffect, useState } from 'react';
+import { ErrorHint } from 'src/components/error-hint';
+import { LimitRequestDecision, LimitRequestInfo, useCompliance } from 'src/hooks/compliance.hook';
+
+interface Props {
+  limitRequest: LimitRequestInfo;
+  onDecided: () => void;
+}
+
+// Decides a pending limit request in the compliance tool. Until this existed the decision had to be
+// made in the Google Sheet, because the API endpoint (PUT /limitRequest/:id) had no UI at all.
+export function LimitRequestDecisionForm({ limitRequest, onDecided }: Props): JSX.Element {
+  const { updateLimitRequest, getCallQueueClerks } = useCompliance();
+
+  const [clerks, setClerks] = useState<string[]>([]);
+  const [signature, setSignature] = useState('');
+  const [decision, setDecision] = useState<LimitRequestDecision | ''>('');
+  // Prefilled with the requested amount: accepting in full is the common case, and a partial accept is
+  // an edit of that number rather than an entry from scratch.
+  const [acceptedLimit, setAcceptedLimit] = useState<string>(String(limitRequest.limit));
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string>();
+
+  // Ids are derived from the request so the labels stay associated even if a screen ever renders more
+  // than one of these forms.
+  const signatureId = `limit-request-${limitRequest.id}-signature`;
+  const decisionId = `limit-request-${limitRequest.id}-decision`;
+  const acceptedLimitId = `limit-request-${limitRequest.id}-accepted-limit`;
+
+  useEffect(() => {
+    getCallQueueClerks()
+      .then((list) => {
+        setClerks(list);
+        setSignature((prev) => prev || list[0] || '');
+      })
+      // The clerk list is a convenience; failing to load it must not block the decision, so the field
+      // falls back to free text below.
+      .catch(() => setClerks([]));
+  }, []);
+
+  const grantsLimit =
+    decision === LimitRequestDecision.ACCEPTED || decision === LimitRequestDecision.PARTIALLY_ACCEPTED;
+  const parsedLimit = Number(acceptedLimit);
+  const isLimitValid = !grantsLimit || (acceptedLimit.trim() !== '' && Number.isFinite(parsedLimit) && parsedLimit > 0);
+  const canSubmit = !!signature.trim() && !!decision && isLimitValid && !isSaving;
+
+  async function handleSubmit(): Promise<void> {
+    if (!decision || !signature.trim() || !isLimitValid) return;
+
+    setIsSaving(true);
+    setError(undefined);
+    try {
+      await updateLimitRequest(limitRequest.id, {
+        decision,
+        acceptedLimit: grantsLimit ? parsedLimit : undefined,
+        clerk: signature.trim(),
+      });
+      onDecided();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <div className="mt-4 border-t border-dfxGray-300 pt-4">
+      <h3 className="text-sm font-semibold text-dfxBlue-800 mb-3">Decision</h3>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label htmlFor={signatureId} className="block text-sm font-medium text-dfxBlue-800 mb-1">
+            Signature
+          </label>
+          {clerks.length ? (
+            <select
+              id={signatureId}
+              className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
+              value={signature}
+              onChange={(e) => setSignature(e.target.value)}
+            >
+              <option value="">—</option>
+              {clerks.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              id={signatureId}
+              className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
+              value={signature}
+              onChange={(e) => setSignature(e.target.value)}
+              placeholder="Your sign"
+            />
+          )}
+        </div>
+
+        <div>
+          <label htmlFor={decisionId} className="block text-sm font-medium text-dfxBlue-800 mb-1">
+            Decision
+          </label>
+          <select
+            id={decisionId}
+            className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
+            value={decision}
+            onChange={(e) => setDecision(e.target.value as LimitRequestDecision | '')}
+          >
+            <option value="">—</option>
+            <option value={LimitRequestDecision.ACCEPTED}>Accept</option>
+            <option value={LimitRequestDecision.PARTIALLY_ACCEPTED}>Partially accept</option>
+            <option value={LimitRequestDecision.REJECTED}>Reject</option>
+          </select>
+        </div>
+      </div>
+
+      {grantsLimit && (
+        <div className="mt-4 max-w-xs">
+          <label htmlFor={acceptedLimitId} className="block text-sm font-medium text-dfxBlue-800 mb-1">
+            Accepted limit (CHF)
+          </label>
+          <input
+            id={acceptedLimitId}
+            type="number"
+            min={1}
+            className="w-full px-3 py-2 text-sm bg-white border border-dfxGray-300 rounded text-dfxBlue-800"
+            value={acceptedLimit}
+            onChange={(e) => setAcceptedLimit(e.target.value)}
+          />
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-3">
+          <ErrorHint message={error} />
+        </div>
+      )}
+
+      <div className="mt-4 max-w-xs">
+        <StyledButton
+          width={StyledButtonWidth.FULL}
+          label={isSaving ? 'Saving...' : 'Save decision'}
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -183,7 +183,20 @@ export interface SupportMessageInfo {
   created: string;
 }
 
+// Mirrors the API's LimitRequestDecision. Accepted/PartiallyAccepted/Rejected are the decisions a
+// clerk makes; Expired/Closed/Approved1of2 are set by the backend and are therefore not offered here.
+export enum LimitRequestDecision {
+  ACCEPTED = 'Accepted',
+  PARTIALLY_ACCEPTED = 'PartiallyAccepted',
+  REJECTED = 'Rejected',
+}
+
+// A decision the API treats as final (LimitRequestFinalStates): the request can no longer be changed,
+// so the decision form is not offered for one of these.
+export const LimitRequestFinalDecisions = ['Accepted', 'PartiallyAccepted', 'Rejected', 'Expired', 'Closed'] as const;
+
 export interface LimitRequestInfo {
+  id: number;
   limit: number;
   acceptedLimit?: number;
   decision?: string;
@@ -1067,6 +1080,26 @@ export function useCompliance() {
     });
   }
 
+  // Decides a pending limit request. The API closes the support issue and triggers the KYC webhook on
+  // an accepting decision, so this is the whole action — nothing else has to be updated alongside it.
+  async function updateLimitRequest(
+    limitRequestId: number,
+    data: { decision: LimitRequestDecision; acceptedLimit?: number; clerk: string },
+  ): Promise<void> {
+    return call<void>({
+      url: `limitRequest/${limitRequestId}`,
+      method: 'PUT',
+      data: {
+        decision: data.decision,
+        // Only sent when the decision grants a limit: the API rejects a null and keeps the previous
+        // value when the field is absent, which is what a rejection should leave behind.
+        ...(data.acceptedLimit != null ? { acceptedLimit: data.acceptedLimit } : {}),
+        clerk: data.clerk,
+        edited: new Date().toISOString(),
+      },
+    });
+  }
+
   async function chargebackTransaction(transactionId: number, data: ChargebackRefundData): Promise<void> {
     return call<void>({
       url: `support/transaction/${transactionId}/refund`,
@@ -1243,6 +1276,7 @@ export function useCompliance() {
       updateKycStep,
       updateUserData,
       createLimitRequest,
+      updateLimitRequest,
       chargebackTransaction,
       stopTransaction,
       updateBankData,

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -1148,21 +1148,27 @@ export function useCompliance() {
   }
 
   /**
-   * Decides a limit request the way the Google Sheet does, in the same order and with the same effects:
+   * Decides a limit request with the same effects the Google Sheet had:
    *
    *   1. `PUT userData/{id} { depositLimit }` — only for a decision that grants a limit. This is the
    *      step that changes what the customer may actually trade: nothing in the API derives the annual
    *      limit from the limit request, so a decision without it would be recorded but toothless.
-   *   2. `PUT limitRequest/{id} { decision, acceptedLimit, clerk, edited }` — the decision itself. The
-   *      API closes the support issue and fires the KYC webhook once the decision is final, so neither
-   *      needs a call of its own; the sheet's separate issue update is redundant against this endpoint.
-   *   3. `POST kyc/admin/log` — the file note ("Aktennotiz"), through the same builder as the
-   *      DfxApproval flow, so both decisions read alike in the customer's file.
+   *   2. `POST support/{id}/limit-request-pdf` — the `UserNotes` / `LimitRequestReport` file record the
+   *      sheet produced for every final decision.
+   *   3. `PUT limitRequest/{id} { decision, acceptedLimit, clerk, edited }` — the decision itself. The
+   *      API closes the support issue, and for an accepting decision a cron mails the customer within
+   *      five minutes, so neither needs a call of its own.
+   *   4. `POST kyc/admin/log` — the file note ("Aktennotiz") plus the customer's document, through the
+   *      same builder as the DfxApproval flow.
    *
-   * The order matters on failure: a raised limit without a recorded decision can be repaired by
-   * repeating the decision, whereas a recorded decision without the raised limit looks finished but is
-   * not. Partial progress is therefore reported rather than swallowed — same contract as
-   * `saveCallOutcome`.
+   * The report is filed BEFORE the decision, unlike the sheet, because the decision is the only step
+   * that cannot be repeated: the API refuses to change a final decision. Failing on step 1 or 2 leaves
+   * nothing recorded and the whole sequence can simply be retried (re-writing the same deposit limit is
+   * a no-op). Had the decision gone first, a failing report would leave a decided request whose file
+   * record could never be produced. A report left behind by a failed step 3 states the decision the
+   * clerk made and is superseded by the report of the successful retry.
+   *
+   * Partial progress is reported rather than swallowed — same contract as `saveCallOutcome`.
    */
   async function decideLimitRequest(
     context: { limitRequestId: number; userDataId: number },
@@ -1191,9 +1197,19 @@ export function useCompliance() {
     const grantsLimit = LimitRequestGrantingDecisions.includes(decision);
     const results: KycLogResult[] = [];
 
+    // A granting decision without an amount would raise nothing and still record an acceptance — the
+    // customer would then be mailed the old limit by the notification cron. Refused rather than skipped.
+    if (grantsLimit && options.grantedLimit == null)
+      return {
+        success: false,
+        failedStep: 'depositLimit',
+        completedSteps,
+        message: 'An accepted limit request needs the limit it grants',
+      };
+
     // 1) Raise the annual limit
     try {
-      if (grantsLimit && options.grantedLimit != null) {
+      if (grantsLimit) {
         await updateUserData(context.userDataId, { depositLimit: options.grantedLimit });
         results.push({ table: 'userData', column: 'depositLimit', value: String(options.grantedLimit) });
         completedSteps.push('depositLimit');
@@ -1202,21 +1218,7 @@ export function useCompliance() {
       return fail('depositLimit', e);
     }
 
-    // 2) Record the decision. On a rejection the limit that stays in force is recorded on the request,
-    // which is what makes a rejected request readable later.
-    try {
-      await updateLimitRequest(context.limitRequestId, {
-        decision,
-        acceptedLimit: grantsLimit ? options.grantedLimit : options.currentDepositLimit,
-        clerk,
-      });
-      results.push({ table: 'limitRequest', column: 'decision', value: decision });
-      completedSteps.push('limitRequest');
-    } catch (e) {
-      return fail('limitRequest', e);
-    }
-
-    // 3) File the report document, the same record the sheet uploaded for every final decision
+    // 2) File the report document, the record the sheet produced for every final decision
     try {
       await generateLimitRequestPdf(context.userDataId, {
         decision,
@@ -1231,6 +1233,21 @@ export function useCompliance() {
       completedSteps.push('report');
     } catch (e) {
       return fail('report', e);
+    }
+
+    // 3) Record the decision. `acceptedLimit` is only sent for a decision that grants one: on a
+    // rejection it would read back as an accepted amount next to the rejection in every view that
+    // renders the field.
+    try {
+      await updateLimitRequest(context.limitRequestId, {
+        decision,
+        acceptedLimit: grantsLimit ? options.grantedLimit : undefined,
+        clerk,
+      });
+      results.push({ table: 'limitRequest', column: 'decision', value: decision });
+      completedSteps.push('limitRequest');
+    } catch (e) {
+      return fail('limitRequest', e);
     }
 
     // 4) File note
@@ -1264,7 +1281,13 @@ export function useCompliance() {
         buildKycLogMessage({
           description: 'LimitRequest',
           clerk: options.clerk.trim(),
-          results: [{ table: 'limitRequest', column: 'decision', value: options.decision }],
+          // `Expired`/`Closed` are set by the backend, not by a clerk; anchoring the note to them would
+          // read as a decision somebody made.
+          results: LimitRequestGrantingDecisions.concat(LimitRequestDecision.REJECTED).includes(
+            options.decision as LimitRequestDecision,
+          )
+            ? [{ table: 'limitRequest', column: 'decision', value: options.decision }]
+            : [{ table: 'limitRequest', column: 'note', value: String(context.limitRequestId) }],
           comment: options.comment,
         }),
         options.attachment,

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -955,11 +955,23 @@ export function useCompliance() {
     });
   }
 
-  async function createKycLog(userDataId: number, comment: string): Promise<void> {
+  // `file` is a data URL (`data:<contentType>;base64,<data>`, what `toBase64` produces). The API stores
+  // it under the account's UserNotes and links it to this very log entry, so the document and the note
+  // explaining it stay together — which is what filing a customer's proof of funds needs.
+  async function createKycLog(
+    userDataId: number,
+    comment: string,
+    attachment?: { data: string; name: string },
+  ): Promise<void> {
     return call<void>({
       url: 'kyc/admin/log',
       method: 'POST',
-      data: { type: 'ManualLog', userData: { id: userDataId }, comment },
+      data: {
+        type: 'ManualLog',
+        userData: { id: userDataId },
+        comment,
+        ...(attachment ? { file: attachment.data, fileName: attachment.name } : {}),
+      },
     });
   }
 
@@ -1163,6 +1175,8 @@ export function useCompliance() {
       comment?: string;
       fundOrigin?: string;
       investmentDate?: string;
+      /** The customer's proof document, filed together with the note. */
+      attachment?: { data: string; name: string };
     },
   ): Promise<LimitRequestDecisionResult> {
     const completedSteps: LimitRequestDecisionStep[] = [];
@@ -1224,6 +1238,7 @@ export function useCompliance() {
       await createKycLog(
         context.userDataId,
         buildKycLogMessage({ description: 'LimitRequest', clerk, results, comment: options.comment }),
+        options.attachment,
       );
       completedSteps.push('log');
     } catch (e) {

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -1248,6 +1248,38 @@ export function useCompliance() {
     return { success: true, completedSteps };
   }
 
+  /**
+   * Files a note (and optionally the customer's document) against an already-decided limit request.
+   * The API refuses to change a final decision, so without this a decision whose report or note failed
+   * halfway could never be completed, and a document arriving after the decision would have nowhere to
+   * go. Same log shape as the decision itself, so both entries read alike in the file.
+   */
+  async function fileLimitRequestNote(
+    context: { limitRequestId: number; userDataId: number },
+    options: { clerk: string; decision: string; comment?: string; attachment?: { data: string; name: string } },
+  ): Promise<LimitRequestDecisionResult> {
+    try {
+      await createKycLog(
+        context.userDataId,
+        buildKycLogMessage({
+          description: 'LimitRequest',
+          clerk: options.clerk.trim(),
+          results: [{ table: 'limitRequest', column: 'decision', value: options.decision }],
+          comment: options.comment,
+        }),
+        options.attachment,
+      );
+      return { success: true, completedSteps: ['log'] };
+    } catch (e) {
+      return {
+        success: false,
+        failedStep: 'log',
+        completedSteps: [],
+        message: e instanceof Error ? e.message : String(e),
+      };
+    }
+  }
+
   async function chargebackTransaction(transactionId: number, data: ChargebackRefundData): Promise<void> {
     return call<void>({
       url: `support/transaction/${transactionId}/refund`,
@@ -1426,6 +1458,7 @@ export function useCompliance() {
       createLimitRequest,
       updateLimitRequest,
       decideLimitRequest,
+      fileLimitRequestNote,
       generateLimitRequestPdf,
       chargebackTransaction,
       stopTransaction,

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -195,8 +195,23 @@ export enum LimitRequestDecision {
 // so the decision form is not offered for one of these.
 export const LimitRequestFinalDecisions = ['Accepted', 'PartiallyAccepted', 'Rejected', 'Expired', 'Closed'] as const;
 
+// The decisions that grant a limit (LimitRequestAcceptedStates on the API side) and therefore require
+// the account's depositLimit to be raised alongside them.
+export const LimitRequestGrantingDecisions: LimitRequestDecision[] = [
+  LimitRequestDecision.ACCEPTED,
+  LimitRequestDecision.PARTIALLY_ACCEPTED,
+];
+
+export type LimitRequestDecisionStep = 'depositLimit' | 'limitRequest' | 'report' | 'log';
+
+export interface LimitRequestDecisionResult {
+  success: boolean;
+  failedStep?: LimitRequestDecisionStep;
+  completedSteps: LimitRequestDecisionStep[];
+  message?: string;
+}
+
 export interface LimitRequestInfo {
-  id: number;
   limit: number;
   acceptedLimit?: number;
   decision?: string;
@@ -827,6 +842,26 @@ export function useCompliance() {
     });
   }
 
+  async function generateLimitRequestPdf(
+    userDataId: number,
+    data: {
+      decision: LimitRequestDecision;
+      clerk: string;
+      requestedLimit: number;
+      grantedLimit?: number;
+      previousLimit?: number;
+      fundOrigin?: string;
+      investmentDate?: string;
+      note?: string;
+    },
+  ): Promise<{ pdfData: string; fileName: string }> {
+    return call<{ pdfData: string; fileName: string }>({
+      url: `support/${userDataId}/limit-request-pdf`,
+      method: 'POST',
+      data,
+    });
+  }
+
   async function getPendingTransactions(): Promise<PendingTransactionInfo[]> {
     return call<PendingTransactionInfo[]>({
       url: 'support/pending-transactions',
@@ -1100,6 +1135,104 @@ export function useCompliance() {
     });
   }
 
+  /**
+   * Decides a limit request the way the Google Sheet does, in the same order and with the same effects:
+   *
+   *   1. `PUT userData/{id} { depositLimit }` — only for a decision that grants a limit. This is the
+   *      step that changes what the customer may actually trade: nothing in the API derives the annual
+   *      limit from the limit request, so a decision without it would be recorded but toothless.
+   *   2. `PUT limitRequest/{id} { decision, acceptedLimit, clerk, edited }` — the decision itself. The
+   *      API closes the support issue and fires the KYC webhook once the decision is final, so neither
+   *      needs a call of its own; the sheet's separate issue update is redundant against this endpoint.
+   *   3. `POST kyc/admin/log` — the file note ("Aktennotiz"), through the same builder as the
+   *      DfxApproval flow, so both decisions read alike in the customer's file.
+   *
+   * The order matters on failure: a raised limit without a recorded decision can be repaired by
+   * repeating the decision, whereas a recorded decision without the raised limit looks finished but is
+   * not. Partial progress is therefore reported rather than swallowed — same contract as
+   * `saveCallOutcome`.
+   */
+  async function decideLimitRequest(
+    context: { limitRequestId: number; userDataId: number },
+    decision: LimitRequestDecision,
+    options: {
+      clerk: string;
+      requestedLimit: number;
+      grantedLimit?: number;
+      currentDepositLimit?: number;
+      comment?: string;
+      fundOrigin?: string;
+      investmentDate?: string;
+    },
+  ): Promise<LimitRequestDecisionResult> {
+    const completedSteps: LimitRequestDecisionStep[] = [];
+    const fail = (step: LimitRequestDecisionStep, err: unknown): LimitRequestDecisionResult => ({
+      success: false,
+      failedStep: step,
+      completedSteps,
+      message: err instanceof Error ? err.message : String(err),
+    });
+
+    const clerk = options.clerk.trim();
+    const grantsLimit = LimitRequestGrantingDecisions.includes(decision);
+    const results: KycLogResult[] = [];
+
+    // 1) Raise the annual limit
+    try {
+      if (grantsLimit && options.grantedLimit != null) {
+        await updateUserData(context.userDataId, { depositLimit: options.grantedLimit });
+        results.push({ table: 'userData', column: 'depositLimit', value: String(options.grantedLimit) });
+        completedSteps.push('depositLimit');
+      }
+    } catch (e) {
+      return fail('depositLimit', e);
+    }
+
+    // 2) Record the decision. On a rejection the limit that stays in force is recorded on the request,
+    // which is what makes a rejected request readable later.
+    try {
+      await updateLimitRequest(context.limitRequestId, {
+        decision,
+        acceptedLimit: grantsLimit ? options.grantedLimit : options.currentDepositLimit,
+        clerk,
+      });
+      results.push({ table: 'limitRequest', column: 'decision', value: decision });
+      completedSteps.push('limitRequest');
+    } catch (e) {
+      return fail('limitRequest', e);
+    }
+
+    // 3) File the report document, the same record the sheet uploaded for every final decision
+    try {
+      await generateLimitRequestPdf(context.userDataId, {
+        decision,
+        clerk,
+        requestedLimit: options.requestedLimit,
+        grantedLimit: grantsLimit ? options.grantedLimit : undefined,
+        previousLimit: options.currentDepositLimit,
+        fundOrigin: options.fundOrigin,
+        investmentDate: options.investmentDate,
+        note: options.comment,
+      });
+      completedSteps.push('report');
+    } catch (e) {
+      return fail('report', e);
+    }
+
+    // 4) File note
+    try {
+      await createKycLog(
+        context.userDataId,
+        buildKycLogMessage({ description: 'LimitRequest', clerk, results, comment: options.comment }),
+      );
+      completedSteps.push('log');
+    } catch (e) {
+      return fail('log', e);
+    }
+
+    return { success: true, completedSteps };
+  }
+
   async function chargebackTransaction(transactionId: number, data: ChargebackRefundData): Promise<void> {
     return call<void>({
       url: `support/transaction/${transactionId}/refund`,
@@ -1277,6 +1410,8 @@ export function useCompliance() {
       updateUserData,
       createLimitRequest,
       updateLimitRequest,
+      decideLimitRequest,
+      generateLimitRequestPdf,
       chargebackTransaction,
       stopTransaction,
       updateBankData,

--- a/src/screens/compliance-support-issue.screen.tsx
+++ b/src/screens/compliance-support-issue.screen.tsx
@@ -1,17 +1,12 @@
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
-import { LimitRequestDecisionForm } from 'src/components/compliance/limit-request-decision-form';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
-import { LimitRequestFinalDecisions, SupportIssueInfo, useCompliance } from 'src/hooks/compliance.hook';
+import { SupportIssueInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { formatDateTime, statusBadge } from 'src/util/compliance-helpers';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
-
-function isDecisionFinal(decision?: string): boolean {
-  return !!decision && (LimitRequestFinalDecisions as readonly string[]).includes(decision);
-}
 
 export default function ComplianceSupportIssueScreen(): JSX.Element {
   useComplianceGuard();
@@ -28,51 +23,29 @@ export default function ComplianceSupportIssueScreen(): JSX.Element {
 
   useLayoutOptions({ title: translate('screens/compliance', 'Support Issue'), backButton: true, noMaxWidth: true });
 
-  // Returns a cancel handle so the initial effect can drop a late response after unmount, while the
-  // reload after a decision can simply await the same fetch.
-  const loadIssue = useCallback((): { promise: Promise<void>; cancel: () => void } => {
-    let cancelled = false;
-    if (!userDataId || !issueId) {
-      setError('Missing parameters');
-      setIsLoading(false);
-      return { promise: Promise.resolve(), cancel: () => undefined };
-    }
-
-    setIsLoading(true);
-    const promise = getUserData(+userDataId)
-      .then((data) => {
-        if (cancelled) return;
-        const found = data.supportIssues?.find((s) => s.id === +issueId);
-        if (found) {
-          setIssue(found);
-          setError(undefined);
-        } else {
-          setError('Support issue not found');
-        }
-      })
-      .catch((e: unknown) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : 'Unknown error');
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
-      });
-
-    return {
-      promise,
-      cancel: () => {
-        cancelled = true;
-      },
-    };
-  }, [userDataId, issueId]);
-
   useEffect(() => {
-    // The list passes the issue along, so the detail view renders without a round trip; only a direct
-    // hit on the URL has to fetch.
     if (issue) return;
 
-    const { cancel } = loadIssue();
-    return cancel;
-  }, [loadIssue]);
+    let cancelled = false;
+    if (userDataId && issueId) {
+      setIsLoading(true);
+      getUserData(+userDataId)
+        .then((data) => {
+          if (cancelled) return;
+          const found = data.supportIssues?.find((s) => s.id === +issueId);
+          if (found) setIssue(found);
+          else setError('Support issue not found');
+        })
+        .catch((e: unknown) => !cancelled && setError(e instanceof Error ? e.message : 'Unknown error'))
+        .finally(() => !cancelled && setIsLoading(false));
+    } else {
+      setError('Missing parameters');
+      setIsLoading(false);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [userDataId, issueId]);
 
   if (error) return <ErrorHint message={error} />;
   if (isLoading || !issue) return <StyledLoadingSpinner size={SpinnerSize.LG} />;
@@ -191,12 +164,6 @@ export default function ComplianceSupportIssueScreen(): JSX.Element {
                 )}
               </tbody>
             </table>
-
-            {/* A final decision cannot be changed (the API rejects it), so the form is only offered
-                while the request is still open. */}
-            {!isDecisionFinal(issue.limitRequest.decision) && (
-              <LimitRequestDecisionForm limitRequest={issue.limitRequest} onDecided={() => void loadIssue().promise} />
-            )}
           </div>
         )}
 

--- a/src/screens/compliance-support-issue.screen.tsx
+++ b/src/screens/compliance-support-issue.screen.tsx
@@ -1,12 +1,17 @@
 import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
+import { LimitRequestDecisionForm } from 'src/components/compliance/limit-request-decision-form';
 import { ErrorHint } from 'src/components/error-hint';
 import { useSettingsContext } from 'src/contexts/settings.context';
-import { SupportIssueInfo, useCompliance } from 'src/hooks/compliance.hook';
+import { LimitRequestFinalDecisions, SupportIssueInfo, useCompliance } from 'src/hooks/compliance.hook';
 import { useComplianceGuard } from 'src/hooks/guard.hook';
 import { formatDateTime, statusBadge } from 'src/util/compliance-helpers';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+function isDecisionFinal(decision?: string): boolean {
+  return !!decision && (LimitRequestFinalDecisions as readonly string[]).includes(decision);
+}
 
 export default function ComplianceSupportIssueScreen(): JSX.Element {
   useComplianceGuard();
@@ -23,29 +28,51 @@ export default function ComplianceSupportIssueScreen(): JSX.Element {
 
   useLayoutOptions({ title: translate('screens/compliance', 'Support Issue'), backButton: true, noMaxWidth: true });
 
-  useEffect(() => {
-    if (issue) return;
-
+  // Returns a cancel handle so the initial effect can drop a late response after unmount, while the
+  // reload after a decision can simply await the same fetch.
+  const loadIssue = useCallback((): { promise: Promise<void>; cancel: () => void } => {
     let cancelled = false;
-    if (userDataId && issueId) {
-      setIsLoading(true);
-      getUserData(+userDataId)
-        .then((data) => {
-          if (cancelled) return;
-          const found = data.supportIssues?.find((s) => s.id === +issueId);
-          if (found) setIssue(found);
-          else setError('Support issue not found');
-        })
-        .catch((e: unknown) => !cancelled && setError(e instanceof Error ? e.message : 'Unknown error'))
-        .finally(() => !cancelled && setIsLoading(false));
-    } else {
+    if (!userDataId || !issueId) {
       setError('Missing parameters');
       setIsLoading(false);
+      return { promise: Promise.resolve(), cancel: () => undefined };
     }
-    return () => {
-      cancelled = true;
+
+    setIsLoading(true);
+    const promise = getUserData(+userDataId)
+      .then((data) => {
+        if (cancelled) return;
+        const found = data.supportIssues?.find((s) => s.id === +issueId);
+        if (found) {
+          setIssue(found);
+          setError(undefined);
+        } else {
+          setError('Support issue not found');
+        }
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Unknown error');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return {
+      promise,
+      cancel: () => {
+        cancelled = true;
+      },
     };
   }, [userDataId, issueId]);
+
+  useEffect(() => {
+    // The list passes the issue along, so the detail view renders without a round trip; only a direct
+    // hit on the URL has to fetch.
+    if (issue) return;
+
+    const { cancel } = loadIssue();
+    return cancel;
+  }, [loadIssue]);
 
   if (error) return <ErrorHint message={error} />;
   if (isLoading || !issue) return <StyledLoadingSpinner size={SpinnerSize.LG} />;
@@ -164,6 +191,12 @@ export default function ComplianceSupportIssueScreen(): JSX.Element {
                 )}
               </tbody>
             </table>
+
+            {/* A final decision cannot be changed (the API rejects it), so the form is only offered
+                while the request is still open. */}
+            {!isDecisionFinal(issue.limitRequest.decision) && (
+              <LimitRequestDecisionForm limitRequest={issue.limitRequest} onDecided={() => void loadIssue().promise} />
+            )}
           </div>
         )}
 

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -3,12 +3,13 @@ import { SpinnerSize, StyledLoadingSpinner } from '@dfx.swiss/react-components';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { FilePreviewPanel } from 'src/components/compliance/file-preview-panel';
+import { LimitRequestDecisionForm } from 'src/components/compliance/limit-request-decision-form';
 import { ErrorHint } from 'src/components/error-hint';
 import { InfoPanel, InfoRow, SupportMessageList } from 'src/components/support/info-panel';
 import { TemplateArrayPickerModal } from 'src/components/support-templates/template-array-picker-modal';
 import { TemplatePickerModal } from 'src/components/support-templates/template-picker-modal';
 import { useSettingsContext } from 'src/contexts/settings.context';
-import { TransactionInfo, UserDataDetail, useCompliance } from 'src/hooks/compliance.hook';
+import { LimitRequestFinalDecisions, TransactionInfo, UserDataDetail, useCompliance } from 'src/hooks/compliance.hook';
 import { useSupportDashboardGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
 import { useNavigation } from 'src/hooks/navigation.hook';
@@ -409,6 +410,27 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
             )}
           </div>
         )}
+
+        {/* Limit Request decision — the compliance endpoints behind it (userData, limitRequest) are
+            Compliance-gated, so a Support-role clerk would only earn a 403 from the buttons. A decision
+            the API treats as final can no longer be changed, so the form disappears once one is set. */}
+        {issueData.limitRequest &&
+          canAccessCompliance &&
+          !(LimitRequestFinalDecisions as readonly string[]).includes(issueData.limitRequest.decision ?? '') && (
+            <div className="bg-white rounded-lg shadow-sm p-4">
+              <LimitRequestDecisionForm
+                limitRequestId={issueData.limitRequest.id}
+                userDataId={issueData.account.id}
+                requestedLimit={issueData.limitRequest.limit}
+                fundOrigin={issueData.limitRequest.fundOrigin}
+                investmentDate={issueData.limitRequest.investmentDate}
+                currentDepositLimit={issueData.account.depositLimit}
+                clerks={clerks}
+                defaultClerk={updateClerk || undefined}
+                onDecided={loadIssue}
+              />
+            </div>
+          )}
 
         {/* Update Controls */}
         <div className="bg-white rounded-lg shadow-sm p-4">

--- a/src/screens/support-dashboard-issue.screen.tsx
+++ b/src/screens/support-dashboard-issue.screen.tsx
@@ -412,25 +412,30 @@ export default function SupportDashboardIssueScreen(): JSX.Element {
         )}
 
         {/* Limit Request decision — the compliance endpoints behind it (userData, limitRequest) are
-            Compliance-gated, so a Support-role clerk would only earn a 403 from the buttons. A decision
-            the API treats as final can no longer be changed, so the form disappears once one is set. */}
-        {issueData.limitRequest &&
-          canAccessCompliance &&
-          !(LimitRequestFinalDecisions as readonly string[]).includes(issueData.limitRequest.decision ?? '') && (
-            <div className="bg-white rounded-lg shadow-sm p-4">
-              <LimitRequestDecisionForm
-                limitRequestId={issueData.limitRequest.id}
-                userDataId={issueData.account.id}
-                requestedLimit={issueData.limitRequest.limit}
-                fundOrigin={issueData.limitRequest.fundOrigin}
-                investmentDate={issueData.limitRequest.investmentDate}
-                currentDepositLimit={issueData.account.depositLimit}
-                clerks={clerks}
-                defaultClerk={updateClerk || undefined}
-                onDecided={loadIssue}
-              />
-            </div>
-          )}
+            Compliance-gated, so a Support-role clerk would only earn a 403 from the buttons. Once the
+            decision is final the API refuses to change it, and the form drops to filing a note or a
+            document: that is how a decision whose report or note failed halfway gets completed, and how
+            a document arriving later still reaches the file. */}
+        {issueData.limitRequest && canAccessCompliance && (
+          <div className="bg-white rounded-lg shadow-sm p-4">
+            <LimitRequestDecisionForm
+              limitRequestId={issueData.limitRequest.id}
+              userDataId={issueData.account.id}
+              requestedLimit={issueData.limitRequest.limit}
+              fundOrigin={issueData.limitRequest.fundOrigin}
+              investmentDate={issueData.limitRequest.investmentDate}
+              currentDepositLimit={issueData.account.depositLimit}
+              decidedAs={
+                (LimitRequestFinalDecisions as readonly string[]).includes(issueData.limitRequest.decision ?? '')
+                  ? issueData.limitRequest.decision
+                  : undefined
+              }
+              clerks={clerks}
+              defaultClerk={updateClerk || undefined}
+              onDecided={loadIssue}
+            />
+          </div>
+        )}
 
         {/* Update Controls */}
         <div className="bg-white rounded-lg shadow-sm p-4">


### PR DESCRIPTION
## What changed

A limit request can now be decided in the compliance tool, on the support-dashboard issue screen where the rest of that workflow already lives (state, department, clerk, customer message with templates).

`useCompliance().decideLimitRequest` performs the decision as the Google Sheet performed it, in the same order:

1. `PUT userData/{id} { depositLimit }` — only for a decision that grants a limit.
2. `POST support/{id}/limit-request-pdf` — the `UserNotes` / `LimitRequestReport` file record, for acceptances and rejections alike.
3. `PUT limitRequest/{id} { decision, acceptedLimit, clerk, edited }`.
4. `POST kyc/admin/log` — the file note, through the same builder as the DfxApproval flow, carrying the customer's document when one is attached (the API stores it under the account's UserNotes and links it to that log entry).

The report goes **before** the decision, unlike the sheet, because the decision is the only step the API refuses to repeat (`Limit request already final`). Anything failing before it leaves the request undecided and the whole sequence retryable — re-writing the same deposit limit is a no-op. With the decision first, a failing report would leave a decided request whose file record could never be produced. This also makes the pair-PR ordering safe: if this PR were released before api#4600, every decision would fail on the report step with nothing recorded, instead of half-applied.

It reports `{ success, failedStep, completedSteps }` exactly like `saveCallOutcome`, and the form names the steps that already landed when something fails midway — after a failure between step 1 and 2 the clerk has to know the limit was already raised before retrying.

The form appears only for Admin/Compliance sessions — the endpoints behind it are Compliance-gated, a Support clerk would only earn a 403.

Once the decision is final the API refuses to change it, so the form drops to filing a note and a document (`fileLimitRequestNote`, one `kyc/admin/log` call). That is deliberate: it is the only way to complete a decision whose report or note failed halfway — the decision is recorded by then, so a retry of the whole sequence would be refused — and it is how a document arriving after the decision still reaches the file.

## Why step 1 is the point of the exercise

The customer's annual limit lives on `userData.depositLimit`, and nothing in the API derives it from the limit request — `LimitRequestService.updateLimitRequest` never touches it. A UI that only wrote the decision would mark a request "Accepted" while leaving the customer on the old limit. That is why the sheet always issued both calls, and why they are one operation here.

## Deliberate differences from the sheet

- **`acceptedLimit` is set only for a decision that grants one.** The sheet wrote the account's current limit on some rejections, but every view labels that field "Accepted", so a rejected request would read as an accepted amount. It is never sent as `null` either: the API validator rejects that.
- **A granting decision without an amount is refused** rather than skipped. It would otherwise record an acceptance against an unchanged limit, and the notification cron would mail the customer their old limit as if it had been raised.
- **`clerk` is the acting clerk**, not the sheet's hard-coded `VR`.
- **The issue state is not set by the form.** The API already moves the issue to `Completed` when the decision becomes final, and the Update Issue panel directly below can still set any other state — the sheet needed its own call because it talked to the API without that panel.
- **The customer's proof document can be filed in the same step.** In the sheet the clerk had to pull it out of the message thread and file it by hand; here it is picked in the decision form and stored with the note that explains it. A document that cannot be read stops the decision rather than recording it without the proof.
- **The customer message stays where it is**, in the existing composer with its templates. Note that an accepting decision already triggers an automatic customer mail through `LimitRequestNotificationService` (within five minutes, except for RealUnit), which the form now says out loud so nobody sends a second one by hand.
- **Decimal amounts are refused before the call.** `user_data.depositLimit` and `limit_request.acceptedLimit` are integer columns validated with `@IsInt`, so a decimal would come back as a 400.
- Numeric input is enforced. The sheet accepted anything: one decision in the log went out with the clerk's initials in the amount field, which produced a 400 on the limit request and a silent no-op on the deposit limit.

Pair PR: **DFXswiss/api#4600** adds the report endpoint used in step 3. **It has to be released first.**

## Checks

- `limit-request-decision.hook.test.ts` (15 tests): the exact call sequence and payloads for acceptance, partial acceptance and rejection; `acceptedLimit` omitted when no limit is known; the note reaching both the log and the report; and each failure position stopping the sequence with the right `failedStep`/`completedSteps`.
  It also pins that the attached document travels with the note and that the file fields are absent when none is attached.
- `limit-request-decision.test.tsx` (20 tests): the decision gate, prefilled amount, amount validation, the amount not travelling with a rejection, the file note, both failure renderings, the free-text clerk fallback, the picked document reaching the hook, an unreadable document stopping the decision, the decimal-amount refusal, the note-only mode (decision fields gone, note or document alone accepted, the decision itself untouched), a rejecting FileReader, the reset after success, the double-submit block, the switch to note mode when the decision landed but a later step failed, and the clerk list arriving late.
- Full suite: 65 suites / 719 tests pass. ESLint clean (`--max-warnings 0`), Prettier clean.
