### PR TITLE
34304637 - Harden the limit request decision flow in the compliance tool

### DIFF
--- a/src/__tests__/limit-request-decision.hook.test.ts
+++ b/src/__tests__/limit-request-decision.hook.test.ts
@@ -55,7 +55,7 @@ describe('useCompliance().fileLimitRequestNote', () => {
       clerk: 'JR',
       decision: 'Accepted',
       comment: 'Beleg nachgereicht',
-      attachment: { data: 'data:application/pdf;base64,QQ==', name: 'Kaufvertrag.pdf' },
+      attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
     });
 
     expect(outcome).toEqual({ success: true, completedSteps: ['log'] });
@@ -83,11 +83,11 @@ describe('useCompliance().decideLimitRequest', () => {
     mockCall.mockReset().mockResolvedValue(undefined);
   });
 
-  // The account first, then the report, then the decision, then the note. The decision is last of the
-  // three writes on purpose: it is the only one the API refuses to repeat, so anything failing before
-  // it leaves the request retryable. Nothing in the API derives the annual limit from the request, so
-  // dropping the userData call would record an acceptance that leaves the customer on the old limit.
-  it('raises the annual limit, files the report, records the acceptance, then files the note', async () => {
+  // Report first, then the decision (which raises depositLimit server-side behind the finality check),
+  // then the note. The decision is the only step the API refuses to repeat, so anything failing before
+  // it leaves the request retryable. Sending grantedDepositLimit on the decision call — rather than a
+  // separate userData write — is what closes the race with a second, later-clicking clerk.
+  it('files the report, records the accepted grant, then files the note', async () => {
     const { result } = renderHook(() => useCompliance());
 
     const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
@@ -101,12 +101,11 @@ describe('useCompliance().decideLimitRequest', () => {
 
     expect(outcome).toEqual({
       success: true,
-      completedSteps: ['depositLimit', 'report', 'limitRequest', 'log'],
+      completedSteps: ['report', 'limitRequest', 'log'],
     });
 
     const urls = mockCall.mock.calls.map(([a]) => `${a.method} ${a.url}`);
     expect(urls).toEqual([
-      'PUT userData/397328',
       'POST support/397328/limit-request-pdf',
       'PUT limitRequest/855',
       'POST kyc/admin/log',
@@ -124,10 +123,16 @@ describe('useCompliance().decideLimitRequest', () => {
       note: undefined,
     });
 
-    expect(callsTo('userData/397328')[0].data).toEqual({ depositLimit: 500000 });
+    // The depositLimit write now lives inside the decision call — no separate userData PUT.
+    expect(callsTo('userData/397328')).toHaveLength(0);
 
     const decision = callsTo('limitRequest/855')[0].data;
-    expect(decision).toMatchObject({ decision: 'Accepted', acceptedLimit: 500000, clerk: 'JR' });
+    expect(decision).toMatchObject({
+      decision: 'Accepted',
+      acceptedLimit: 500000,
+      grantedDepositLimit: 500000,
+      clerk: 'JR',
+    });
     // @IsDate on the API side: the value has to parse as a date, not merely be a string.
     expect(Number.isNaN(Date.parse(decision.edited))).toBe(false);
 
@@ -135,6 +140,7 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(log).toMatchObject({ type: 'ManualLog', userData: { id: 397328 } });
     expect(log.comment).toContain('Services - LimitRequest');
     expect(log.comment).toContain('Editor: JR');
+    // The KycLogResult still documents the limit change even though the write is inside the decision call.
     expect(log.comment).toContain('userData-depositLimit-500000');
     expect(log.comment).toContain('limitRequest-decision-Accepted');
   });
@@ -149,15 +155,17 @@ describe('useCompliance().decideLimitRequest', () => {
       currentDepositLimit: 100000,
     });
 
-    expect(callsTo('userData/397328')[0].data).toEqual({ depositLimit: 200000 });
+    expect(callsTo('userData/397328')).toHaveLength(0);
     expect(callsTo('limitRequest/855')[0].data).toMatchObject({
       decision: 'PartiallyAccepted',
       acceptedLimit: 200000,
+      grantedDepositLimit: 200000,
     });
   });
 
-  // A rejection must not touch the account, and must not write an acceptedLimit: every view that shows
-  // that field labels it "Accepted", so a rejected request would read as an accepted amount.
+  // A rejection must not touch the account, and must not write an acceptedLimit or grantedDepositLimit:
+  // every view that shows acceptedLimit labels it "Accepted", so a rejected request would read as an
+  // accepted amount; the API rejects grantedDepositLimit on a non-granting decision.
   it('leaves the account untouched on a rejection and grants no limit', async () => {
     const { result } = renderHook(() => useCompliance());
 
@@ -177,6 +185,7 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(callsTo('userData/397328')).toHaveLength(0);
     expect(callsTo('limitRequest/855')[0].data).toMatchObject({ decision: 'Rejected', clerk: 'JR' });
     expect(callsTo('limitRequest/855')[0].data).not.toHaveProperty('acceptedLimit');
+    expect(callsTo('limitRequest/855')[0].data).not.toHaveProperty('grantedDepositLimit');
     expect(callsTo('kyc/admin/log')[0].data.comment).not.toContain('depositLimit');
   });
 
@@ -191,10 +200,11 @@ describe('useCompliance().decideLimitRequest', () => {
     });
 
     expect(callsTo('limitRequest/855')[0].data).not.toHaveProperty('acceptedLimit');
+    expect(callsTo('limitRequest/855')[0].data).not.toHaveProperty('grantedDepositLimit');
   });
 
-  // Without the amount the first step would silently do nothing while the decision still went in, and
-  // the notification cron would then mail the customer their old limit as if it had been raised.
+  // Without the amount the decision call would carry nothing to raise and still record an acceptance,
+  // and the notification cron would then mail the customer their old limit as if it had been raised.
   it('refuses a granting decision that carries no amount, before touching anything', async () => {
     const { result } = renderHook(() => useCompliance());
 
@@ -203,7 +213,7 @@ describe('useCompliance().decideLimitRequest', () => {
       requestedLimit: 500000,
     });
 
-    expect(outcome).toMatchObject({ success: false, failedStep: 'depositLimit', completedSteps: [] });
+    expect(outcome).toMatchObject({ success: false, failedStep: 'limitRequest', completedSteps: [] });
     expect(outcome.message).toContain('needs the limit it grants');
     expect(mockCall).not.toHaveBeenCalled();
   });
@@ -247,11 +257,11 @@ describe('useCompliance().decideLimitRequest', () => {
       grantedLimit: 500000,
       currentDepositLimit: 100000,
       comment: 'Hausverkauf',
-      attachment: { data: 'data:application/pdf;base64,QQ==', name: 'Kaufvertrag.pdf' },
+      attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
     });
 
     const log = callsTo('kyc/admin/log')[0].data;
-    expect(log.file).toBe('data:application/pdf;base64,QQ==');
+    expect(log.file).toBe('[PDF attachment removed — 0 KB]');
     expect(log.fileName).toBe('Kaufvertrag.pdf');
     expect(log.comment).toContain('comment: Hausverkauf');
   });
@@ -270,12 +280,9 @@ describe('useCompliance().decideLimitRequest', () => {
   });
 
   // The failure contract: stop at the first failing step and report what already landed, so a retry
-  // cannot silently raise the limit twice or leave a decision recorded against an unchanged account.
-  it('stops and reports when the decision call fails after the limit and report landed', async () => {
-    mockCall
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error('Limit request already final'));
+  // cannot re-decide a request that is already final or leave a decision recorded against a missing report.
+  it('stops and reports when the decision call fails after the report landed', async () => {
+    mockCall.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Limit request already final'));
     const { result } = renderHook(() => useCompliance());
 
     const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
@@ -287,13 +294,13 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(outcome).toEqual({
       success: false,
       failedStep: 'limitRequest',
-      completedSteps: ['depositLimit', 'report'],
+      completedSteps: ['report'],
       message: 'Limit request already final',
     });
     expect(callsTo('kyc/admin/log')).toHaveLength(0);
   });
 
-  it('does not record a decision when raising the limit fails', async () => {
+  it('does not call the decision endpoint when the report fails', async () => {
     mockCall.mockRejectedValueOnce(new Error('nope'));
     const { result } = renderHook(() => useCompliance());
 
@@ -303,14 +310,14 @@ describe('useCompliance().decideLimitRequest', () => {
       grantedLimit: 500000,
     });
 
-    expect(outcome).toMatchObject({ success: false, failedStep: 'depositLimit', completedSteps: [] });
+    expect(outcome).toMatchObject({ success: false, failedStep: 'report', completedSteps: [] });
     expect(callsTo('limitRequest/855')).toHaveLength(0);
   });
 
   // The reason the report goes before the decision: a failing report leaves the request undecided, so
   // the clerk can simply try again once the report endpoint is reachable.
   it('leaves the request undecided when the report fails', async () => {
-    mockCall.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('storage down'));
+    mockCall.mockRejectedValueOnce(new Error('storage down'));
     const { result } = renderHook(() => useCompliance());
 
     const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
@@ -322,7 +329,7 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(outcome).toMatchObject({
       success: false,
       failedStep: 'report',
-      completedSteps: ['depositLimit'],
+      completedSteps: [],
     });
     expect(callsTo('limitRequest/855')).toHaveLength(0);
     expect(callsTo('kyc/admin/log')).toHaveLength(0);
@@ -330,7 +337,6 @@ describe('useCompliance().decideLimitRequest', () => {
 
   it('reports a failed note last, with everything before it recorded', async () => {
     mockCall
-      .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error('log down'));
@@ -345,7 +351,7 @@ describe('useCompliance().decideLimitRequest', () => {
     expect(outcome).toMatchObject({
       success: false,
       failedStep: 'log',
-      completedSteps: ['depositLimit', 'report', 'limitRequest'],
+      completedSteps: ['report', 'limitRequest'],
     });
   });
 });

--- a/src/__tests__/limit-request-decision.hook.test.ts
+++ b/src/__tests__/limit-request-decision.hook.test.ts
@@ -55,7 +55,7 @@ describe('useCompliance().fileLimitRequestNote', () => {
       clerk: 'JR',
       decision: 'Accepted',
       comment: 'Beleg nachgereicht',
-      attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
+      attachment: { data: 'data:application/pdf;base64,QQ==', name: 'Kaufvertrag.pdf' },
     });
 
     expect(outcome).toEqual({ success: true, completedSteps: ['log'] });
@@ -257,11 +257,11 @@ describe('useCompliance().decideLimitRequest', () => {
       grantedLimit: 500000,
       currentDepositLimit: 100000,
       comment: 'Hausverkauf',
-      attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
+      attachment: { data: 'data:application/pdf;base64,QQ==', name: 'Kaufvertrag.pdf' },
     });
 
     const log = callsTo('kyc/admin/log')[0].data;
-    expect(log.file).toBe('[PDF attachment removed — 0 KB]');
+    expect(log.file).toBe('data:application/pdf;base64,QQ==');
     expect(log.fileName).toBe('Kaufvertrag.pdf');
     expect(log.comment).toContain('comment: Hausverkauf');
   });

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -79,7 +79,7 @@ describe('LimitRequestDecisionForm', () => {
     mockDecideLimitRequest.mockResolvedValue({ success: true, completedSteps: [] });
     mockFileLimitRequestNote.mockResolvedValue({ success: true, completedSteps: ['log'] });
     mockToBase64.mockImplementation(async (file: File) =>
-      file.name === 'Kaufvertrag.pdf' ? 'data:application/pdf;base64,Y29udHJhY3Q=' : 'data:text/plain;base64,eA==',
+      file.name === 'Kaufvertrag.pdf' ? '[PDF attachment removed — 0 KB]' : 'data:text/plain;base64,eA==',
     );
   });
 
@@ -110,6 +110,15 @@ describe('LimitRequestDecisionForm', () => {
     expect(onDecided).toHaveBeenCalledTimes(1);
   });
 
+  it('disables the amount field on full acceptance and keeps it at the requested amount', () => {
+    renderForm();
+    selectDecision('Accepted');
+
+    const input = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' }) as HTMLInputElement;
+    expect(input).toBeDisabled();
+    expect(input.value).toBe(String(REQUESTED));
+  });
+
   it('submits the edited amount for a partial acceptance', async () => {
     renderForm();
 
@@ -128,7 +137,7 @@ describe('LimitRequestDecisionForm', () => {
 
   it('blocks an empty or non-positive amount on a granting decision', () => {
     renderForm();
-    selectDecision('Accepted');
+    selectDecision('PartiallyAccepted');
     const input = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' });
 
     fireEvent.change(input, { target: { value: '' } });
@@ -139,6 +148,45 @@ describe('LimitRequestDecisionForm', () => {
 
     fireEvent.change(input, { target: { value: '150000' } });
     expect(saveButton()).not.toBeDisabled();
+  });
+
+  // A partial amount must sit strictly between the current annual limit and the requested amount.
+  it('enforces partial-acceptance bounds against the requested amount and the current limit', () => {
+    renderForm();
+    selectDecision('PartiallyAccepted');
+    const input = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' }) as HTMLInputElement;
+
+    // Field is cleared on selecting PartiallyAccepted.
+    expect(input.value).toBe('');
+    expect(saveButton()).toBeDisabled();
+
+    // Equal to the requested amount is not a partial acceptance.
+    fireEvent.change(input, { target: { value: String(REQUESTED) } });
+    expect(saveButton()).toBeDisabled();
+    expect(screen.getByTestId('accepted-limit-hint')).toBeInTheDocument();
+
+    // Equal to (or below) the current limit would not raise anything.
+    fireEvent.change(input, { target: { value: String(CURRENT_LIMIT) } });
+    expect(saveButton()).toBeDisabled();
+    expect(screen.getByTestId('accepted-limit-hint')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '150000' } });
+    expect(saveButton()).not.toBeDisabled();
+    expect(screen.queryByTestId('accepted-limit-hint')).not.toBeInTheDocument();
+  });
+
+  it('shows the accepted-limit hint only while a partial amount is invalid', () => {
+    renderForm();
+    selectDecision('PartiallyAccepted');
+    const input = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' });
+
+    expect(screen.queryByTestId('accepted-limit-hint')).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: String(REQUESTED) } });
+    expect(screen.getByTestId('accepted-limit-hint')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '150000' } });
+    expect(screen.queryByTestId('accepted-limit-hint')).not.toBeInTheDocument();
   });
 
   // A rejection grants nothing, so the amount field has no meaning there and must not travel with it.
@@ -172,14 +220,14 @@ describe('LimitRequestDecisionForm', () => {
     );
   });
 
-  // Partial application is the dangerous state: the limit is already raised while the decision is not
-  // recorded. The clerk has to see that before retrying, or they raise it a second time blind.
+  // Partial application is the dangerous state: some steps already landed while later ones did not.
+  // The clerk has to see that before retrying.
   it('names the steps that already landed when the sequence fails midway', async () => {
     const onDecided = renderForm();
     mockDecideLimitRequest.mockResolvedValue({
       success: false,
       failedStep: 'limitRequest',
-      completedSteps: ['depositLimit'],
+      completedSteps: ['report'],
       message: 'Limit request already final',
     });
 
@@ -187,7 +235,8 @@ describe('LimitRequestDecisionForm', () => {
     await clickSave();
 
     expect(screen.getByTestId('error-hint')).toHaveTextContent('Limit request already final');
-    expect(screen.getByTestId('error-hint')).toHaveTextContent('already applied: depositLimit');
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('failed at: limitRequest');
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('already applied: report');
     expect(onDecided).not.toHaveBeenCalled();
     // The form stays usable so the clerk can retry or pick another decision.
     expect(saveButton()).not.toBeDisabled();
@@ -197,7 +246,7 @@ describe('LimitRequestDecisionForm', () => {
     renderForm();
     mockDecideLimitRequest.mockResolvedValue({
       success: false,
-      failedStep: 'depositLimit',
+      failedStep: 'report',
       completedSteps: [],
       message: 'nope',
     });
@@ -206,6 +255,7 @@ describe('LimitRequestDecisionForm', () => {
     await clickSave();
 
     expect(screen.getByTestId('error-hint')).toHaveTextContent('nope');
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('failed at: report');
     expect(screen.getByTestId('error-hint')).not.toHaveTextContent('already applied');
   });
 
@@ -225,7 +275,7 @@ describe('LimitRequestDecisionForm', () => {
       CONTEXT,
       'Accepted',
       expect.objectContaining({
-        attachment: { data: 'data:application/pdf;base64,Y29udHJhY3Q=', name: 'Kaufvertrag.pdf' },
+        attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
       }),
     );
   });
@@ -250,7 +300,7 @@ describe('LimitRequestDecisionForm', () => {
   // than being rounded. The form has to refuse it before the call.
   it('refuses a decimal amount', () => {
     renderForm();
-    selectDecision('Accepted');
+    selectDecision('PartiallyAccepted');
     const input = screen.getByLabelText('Accepted limit (CHF)', { selector: 'input' });
 
     fireEvent.change(input, { target: { value: '150000.5' } });
@@ -308,7 +358,7 @@ describe('LimitRequestDecisionForm', () => {
       expect(mockFileLimitRequestNote).toHaveBeenCalledWith(
         CONTEXT,
         expect.objectContaining({
-          attachment: { data: 'data:application/pdf;base64,Y29udHJhY3Q=', name: 'Kaufvertrag.pdf' },
+          attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
         }),
       );
     });
@@ -366,13 +416,13 @@ describe('LimitRequestDecisionForm', () => {
   });
 
   // Once the decision is recorded the API refuses to change it. Without switching modes right away, a
-  // retry would re-write the deposit limit with whatever is in the amount field and fail again.
+  // retry would re-fire the decision sequence and fail again.
   it('switches to note mode when the decision landed but a later step failed', async () => {
     renderForm();
     mockDecideLimitRequest.mockResolvedValue({
       success: false,
       failedStep: 'log',
-      completedSteps: ['depositLimit', 'report', 'limitRequest'],
+      completedSteps: ['report', 'limitRequest'],
       message: 'log down',
     });
 
@@ -380,8 +430,31 @@ describe('LimitRequestDecisionForm', () => {
     await clickSave();
 
     expect(screen.getByTestId('error-hint')).toHaveTextContent('log down');
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('failed at: log');
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('already applied: report, limitRequest');
     expect(screen.queryByLabelText('Decision', { selector: 'select' })).not.toBeInTheDocument();
     expect(screen.getByText(/already decided \(Accepted\)/)).toBeInTheDocument();
+  });
+
+  // Core race-window fix: after a successful decision the form must lock into note-only mode in the
+  // same render cycle, before the parent reloads via onDecided. Without this a second click can re-
+  // fire decideLimitRequest while the parent is still refreshing.
+  it('locks into note mode immediately after a successful decision, before the parent reloads', async () => {
+    renderForm();
+    mockDecideLimitRequest.mockResolvedValue({ success: true, completedSteps: ['report', 'limitRequest', 'log'] });
+
+    selectDecision('Rejected');
+    await clickSave();
+
+    expect(mockDecideLimitRequest).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('button', { name: 'Save decision' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save file note' })).toBeInTheDocument();
+
+    // a further click must not re-trigger the decision call
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save file note' }));
+    });
+    expect(mockDecideLimitRequest).toHaveBeenCalledTimes(1);
   });
 
   // The clerk list arrives after the first render; a name typed before that must not stay in state

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -79,7 +79,7 @@ describe('LimitRequestDecisionForm', () => {
     mockDecideLimitRequest.mockResolvedValue({ success: true, completedSteps: [] });
     mockFileLimitRequestNote.mockResolvedValue({ success: true, completedSteps: ['log'] });
     mockToBase64.mockImplementation(async (file: File) =>
-      file.name === 'Kaufvertrag.pdf' ? '[PDF attachment removed — 0 KB]' : 'data:text/plain;base64,eA==',
+      file.name === 'Kaufvertrag.pdf' ? 'data:application/pdf;base64,Y29udHJhY3Q=' : 'data:text/plain;base64,eA==',
     );
   });
 
@@ -275,7 +275,7 @@ describe('LimitRequestDecisionForm', () => {
       CONTEXT,
       'Accepted',
       expect.objectContaining({
-        attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
+        attachment: { data: 'data:application/pdf;base64,Y29udHJhY3Q=', name: 'Kaufvertrag.pdf' },
       }),
     );
   });
@@ -358,7 +358,7 @@ describe('LimitRequestDecisionForm', () => {
       expect(mockFileLimitRequestNote).toHaveBeenCalledWith(
         CONTEXT,
         expect.objectContaining({
-          attachment: { data: '[PDF attachment removed — 0 KB]', name: 'Kaufvertrag.pdf' },
+          attachment: { data: 'data:application/pdf;base64,Y29udHJhY3Q=', name: 'Kaufvertrag.pdf' },
         }),
       );
     });

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
 import {
   LimitRequestDecision,
@@ -27,10 +27,10 @@ interface Props {
   onDecided: () => void;
 }
 
-// Collects the decision and hands it to `useCompliance().decideLimitRequest`, which performs the same
-// steps in the same order as the Google Sheet (raise the annual limit, record the decision, file the
-// report document, file the note) and reports how far it got. The customer message stays where it
-// already lives on this screen.
+// Collects the decision and hands it to `useCompliance().decideLimitRequest`, which runs the three
+// steps in order (file the report, record the decision — the API raises depositLimit itself behind
+// its finality check — then file the note) and reports how far it got. The customer message stays
+// where it already lives on this screen.
 export function LimitRequestDecisionForm({
   limitRequestId,
   userDataId,
@@ -46,8 +46,8 @@ export function LimitRequestDecisionForm({
   const { decideLimitRequest, fileLimitRequestNote } = useCompliance();
 
   // A decision recorded by this very attempt whose later step failed: the request is final from then
-  // on, so the form must stop offering a decision before the clerk retries and re-writes the deposit
-  // limit with whatever is in the amount field. The screen only learns this on its next reload.
+  // on, so the form must stop offering a decision before the clerk retries. Also set on success so the
+  // form locks into note-only mode immediately, before the parent reloads via onDecided().
   const [recordedDecision, setRecordedDecision] = useState<string>();
   const isDecided = !!decidedAs || !!recordedDecision;
   const effectiveDecision = decidedAs ?? recordedDecision;
@@ -62,8 +62,8 @@ export function LimitRequestDecisionForm({
   }, [clerks]);
 
   const [decision, setDecision] = useState<LimitRequestDecision | ''>('');
-  // Prefilled with the requested amount: accepting in full is the common case, and a partial accept is
-  // an edit of that number rather than an entry from scratch.
+  // Prefilled with the requested amount: accepting in full is the common case. On ACCEPTED the field
+  // is forced back to requestedLimit and disabled; on PARTIALLY_ACCEPTED it is cleared for a new entry.
   const [acceptedLimit, setAcceptedLimit] = useState<string>(String(requestedLimit));
   const [comment, setComment] = useState('');
   // The customer's proof of funds, filed with the note in the same step — in the sheet the clerk had to
@@ -73,6 +73,7 @@ export function LimitRequestDecisionForm({
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string>();
   const [doneSteps, setDoneSteps] = useState<LimitRequestDecisionStep[]>([]);
+  const [failedStep, setFailedStep] = useState<LimitRequestDecisionStep>();
 
   const clerkId = `limit-request-${limitRequestId}-clerk`;
   const decisionId = `limit-request-${limitRequestId}-decision`;
@@ -84,11 +85,37 @@ export function LimitRequestDecisionForm({
   const parsedLimit = Number(acceptedLimit);
   // Both target columns are integers (`user_data.depositLimit`, `limit_request.acceptedLimit`) and both
   // DTOs validate with @IsInt, so a decimal would be refused by the API rather than rounded silently.
-  const isLimitValid =
-    !grantsLimit || (acceptedLimit.trim() !== '' && Number.isInteger(parsedLimit) && parsedLimit > 0);
+  // For PARTIALLY_ACCEPTED the amount must also sit strictly between the current limit and the request.
+  const isPartialLimitValid =
+    acceptedLimit.trim() !== '' &&
+    Number.isInteger(parsedLimit) &&
+    parsedLimit > 0 &&
+    parsedLimit < requestedLimit &&
+    (currentDepositLimit == null || parsedLimit > currentDepositLimit);
+  const isLimitValid = !grantsLimit || decision === LimitRequestDecision.ACCEPTED || isPartialLimitValid;
   const canSubmit = isDecided
     ? !!clerk.trim() && (!!comment.trim() || !!document) && !isSaving
     : !!clerk.trim() && !!decision && isLimitValid && !isSaving;
+
+  function handleDecisionChange(e: ChangeEvent<HTMLSelectElement>): void {
+    const value = e.target.value as LimitRequestDecision | '';
+    setDecision(value);
+    if (value === LimitRequestDecision.ACCEPTED) setAcceptedLimit(String(requestedLimit));
+    else if (value === LimitRequestDecision.PARTIALLY_ACCEPTED) setAcceptedLimit('');
+  }
+
+  function partialLimitHint(): string {
+    if (!Number.isInteger(parsedLimit) || parsedLimit <= 0) {
+      return 'Enter a positive whole number in CHF.';
+    }
+    if (parsedLimit >= requestedLimit) {
+      return `Must be strictly less than the requested amount (${requestedLimit.toLocaleString()} CHF).`;
+    }
+    if (currentDepositLimit != null && parsedLimit <= currentDepositLimit) {
+      return `Must be strictly greater than the current limit (${currentDepositLimit.toLocaleString()} CHF).`;
+    }
+    return 'Enter a valid partial amount.';
+  }
 
   function resetDocument(): void {
     setDocument(undefined);
@@ -113,6 +140,7 @@ export function LimitRequestDecisionForm({
     setIsSaving(true);
     setError(undefined);
     setDoneSteps([]);
+    setFailedStep(undefined);
 
     const attachment = await readDocument();
     if (attachment === 'failed') {
@@ -139,13 +167,17 @@ export function LimitRequestDecisionForm({
 
     setIsSaving(false);
     if (result.success) {
+      // Lock into note-only mode immediately so a second click cannot re-fire the decision sequence
+      // before the parent reloads. Only meaningful in decision mode (note-only already has no decision).
+      if (!isDecided && decision) setRecordedDecision(decision);
       setComment('');
       resetDocument();
       onDecided();
     } else {
       // Naming the steps that did land matters: after a failure in between, the operator has to know
-      // whether the limit was already raised before retrying.
+      // how far the sequence got before retrying.
       setDoneSteps(result.completedSteps);
+      setFailedStep(result.failedStep);
       setError(result.message ?? 'Unknown error');
       if (result.completedSteps.includes('limitRequest') && decision) setRecordedDecision(decision);
     }
@@ -167,7 +199,7 @@ export function LimitRequestDecisionForm({
               id={decisionId}
               className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[150px]"
               value={decision}
-              onChange={(e) => setDecision(e.target.value as LimitRequestDecision | '')}
+              onChange={handleDecisionChange}
             >
               <option value="">-</option>
               <option value={LimitRequestDecision.ACCEPTED}>Accepted</option>
@@ -187,10 +219,18 @@ export function LimitRequestDecisionForm({
               type="number"
               min={1}
               step={1}
-              className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
+              className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px] disabled:opacity-50"
               value={acceptedLimit}
+              disabled={decision === LimitRequestDecision.ACCEPTED}
               onChange={(e) => setAcceptedLimit(e.target.value)}
             />
+            {decision === LimitRequestDecision.PARTIALLY_ACCEPTED &&
+              acceptedLimit.trim() !== '' &&
+              !isPartialLimitValid && (
+                <p data-testid="accepted-limit-hint" className="text-xs text-primary-red">
+                  {partialLimitHint()}
+                </p>
+              )}
           </div>
         )}
 
@@ -279,7 +319,11 @@ export function LimitRequestDecisionForm({
 
       {error && (
         <div className="mt-3">
-          <ErrorHint message={`${error}${doneSteps.length ? ` (already applied: ${doneSteps.join(', ')})` : ''}`} />
+          <ErrorHint
+            message={`${error}${failedStep ? ` (failed at: ${failedStep})` : ''}${
+              doneSteps.length ? ` (already applied: ${doneSteps.join(', ')})` : ''
+            }`}
+          />
         </div>
       )}
     </div>

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -202,7 +202,7 @@ export const LimitRequestGrantingDecisions: LimitRequestDecision[] = [
   LimitRequestDecision.PARTIALLY_ACCEPTED,
 ];
 
-export type LimitRequestDecisionStep = 'depositLimit' | 'limitRequest' | 'report' | 'log';
+export type LimitRequestDecisionStep = 'report' | 'limitRequest' | 'log';
 
 export interface LimitRequestDecisionResult {
   success: boolean;
@@ -1132,9 +1132,16 @@ export function useCompliance() {
 
   // Decides a pending limit request. The API closes the support issue and triggers the KYC webhook on
   // an accepting decision, so this is the whole action — nothing else has to be updated alongside it.
+  // When `grantedDepositLimit` is present the API also raises `userData.depositLimit` itself, behind
+  // its own finality check on the request.
   async function updateLimitRequest(
     limitRequestId: number,
-    data: { decision: LimitRequestDecision; acceptedLimit?: number; clerk: string },
+    data: {
+      decision: LimitRequestDecision;
+      acceptedLimit?: number;
+      grantedDepositLimit?: number;
+      clerk: string;
+    },
   ): Promise<void> {
     return call<void>({
       url: `limitRequest/${limitRequestId}`,
@@ -1142,8 +1149,12 @@ export function useCompliance() {
       data: {
         decision: data.decision,
         // Only sent when the decision grants a limit: the API rejects a null and keeps the previous
-        // value when the field is absent, which is what a rejection should leave behind.
+        // value when the field is absent.
         ...(data.acceptedLimit != null ? { acceptedLimit: data.acceptedLimit } : {}),
+        // The API raises userData.depositLimit itself, behind its own finality check on the request —
+        // sending it here (rather than through a separate userData call) is what closes the race with a
+        // second, later-decided clerk. Only sent on a granting decision; the API rejects it otherwise.
+        ...(data.grantedDepositLimit != null ? { grantedDepositLimit: data.grantedDepositLimit } : {}),
         clerk: data.clerk,
         edited: new Date().toISOString(),
       },
@@ -1151,25 +1162,23 @@ export function useCompliance() {
   }
 
   /**
-   * Decides a limit request with the same effects the Google Sheet had:
+   * Decides a limit request in three steps:
    *
-   *   1. `PUT userData/{id} { depositLimit }` — only for a decision that grants a limit. This is the
-   *      step that changes what the customer may actually trade: nothing in the API derives the annual
-   *      limit from the limit request, so a decision without it would be recorded but toothless.
-   *   2. `POST support/{id}/limit-request-pdf` — the `UserNotes` / `LimitRequestReport` file record the
-   *      sheet produced for every final decision.
-   *   3. `PUT limitRequest/{id} { decision, acceptedLimit, clerk, edited }` — the decision itself. The
-   *      API closes the support issue, and for an accepting decision a cron mails the customer within
-   *      five minutes, so neither needs a call of its own.
-   *   4. `POST kyc/admin/log` — the file note ("Aktennotiz") plus the customer's document, through the
-   *      same builder as the DfxApproval flow.
-   *
-   * The report is filed BEFORE the decision, unlike the sheet, because the decision is the only step
-   * that cannot be repeated: the API refuses to change a final decision. Failing on step 1 or 2 leaves
-   * nothing recorded and the whole sequence can simply be retried (re-writing the same deposit limit is
-   * a no-op). Had the decision gone first, a failing report would leave a decided request whose file
-   * record could never be produced. A report left behind by a failed step 3 states the decision the
-   * clerk made and is superseded by the report of the successful retry.
+   *   1. `POST support/{id}/limit-request-pdf` — the `UserNotes` / `LimitRequestReport` file record the
+   *      sheet produced for every final decision. Filed before the decision because the decision is
+   *      the only step the API refuses to repeat: a failing report leaves the request undecided and
+   *      the whole sequence can simply be retried.
+   *   2. `PUT limitRequest/{id} { decision, acceptedLimit?, grantedDepositLimit?, clerk, edited }` —
+   *      the decision itself. The API closes the support issue, and for an accepting decision a cron
+   *      mails the customer within five minutes. When `grantedDepositLimit` is present the API also
+   *      raises `userData.depositLimit` itself, behind its own finality check on the request — that is
+   *      the difference from the former separate `PUT userData/{id} { depositLimit }` call and closes
+   *      the race with a second, later-clicking clerk who could still raise the limit after another
+   *      clerk had already finalised the request.
+   *   3. `POST kyc/admin/log` — the file note ("Aktennotiz") plus the customer's document, through the
+   *      same builder as the DfxApproval flow. The `KycLogResult` entry for `userData.depositLimit` is
+   *      still written into this note (documenting the limit change) even though the actual write now
+   *      lives inside the decision call.
    *
    * Partial progress is reported rather than swallowed — same contract as `saveCallOutcome`.
    */
@@ -1202,26 +1211,18 @@ export function useCompliance() {
 
     // A granting decision without an amount would raise nothing and still record an acceptance — the
     // customer would then be mailed the old limit by the notification cron. Refused rather than skipped.
+    // failedStep is 'limitRequest': that decision call is what would carry (and reject) the missing amount.
     if (grantsLimit && options.grantedLimit == null)
       return {
         success: false,
-        failedStep: 'depositLimit',
+        failedStep: 'limitRequest',
         completedSteps,
         message: 'An accepted limit request needs the limit it grants',
       };
 
-    // 1) Raise the annual limit
-    try {
-      if (grantsLimit) {
-        await updateUserData(context.userDataId, { depositLimit: options.grantedLimit });
-        results.push({ table: 'userData', column: 'depositLimit', value: String(options.grantedLimit) });
-        completedSteps.push('depositLimit');
-      }
-    } catch (e) {
-      return fail('depositLimit', e);
-    }
-
-    // 2) File the report document, the record the sheet produced for every final decision
+    // 1) File the report document, the record the sheet produced for every final decision. Filed before
+    // the decision because the decision is the only step the API refuses to repeat: a failing report
+    // leaves the request undecided and the whole sequence can simply be retried.
     try {
       await generateLimitRequestPdf(context.userDataId, {
         decision,
@@ -1238,22 +1239,25 @@ export function useCompliance() {
       return fail('report', e);
     }
 
-    // 3) Record the decision. `acceptedLimit` is only sent for a decision that grants one: on a
-    // rejection it would read back as an accepted amount next to the rejection in every view that
-    // renders the field.
+    // 2) Record the decision. The API raises userData.depositLimit itself when grantedDepositLimit is
+    // present, behind its own finality check — nothing else has to touch the account. acceptedLimit and
+    // grantedDepositLimit are only sent for a decision that grants one; on a rejection either would read
+    // back as an accepted amount, or be rejected outright by the API.
     try {
       await updateLimitRequest(context.limitRequestId, {
         decision,
         acceptedLimit: grantsLimit ? options.grantedLimit : undefined,
+        grantedDepositLimit: grantsLimit ? options.grantedLimit : undefined,
         clerk,
       });
+      if (grantsLimit) results.push({ table: 'userData', column: 'depositLimit', value: String(options.grantedLimit) });
       results.push({ table: 'limitRequest', column: 'decision', value: decision });
       completedSteps.push('limitRequest');
     } catch (e) {
       return fail('limitRequest', e);
     }
 
-    // 4) File note
+    // 3) File note
     try {
       await createKycLog(
         context.userDataId,


### PR DESCRIPTION
Addresses the in-scope items of #1251 (the pre-existing observations recorded there stay open). Follow-up to #1247.

## What changed

- **The decision call now carries the deposit limit.** `decideLimitRequest` sends `grantedDepositLimit` (granting decisions only) with `PUT limitRequest/{id}`; the API raises `userData.depositLimit` itself, behind its own finality check on the request. The separate `PUT userData/{id} { depositLimit }` step is gone. This closes the race where a second, later-clicking clerk could still raise the limit on a request another session had already finalized — the sequence is now report → decision (incl. limit) → note, and the step type narrows to `'report' | 'limitRequest' | 'log'`.
- **The form locks immediately after a successful decision.** `recordedDecision` is now also set in the success branch, so the form drops into note-only mode before the parent reloads — a second click cannot re-fire the decision sequence (and with it a duplicate report file).
- **The failed step is shown.** The error hint now names `failed at: <step>` next to the existing `already applied: …` list.
- **Amounts are validated per decision.** `Accepted` fixes the field to the requested amount (input disabled); `PartiallyAccepted` clears the prefill and requires a whole-number amount strictly below the requested limit and, where known, strictly above the current one, with an inline hint.

## Release order

Requires the api-side counterpart (new optional `grantedDepositLimit` on the limit-request update endpoint) to be **released first** — pair PR: DFXswiss/api#4627. Until then this client would fail loudly on the decision step, leaving the request undecided and retryable (same fail-closed ordering as #1247).

## Checks

- `limit-request-decision.hook.test.ts`: new-sequence call shapes (no `userData` call; `grantedDepositLimit` only on granting decisions), failure positions with correct `failedStep`/`completedSteps`.
- `limit-request-decision.test.tsx`: regression test that the form is in note-only mode right after success (before the parent reload) and a further click does not re-trigger the decision; `failedStep` rendering; per-decision amount validation including the cleared prefill on `PartiallyAccepted`.
