### PR TITLE
b360fbab - Keep the deposit limit consistent with the final limit-request decision

### DIFF
--- a/src/__tests__/limit-request-decision.hook.test.ts
+++ b/src/__tests__/limit-request-decision.hook.test.ts
@@ -204,7 +204,7 @@ describe('useCompliance().decideLimitRequest', () => {
     });
 
     expect(outcome).toMatchObject({ success: false, failedStep: 'depositLimit', completedSteps: [] });
-    expect(outcome.message).toContain('needs the limit it grants');
+    expect(outcome.message).toContain('needs a positive integer limit');
     expect(mockCall).not.toHaveBeenCalled();
   });
 
@@ -347,5 +347,58 @@ describe('useCompliance().decideLimitRequest', () => {
       failedStep: 'log',
       completedSteps: ['depositLimit', 'report', 'limitRequest'],
     });
+  });
+
+  // Zero, negative, decimal and NaN would either no-op or be refused by @IsInt — never raise the limit.
+  it.each([0, -5, 1.5, NaN])(
+    'refuses a granting decision with non-positive-integer grantedLimit %p, before touching anything',
+    async (grantedLimit) => {
+      const { result } = renderHook(() => useCompliance());
+
+      const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.ACCEPTED, {
+        clerk: 'JR',
+        requestedLimit: 500000,
+        grantedLimit,
+      });
+
+      expect(outcome).toMatchObject({
+        success: false,
+        failedStep: 'depositLimit',
+        completedSteps: [],
+      });
+      expect(mockCall).not.toHaveBeenCalled();
+    },
+  );
+
+  // A prior partial attempt already raised the limit; a rejection must write the original value back so
+  // the final decision does not leave a silently elevated depositLimit.
+  it('reverts the annual limit on a rejection when revertDepositLimitTo is set', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    const outcome = await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+      revertDepositLimitTo: 50000,
+    });
+
+    expect(outcome.completedSteps).toContain('depositLimit');
+    expect(mockCall.mock.calls.map(([a]) => `${a.method} ${a.url}`)).toEqual([
+      'PUT userData/397328',
+      'POST support/397328/limit-request-pdf',
+      'PUT limitRequest/855',
+      'POST kyc/admin/log',
+    ]);
+    expect(callsTo('userData/397328')[0].data).toEqual({ depositLimit: 50000 });
+  });
+
+  it('does not touch userData on a rejection without revertDepositLimitTo', async () => {
+    const { result } = renderHook(() => useCompliance());
+
+    await result.current.decideLimitRequest(CONTEXT, LimitRequestDecision.REJECTED, {
+      clerk: 'JR',
+      requestedLimit: 500000,
+    });
+
+    expect(callsTo('userData/397328')).toHaveLength(0);
   });
 });

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -431,6 +431,64 @@ describe('LimitRequestDecisionForm', () => {
     );
   });
 
+  // A later failed attempt can report completedSteps: []; doneSteps must still keep depositLimit so
+  // a subsequent rejection still reverts the annual limit.
+  it('keeps depositLimit as done across a chain of failed attempts, so a later rejection still reverts it', async () => {
+    renderForm();
+    mockDecideLimitRequest
+      .mockResolvedValueOnce({
+        success: false,
+        failedStep: 'report',
+        completedSteps: ['depositLimit'],
+        message: 'storage down',
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        failedStep: 'depositLimit',
+        completedSteps: [],
+        message: 'db down',
+      })
+      .mockResolvedValueOnce({ success: true, completedSteps: ['depositLimit', 'report', 'limitRequest', 'log'] });
+
+    selectDecision('Accepted');
+    await clickSave();
+
+    selectDecision('Rejected');
+    await clickSave();
+    await clickSave();
+
+    expect(mockDecideLimitRequest).toHaveBeenCalledTimes(3);
+    expect(mockDecideLimitRequest).toHaveBeenNthCalledWith(
+      3,
+      CONTEXT,
+      'Rejected',
+      expect.objectContaining({ revertDepositLimitTo: CURRENT_LIMIT }),
+    );
+  });
+
+  // Without a known previous limit a non-granting decision must not save after depositLimit already
+  // landed — that would leave the raised limit in force while recording a rejection.
+  it('blocks the save and does not call the hook again when the revert target is unknown', async () => {
+    renderForm({ currentDepositLimit: undefined });
+    mockDecideLimitRequest.mockResolvedValueOnce({
+      success: false,
+      failedStep: 'report',
+      completedSteps: ['depositLimit'],
+      message: 'storage down',
+    });
+
+    selectDecision('Accepted');
+    await clickSave();
+
+    selectDecision('Rejected');
+    await clickSave();
+
+    expect(mockDecideLimitRequest).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('error-hint')).toHaveTextContent(
+      'The previous annual limit is unknown, so it cannot be restored. Reload the issue before rejecting.',
+    );
+  });
+
   // The clerk list arrives after the first render; a name typed before that must not stay in state
   // behind a select that shows something else.
   it('adopts a clerk from the list once it arrives', async () => {

--- a/src/__tests__/limit-request-decision.test.tsx
+++ b/src/__tests__/limit-request-decision.test.tsx
@@ -3,6 +3,15 @@ const mockDecideLimitRequest = jest.fn();
 const mockFileLimitRequestNote = jest.fn();
 const mockToBase64 = jest.fn();
 
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_ns: string, key: string, interpolation?: Record<string, string | number>) =>
+      interpolation
+        ? Object.entries(interpolation).reduce((acc, [k, v]) => acc.replace(`{{${k}}}`, String(v)), key)
+        : key,
+  }),
+}));
+
 // Mocked wholesale rather than via requireActual: the real module pulls in @dfx.swiss/react, which
 // ships ESM that this Jest setup cannot parse. The two exports the component reads at runtime are
 // restated here; their values are the API's and are pinned by the hook test next to this one, which
@@ -255,6 +264,8 @@ describe('LimitRequestDecisionForm', () => {
 
     fireEvent.change(input, { target: { value: '150000.5' } });
     expect(saveButton()).toBeDisabled();
+    fireEvent.click(saveButton());
+    expect(mockDecideLimitRequest).not.toHaveBeenCalled();
 
     fireEvent.change(input, { target: { value: '150000' } });
     expect(saveButton()).not.toBeDisabled();
@@ -359,6 +370,12 @@ describe('LimitRequestDecisionForm', () => {
 
     expect(saveButton('Saving...')).toBeDisabled();
 
+    // Second click while still saving — disabled button must not issue another call.
+    await act(async () => {
+      fireEvent.click(saveButton('Saving...'));
+    });
+    expect(mockDecideLimitRequest).toHaveBeenCalledTimes(1);
+
     await act(async () => {
       release({ success: true, completedSteps: [] });
     });
@@ -382,6 +399,36 @@ describe('LimitRequestDecisionForm', () => {
     expect(screen.getByTestId('error-hint')).toHaveTextContent('log down');
     expect(screen.queryByLabelText('Decision', { selector: 'select' })).not.toBeInTheDocument();
     expect(screen.getByText(/already decided \(Accepted\)/)).toBeInTheDocument();
+  });
+
+  // A failed grant already raised the annual limit. Switching to a rejection must restore the original
+  // value; the form surfaces that and passes revertDepositLimitTo so the hook can write it back.
+  it('offers to restore the previous limit when rejecting after a partial grant', async () => {
+    renderForm();
+    mockDecideLimitRequest.mockResolvedValueOnce({
+      success: false,
+      failedStep: 'report',
+      completedSteps: ['depositLimit'],
+      message: 'storage down',
+    });
+
+    selectDecision('Accepted');
+    await clickSave();
+
+    selectDecision('Rejected');
+    expect(
+      screen.getByText(
+        `The annual limit was already raised by the failed attempt. Saving a rejection will restore the previous limit of ${CURRENT_LIMIT.toLocaleString()} CHF.`,
+      ),
+    ).toBeInTheDocument();
+
+    await clickSave();
+
+    expect(mockDecideLimitRequest).toHaveBeenLastCalledWith(
+      CONTEXT,
+      'Rejected',
+      expect.objectContaining({ revertDepositLimitTo: CURRENT_LIMIT }),
+    );
   });
 
   // The clerk list arrives after the first render; a name typed before that must not stay in state

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ErrorHint } from 'src/components/error-hint';
+import { useSettingsContext } from 'src/contexts/settings.context';
 import {
   LimitRequestDecision,
   LimitRequestDecisionStep,
@@ -43,6 +44,7 @@ export function LimitRequestDecisionForm({
   defaultClerk,
   onDecided,
 }: Props): JSX.Element {
+  const { translate } = useSettingsContext();
   const { decideLimitRequest, fileLimitRequestNote } = useCompliance();
 
   // A decision recorded by this very attempt whose later step failed: the request is final from then
@@ -117,7 +119,7 @@ export function LimitRequestDecisionForm({
     const attachment = await readDocument();
     if (attachment === 'failed') {
       setIsSaving(false);
-      setError('The selected document could not be read');
+      setError(translate('screens/compliance', 'The selected document could not be read'));
       return;
     }
 
@@ -131,6 +133,12 @@ export function LimitRequestDecisionForm({
           requestedLimit,
           grantedLimit: grantsLimit ? parsedLimit : undefined,
           currentDepositLimit,
+          // A prior attempt already raised the limit; a non-granting decision must restore the original.
+          ...(doneSteps.includes('depositLimit') &&
+          decision &&
+          !LimitRequestGrantingDecisions.includes(decision)
+            ? { revertDepositLimitTo: currentDepositLimit }
+            : {}),
           comment: comment.trim() || undefined,
           fundOrigin,
           investmentDate,
@@ -146,7 +154,7 @@ export function LimitRequestDecisionForm({
       // Naming the steps that did land matters: after a failure in between, the operator has to know
       // whether the limit was already raised before retrying.
       setDoneSteps(result.completedSteps);
-      setError(result.message ?? 'Unknown error');
+      setError(result.message ?? translate('screens/compliance', 'Unknown error'));
       if (result.completedSteps.includes('limitRequest') && decision) setRecordedDecision(decision);
     }
   }
@@ -154,14 +162,16 @@ export function LimitRequestDecisionForm({
   return (
     <div className="mt-4 border-t border-dfxGray-300 pt-4">
       <h3 className="text-sm font-semibold text-dfxBlue-800 mb-3">
-        {isDecided ? 'File note for this limit request' : 'Decide Limit Request'}
+        {isDecided
+          ? translate('screens/compliance', 'File note for this limit request')
+          : translate('screens/compliance', 'Decide Limit Request')}
       </h3>
 
       <div className="flex gap-3 flex-wrap items-end">
         {!isDecided && (
           <div className="flex flex-col gap-1">
             <label htmlFor={decisionId} className="text-xs text-dfxGray-700">
-              Decision
+              {translate('screens/compliance', 'Decision')}
             </label>
             <select
               id={decisionId}
@@ -180,7 +190,7 @@ export function LimitRequestDecisionForm({
         {grantsLimit && (
           <div className="flex flex-col gap-1">
             <label htmlFor={acceptedLimitId} className="text-xs text-dfxGray-700">
-              Accepted limit (CHF)
+              {translate('screens/compliance', 'Accepted limit (CHF)')}
             </label>
             <input
               id={acceptedLimitId}
@@ -196,7 +206,7 @@ export function LimitRequestDecisionForm({
 
         <div className="flex flex-col gap-1">
           <label htmlFor={clerkId} className="text-xs text-dfxGray-700">
-            Clerk
+            {translate('screens/compliance', 'Clerk')}
           </label>
           {clerks.length ? (
             <select
@@ -218,14 +228,14 @@ export function LimitRequestDecisionForm({
               className="px-2 py-1.5 text-xs border border-dfxGray-400 rounded bg-white text-dfxBlue-800 min-w-[130px]"
               value={clerk}
               onChange={(e) => setClerk(e.target.value)}
-              placeholder="Sign"
+              placeholder={translate('screens/compliance', 'Sign')}
             />
           )}
         </div>
 
         <div className="flex flex-col gap-1 flex-1 min-w-[200px]">
           <label htmlFor={commentId} className="text-xs text-dfxGray-700">
-            Internal file note
+            {translate('screens/compliance', 'Internal file note')}
           </label>
           <input
             id={commentId}
@@ -237,7 +247,7 @@ export function LimitRequestDecisionForm({
 
         <div className="flex flex-col gap-1">
           <label htmlFor={documentId} className="text-xs text-dfxGray-700">
-            Customer document (optional)
+            {translate('screens/compliance', 'Customer document (optional)')}
           </label>
           <input
             id={documentId}
@@ -253,35 +263,75 @@ export function LimitRequestDecisionForm({
           onClick={handleSubmit}
           disabled={!canSubmit}
         >
-          {isSaving ? 'Saving...' : isDecided ? 'Save file note' : 'Save decision'}
+          {isSaving
+            ? translate('screens/compliance', 'Saving...')
+            : isDecided
+              ? translate('screens/compliance', 'Save file note')
+              : translate('screens/compliance', 'Save decision')}
         </button>
       </div>
 
       {document && (
         <p className="mt-2 text-xs text-dfxGray-700">
-          {`"${document.name}" is filed with the note under the customer's documents.`}
+          {translate('screens/compliance', '"{{name}}" is filed with the note under the customer\'s documents.', {
+            name: document.name,
+          })}
         </p>
       )}
 
       <p className="mt-2 text-xs text-dfxGray-700">
         {isDecided
-          ? `This request is already decided (${effectiveDecision}) and cannot be changed. A note or a document can still be filed.`
+          ? translate(
+              'screens/compliance',
+              'This request is already decided ({{decision}}) and cannot be changed. A note or a document can still be filed.',
+              { decision: effectiveDecision as string },
+            )
           : grantsLimit
-            ? `Sets the annual limit to ${
-                isLimitValid ? parsedLimit.toLocaleString() : '-'
-              } CHF, records the decision and files the report. The customer is mailed automatically within a few minutes.`
+            ? translate(
+                'screens/compliance',
+                'Sets the annual limit to {{amount}} CHF, records the decision and files the report. The customer is mailed automatically within a few minutes.',
+                { amount: isLimitValid ? parsedLimit.toLocaleString() : '-' },
+              )
             : decision
-              ? `Keeps the current annual limit${
-                  currentDepositLimit != null ? ` of ${currentDepositLimit.toLocaleString()} CHF` : ''
-                } and records the decision.`
-              : 'An accepted request also mails the customer automatically within a few minutes.'}
+              ? currentDepositLimit != null
+                ? translate(
+                    'screens/compliance',
+                    'Keeps the current annual limit of {{amount}} CHF and records the decision.',
+                    { amount: currentDepositLimit.toLocaleString() },
+                  )
+                : translate('screens/compliance', 'Keeps the current annual limit and records the decision.')
+              : translate(
+                  'screens/compliance',
+                  'An accepted request also mails the customer automatically within a few minutes.',
+                )}
       </p>
 
       {error && (
         <div className="mt-3">
-          <ErrorHint message={`${error}${doneSteps.length ? ` (already applied: ${doneSteps.join(', ')})` : ''}`} />
+          <ErrorHint
+            message={`${error}${
+              doneSteps.length
+                ? translate('screens/compliance', ' (already applied: {{steps}})', {
+                    steps: doneSteps.join(', '),
+                  })
+                : ''
+            }`}
+          />
         </div>
       )}
+
+      {doneSteps.includes('depositLimit') &&
+        !!decision &&
+        !LimitRequestGrantingDecisions.includes(decision) &&
+        currentDepositLimit != null && (
+          <p className="mt-2 text-xs text-dfxGray-700">
+            {translate(
+              'screens/compliance',
+              'The annual limit was already raised by the failed attempt. Saving a rejection will restore the previous limit of {{amount}} CHF.',
+              { amount: currentDepositLimit.toLocaleString() },
+            )}
+          </p>
+        )}
     </div>
   );
 }

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -112,9 +112,25 @@ export function LimitRequestDecisionForm({
   async function handleSubmit(): Promise<void> {
     if (!canSubmit) return;
 
+    // Revert needed but target unknown: fail closed rather than store a rejection while the raised limit stays.
+    if (
+      !isDecided &&
+      doneSteps.includes('depositLimit') &&
+      decision &&
+      !LimitRequestGrantingDecisions.includes(decision) &&
+      currentDepositLimit == null
+    ) {
+      setError(
+        translate(
+          'screens/compliance',
+          'The previous annual limit is unknown, so it cannot be restored. Reload the issue before rejecting.',
+        ),
+      );
+      return;
+    }
+
     setIsSaving(true);
     setError(undefined);
-    setDoneSteps([]);
 
     const attachment = await readDocument();
     if (attachment === 'failed') {
@@ -145,13 +161,16 @@ export function LimitRequestDecisionForm({
 
     setIsSaving(false);
     if (result.success) {
+      // Cleared only here: resetting at the start of a submit would lose the record of an already
+      // raised limit on any early return (e.g. an unreadable document) — the revert path depends on it.
+      setDoneSteps([]);
       setComment('');
       resetDocument();
       onDecided();
     } else {
-      // Naming the steps that did land matters: after a failure in between, the operator has to know
-      // whether the limit was already raised before retrying.
-      setDoneSteps(result.completedSteps);
+      // Once a step has landed it stays landed; a later attempt that fails before its first step must
+      // not erase knowledge of an already raised limit — the revert path above depends on it.
+      setDoneSteps(Array.from(new Set([...doneSteps, ...result.completedSteps])));
       setError(result.message ?? translate('screens/compliance', 'Unknown error'));
       if (result.completedSteps.includes('limitRequest') && decision) setRecordedDecision(decision);
     }

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -134,9 +134,7 @@ export function LimitRequestDecisionForm({
           grantedLimit: grantsLimit ? parsedLimit : undefined,
           currentDepositLimit,
           // A prior attempt already raised the limit; a non-granting decision must restore the original.
-          ...(doneSteps.includes('depositLimit') &&
-          decision &&
-          !LimitRequestGrantingDecisions.includes(decision)
+          ...(doneSteps.includes('depositLimit') && decision && !LimitRequestGrantingDecisions.includes(decision)
             ? { revertDepositLimitTo: currentDepositLimit }
             : {}),
           comment: comment.trim() || undefined,

--- a/src/components/compliance/limit-request-decision-form.tsx
+++ b/src/components/compliance/limit-request-decision-form.tsx
@@ -311,9 +311,9 @@ export function LimitRequestDecisionForm({
           <ErrorHint
             message={`${error}${
               doneSteps.length
-                ? translate('screens/compliance', ' (already applied: {{steps}})', {
+                ? ` ${translate('screens/compliance', '(already applied: {{steps}})', {
                     steps: doneSteps.join(', '),
-                  })
+                  })}`
                 : ''
             }`}
           />

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -1165,9 +1165,12 @@ export function useCompliance() {
    *      same builder as the DfxApproval flow.
    *
    * The report is filed BEFORE the decision, unlike the sheet, because the decision is the only step
-   * that cannot be repeated: the API refuses to change a final decision. Failing on step 1 or 2 leaves
-   * nothing recorded and the whole sequence can simply be retried (re-writing the same deposit limit is
-   * a no-op). Had the decision gone first, a failing report would leave a decided request whose file
+   * that cannot be repeated: the API refuses to change a final decision. A failure on step 1 leaves
+   * nothing recorded. A failure after step 1 leaves the already-raised deposit limit — visible via
+   * completedSteps containing 'depositLimit'. A retry with the same (granting) decision rewrites that
+   * limit idempotently. Switching to a non-granting decision must pass `revertDepositLimitTo` with the
+   * original value, otherwise the limit stays silently raised while a rejection is stored at the end.
+   * Had the decision gone first, a failing report would leave a decided request whose file
    * record could never be produced. A report left behind by a failed step 3 states the decision the
    * clerk made and is superseded by the report of the successful retry.
    *
@@ -1181,6 +1184,12 @@ export function useCompliance() {
       requestedLimit: number;
       grantedLimit?: number;
       currentDepositLimit?: number;
+      /**
+       * Only set when a prior partial attempt already raised the limit and the current decision does
+       * not grant one; step 1 then writes this original value back so a final rejection does not leave
+       * a silently raised limit.
+       */
+      revertDepositLimitTo?: number;
       comment?: string;
       fundOrigin?: string;
       investmentDate?: string;
@@ -1200,21 +1209,26 @@ export function useCompliance() {
     const grantsLimit = LimitRequestGrantingDecisions.includes(decision);
     const results: KycLogResult[] = [];
 
-    // A granting decision without an amount would raise nothing and still record an acceptance — the
-    // customer would then be mailed the old limit by the notification cron. Refused rather than skipped.
-    if (grantsLimit && options.grantedLimit == null)
+    // A granting decision without a positive integer amount would raise nothing (or the API would refuse
+    // a decimal) and still record an acceptance — the customer would then be mailed the old limit by the
+    // notification cron. Refused rather than skipped.
+    if (grantsLimit && !(options.grantedLimit != null && Number.isInteger(options.grantedLimit) && options.grantedLimit > 0))
       return {
         success: false,
         failedStep: 'depositLimit',
         completedSteps,
-        message: 'An accepted limit request needs the limit it grants',
+        message: 'An accepted limit request needs a positive integer limit',
       };
 
-    // 1) Raise the annual limit
+    // 1) Raise the annual limit (or restore the pre-attempt value when reverting a failed grant)
     try {
       if (grantsLimit) {
         await updateUserData(context.userDataId, { depositLimit: options.grantedLimit });
         results.push({ table: 'userData', column: 'depositLimit', value: String(options.grantedLimit) });
+        completedSteps.push('depositLimit');
+      } else if (options.revertDepositLimitTo != null) {
+        await updateUserData(context.userDataId, { depositLimit: options.revertDepositLimitTo });
+        results.push({ table: 'userData', column: 'depositLimit', value: String(options.revertDepositLimitTo) });
         completedSteps.push('depositLimit');
       }
     } catch (e) {

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -1212,7 +1212,10 @@ export function useCompliance() {
     // A granting decision without a positive integer amount would raise nothing (or the API would refuse
     // a decimal) and still record an acceptance — the customer would then be mailed the old limit by the
     // notification cron. Refused rather than skipped.
-    if (grantsLimit && !(options.grantedLimit != null && Number.isInteger(options.grantedLimit) && options.grantedLimit > 0))
+    if (
+      grantsLimit &&
+      !(options.grantedLimit != null && Number.isInteger(options.grantedLimit) && options.grantedLimit > 0)
+    )
       return {
         success: false,
         failedStep: 'depositLimit',


### PR DESCRIPTION
## What changed

Follow-ups to #1247, addressing the review findings on the limit-request decision flow. The invariant this PR enforces client-side: **a finally stored decision must leave a deposit limit that matches it.**

- **Consistency after a partial failure**: when a first attempt already raised the customer's deposit limit (step 1 succeeded) and a later step failed, switching to a non-granting decision no longer leaves the raised limit behind silently. The form passes `revertDepositLimitTo` with the pre-attempt value, step 1 of the retry restores it, and the form announces the restore before saving. Without this, a rejection saved after such a partial failure would become final while the customer kept the raised limit — a state nothing re-checks afterwards.
- **Cumulative step tracking**: the record of an already raised limit survives later failed attempts (a retry that fails before its first step reports `completedSteps: []`, which previously overwrote the knowledge) and early returns such as an unreadable document; it is cleared only on a fully successful save.
- **Fail-closed when the revert target is unknown**: if a revert would be needed but the original limit is not known to the form, the save is refused with an error instead of silently storing a rejection while the raised limit stays.
- **Hook guards its own invariant**: `decideLimitRequest` refuses a granting decision unless `grantedLimit` is a positive integer (`0`, negatives, decimals and `NaN` fail before any API call), instead of relying on the form validation alone.
- **Test hardening**: the double-submit test really submits twice while the first call is pending; the decimal-amount test asserts that no call happens; the revert path, the failed-attempt chain and the unknown-original guard are covered.
- **i18n**: all visible form texts go through `translate('screens/compliance', …)` like the surrounding compliance components. The three decision option labels deliberately stay untranslated: they mirror the API enum values, like the call-queue outcome options.

## Documented limit

The client cannot carry this invariant across a page reload: the transient step state is gone, and re-fetched account data already shows the raised value. The robust fix is server-side (atomic decision endpoint or a consistency check) — tracked in DFXswiss/api#4630. This PR still closes every client-reachable path and is strictly safer than the current develop state, which has all of these gaps open.

## Tests

`limit-request-decision.hook.test.ts` and `limit-request-decision.test.tsx` extended accordingly (44 tests across the two files). Full local gate run green: tests, ESLint (`--max-warnings 0`), Prettier on the touched files, `tsc -p tsconfig.build.json --noEmit`.
