### PR TITLE
Show the preferred call time without a consent step first

### DIFF
--- a/e2e/helpers/fresh-auth.ts
+++ b/e2e/helpers/fresh-auth.ts
@@ -1,0 +1,48 @@
+import { APIRequestContext } from '@playwright/test';
+import * as dotenv from 'dotenv';
+import { HDNodeWallet } from 'ethers';
+import * as path from 'path';
+import { generateTestMnemonic } from '../test-wallet';
+
+dotenv.config({ path: path.join(__dirname, '../../.env') });
+
+// Same base as e2e/helpers/auth-cache.ts — fail loud if unset (no silent fallback to the dev server).
+const apiBase = process.env.REACT_APP_API_URL;
+if (!apiBase) {
+  throw new Error('REACT_APP_API_URL environment variable is required');
+}
+const API_URL = apiBase + '/v1';
+
+/**
+ * Creates a throwaway Dev-API session (signMessage → signature → /auth).
+ * Always fresh — not cached — so phoneCallAccepted stays unset for first-call cases.
+ * Prefer this over auth-cache when the test depends on an empty verification-call state.
+ */
+export async function createFreshDevSession(request: APIRequestContext): Promise<string> {
+  const mnemonic = generateTestMnemonic();
+  const wallet = HDNodeWallet.fromPhrase(mnemonic);
+
+  const signMsgRes = await request.get(`${API_URL}/auth/signMessage?address=${encodeURIComponent(wallet.address)}`, {
+    ignoreHTTPSErrors: true,
+  });
+  if (!signMsgRes.ok()) {
+    const body = await signMsgRes.text().catch(() => 'unknown');
+    throw new Error(`signMessage failed with status ${signMsgRes.status()}: ${body}`);
+  }
+  const { message } = await signMsgRes.json();
+  const signature = await wallet.signMessage(message);
+
+  const authRes = await request.post(`${API_URL}/auth`, {
+    data: { address: wallet.address, signature },
+    ignoreHTTPSErrors: true,
+  });
+  if (!authRes.ok()) {
+    const body = await authRes.text().catch(() => 'unknown');
+    throw new Error(`Auth failed with status ${authRes.status()}: ${body}`);
+  }
+  const data = await authRes.json();
+  if (!data?.accessToken) {
+    throw new Error(`Auth response missing accessToken: ${JSON.stringify(data)}`);
+  }
+  return data.accessToken as string;
+}

--- a/e2e/settings-call-time.spec.ts
+++ b/e2e/settings-call-time.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect, APIRequestContext } from '@playwright/test';
+import * as dotenv from 'dotenv';
+import { HDNodeWallet } from 'ethers';
+import * as path from 'path';
+import { generateTestMnemonic } from './test-wallet';
+
+dotenv.config({ path: path.join(__dirname, '../.env') });
+
+const API_URL = `${process.env.REACT_APP_API_URL ?? ''}/v1`;
+
+/**
+ * Creates a throwaway account on the Dev API (same signMessage → signature → /auth
+ * flow as e2e/helpers/auth-cache.ts), so phoneCallAccepted is unset — the first-call case.
+ */
+async function createFreshDevSession(request: APIRequestContext): Promise<string> {
+  const mnemonic = generateTestMnemonic();
+  const wallet = HDNodeWallet.fromPhrase(mnemonic);
+
+  const signMsgRes = await request.get(`${API_URL}/auth/signMessage?address=${encodeURIComponent(wallet.address)}`, {
+    ignoreHTTPSErrors: true,
+  });
+  if (!signMsgRes.ok()) {
+    const body = await signMsgRes.text().catch(() => 'unknown');
+    throw new Error(`signMessage failed with status ${signMsgRes.status()}: ${body}`);
+  }
+  const { message } = await signMsgRes.json();
+  const signature = await wallet.signMessage(message);
+
+  const authRes = await request.post(`${API_URL}/auth`, {
+    data: { address: wallet.address, signature },
+    ignoreHTTPSErrors: true,
+  });
+  if (!authRes.ok()) {
+    const body = await authRes.text().catch(() => 'unknown');
+    throw new Error(`Auth failed with status ${authRes.status()}: ${body}`);
+  }
+  const data = await authRes.json();
+  if (!data?.accessToken) {
+    throw new Error(`Auth response missing accessToken: ${JSON.stringify(data)}`);
+  }
+  return data.accessToken as string;
+}
+
+/**
+ * First-time customer opening the mail deep-link must see preferred call times
+ * without first choosing "Yes, call me".
+ */
+test.describe('Settings preferred call time visibility', () => {
+  let token: string;
+
+  test.beforeAll(async ({ request }) => {
+    token = await createFreshDevSession(request);
+  });
+
+  test('first-time customer sees Preferred call time on /settings?a=call', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 480 });
+    await page.goto(`/settings?a=call&session=${token}&lang=en`);
+
+    const heading = page.getByRole('heading', { name: 'Verification Call' });
+    await expect(heading).toBeVisible({ timeout: 30000 });
+    await heading.scrollIntoViewIfNeeded();
+
+    // Precondition: fresh account has no consent choice yet (placeholder, not Yes/No).
+    // If the API ever defaulted phoneCallAccepted, this would fail instead of going vacuum-green.
+    const phoneVerification = page.locator('label', { hasText: /^Phone verification$/ }).locator('..');
+    await expect(phoneVerification.getByText('Select...')).toBeVisible();
+
+    await expect(page.locator('label', { hasText: /^Preferred call time$/ })).toBeVisible();
+  });
+});

--- a/e2e/settings-call-time.spec.ts
+++ b/e2e/settings-call-time.spec.ts
@@ -1,49 +1,12 @@
-import { test, expect, APIRequestContext } from '@playwright/test';
-import * as dotenv from 'dotenv';
-import { HDNodeWallet } from 'ethers';
-import * as path from 'path';
-import { generateTestMnemonic } from './test-wallet';
-
-dotenv.config({ path: path.join(__dirname, '../.env') });
-
-const API_URL = `${process.env.REACT_APP_API_URL ?? ''}/v1`;
-
-/**
- * Creates a throwaway account on the Dev API (same signMessage → signature → /auth
- * flow as e2e/helpers/auth-cache.ts), so phoneCallAccepted is unset — the first-call case.
- */
-async function createFreshDevSession(request: APIRequestContext): Promise<string> {
-  const mnemonic = generateTestMnemonic();
-  const wallet = HDNodeWallet.fromPhrase(mnemonic);
-
-  const signMsgRes = await request.get(`${API_URL}/auth/signMessage?address=${encodeURIComponent(wallet.address)}`, {
-    ignoreHTTPSErrors: true,
-  });
-  if (!signMsgRes.ok()) {
-    const body = await signMsgRes.text().catch(() => 'unknown');
-    throw new Error(`signMessage failed with status ${signMsgRes.status()}: ${body}`);
-  }
-  const { message } = await signMsgRes.json();
-  const signature = await wallet.signMessage(message);
-
-  const authRes = await request.post(`${API_URL}/auth`, {
-    data: { address: wallet.address, signature },
-    ignoreHTTPSErrors: true,
-  });
-  if (!authRes.ok()) {
-    const body = await authRes.text().catch(() => 'unknown');
-    throw new Error(`Auth failed with status ${authRes.status()}: ${body}`);
-  }
-  const data = await authRes.json();
-  if (!data?.accessToken) {
-    throw new Error(`Auth response missing accessToken: ${JSON.stringify(data)}`);
-  }
-  return data.accessToken as string;
-}
+import { test, expect } from '@playwright/test';
+import { createFreshDevSession } from './helpers/fresh-auth';
 
 /**
  * First-time customer opening the mail deep-link must see preferred call times
  * without first choosing "Yes, call me".
+ *
+ * Uses a fresh (uncached) account each run: a cached session could already have
+ * phoneCallAccepted set and would not exercise the first-call UI.
  */
 test.describe('Settings preferred call time visibility', () => {
   let token: string;

--- a/src/__tests__/settings-call-time-visible.test.tsx
+++ b/src/__tests__/settings-call-time-visible.test.tsx
@@ -1,0 +1,330 @@
+// SettingsScreen verification-call: preferred times visible without prior consent;
+// each field still saves independently; failed saves surface ErrorHint.
+
+const mockUpdateCallSettings = jest.fn();
+const mockUser = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({
+  PhoneCallStatus: {
+    COMPLETED: 'Completed',
+    FAILED: 'Failed',
+    UNAVAILABLE: 'Unavailable',
+  },
+  PhoneCallTime: {
+    H_9_TO_10: 'H9To10',
+    H_10_TO_11: 'H10To11',
+    H_9_TO_16: 'H9To16',
+  },
+  Utils: {
+    formatIban: (iban: string) => iban,
+  },
+  useBankAccountContext: () => ({
+    bankAccounts: [],
+    updateAccount: jest.fn(),
+    isLoading: false,
+  }),
+  useFiatContext: () => ({
+    currencies: [{ id: 2, name: 'EUR' }],
+  }),
+  useUserContext: () => ({
+    user: mockUser(),
+    isUserLoading: false,
+    userAddresses: [],
+    updateCallSettings: mockUpdateCallSettings,
+    deleteAddress: jest.fn(),
+    deleteAccount: jest.fn(),
+    renameAddress: jest.fn(),
+  }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Controller } = require('react-hook-form');
+
+  function enrich(elements: any, control: any): any {
+    if (!elements) return elements;
+    return React.Children.map(elements, (element: any) => {
+      if (!React.isValidElement(element)) return element;
+      const props: any = element.props;
+      const newChildren = enrich(props.children, control);
+      if (props.name) {
+        return React.cloneElement(element, { control, children: newChildren });
+      }
+      return React.cloneElement(element, { children: newChildren });
+    });
+  }
+
+  return {
+    Form: ({ children, control }: any) => <div>{enrich(children, control)}</div>,
+    SpinnerSize: { LG: 'lg' },
+    StyledButton: ({ label, onClick, isLoading }: any) => (
+      <button type="button" onClick={onClick} disabled={isLoading}>
+        {label}
+      </button>
+    ),
+    StyledButtonColor: { STURDY_WHITE: 'sturdy-white', GRAY_OUTLINE: 'gray' },
+    StyledButtonWidth: { FULL: 'full' },
+    StyledDropdown: ({ name, items, labelFunc, label, control }: any) => (
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }: any) => (
+          <div data-testid={`dropdown-${name}`}>
+            {label && <label>{label}</label>}
+            <span data-testid={`dropdown-${name}-value`}>
+              {field.value === undefined || field.value === null ? 'Select...' : labelFunc(field.value)}
+            </span>
+            {(items ?? []).map((item: any) => (
+              <button
+                key={String(labelFunc(item))}
+                type="button"
+                data-testid={`select-${name}-${labelFunc(item)}`}
+                onClick={() => field.onChange(item)}
+              >
+                {labelFunc(item)}
+              </button>
+            ))}
+          </div>
+        )}
+      />
+    ),
+    // Mirrors real multi-choice: deselecting the last item yields [].
+    StyledDropdownMultiChoice: ({ name, items, labelFunc, label, control }: any) => (
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }: any) => {
+          const selected: any[] = field.value || [];
+          return (
+            <div data-testid={`dropdown-${name}`}>
+              {label && <label>{label}</label>}
+              <span data-testid={`dropdown-${name}-value`}>
+                {selected.length === 0 ? 'Select...' : selected.map((i) => labelFunc(i)).join(', ')}
+              </span>
+              {(items ?? []).map((item: any) => (
+                <button
+                  key={String(labelFunc(item))}
+                  type="button"
+                  data-testid={`select-${name}-${labelFunc(item)}`}
+                  onClick={() => {
+                    const exists = selected.some((s) => JSON.stringify(s) === JSON.stringify(item));
+                    field.onChange(
+                      exists ? selected.filter((s) => JSON.stringify(s) !== JSON.stringify(item)) : [...selected, item],
+                    );
+                  }}
+                >
+                  {labelFunc(item)}
+                </button>
+              ))}
+            </div>
+          );
+        }}
+      />
+    ),
+    StyledHorizontalStack: ({ children }: any) => <div>{children}</div>,
+    StyledLoadingSpinner: () => null,
+    StyledVerticalStack: ({ children }: any) => <div>{children}</div>,
+  };
+});
+
+jest.mock('copy-to-clipboard', () => () => true);
+jest.mock('src/components/actionable-list', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+jest.mock('src/components/error-hint', () => ({
+  ErrorHint: ({ message }: { message: string }) => <div data-testid="error-hint">{message}</div>,
+}));
+jest.mock('src/components/overlay/edit-bank-overlay', () => ({ EditBankAccount: () => null }));
+jest.mock('src/components/overlay/edit-overlay', () => ({ EditOverlay: () => null }));
+jest.mock('src/components/payment/add-bank-account', () => ({ AddBankAccount: () => null }));
+jest.mock('src/config/labels', () => ({
+  addressLabel: () => '',
+  PhoneCallTimeLabels: {
+    H9To10: '09:00 - 10:00',
+    H10To11: '10:00 - 11:00',
+    H9To16: '09:00 - 16:00',
+  },
+}));
+jest.mock('src/contexts/layout.context', () => ({
+  useLayoutContext: () => ({ rootRef: { current: null } }),
+}));
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_ns: string, key: string) => key,
+    language: { id: 1, name: 'English', symbol: 'EN' },
+    currency: { id: 2, name: 'EUR' },
+    availableLanguages: [{ id: 1, name: 'English', symbol: 'EN', foreignName: 'English' }],
+    changeLanguage: jest.fn(),
+    changeCurrency: jest.fn(),
+  }),
+}));
+jest.mock('src/contexts/wallet.context', () => ({
+  useWalletContext: () => ({ setWallet: jest.fn() }),
+}));
+jest.mock('src/contexts/window.context', () => ({
+  useWindowContext: () => ({ width: 800 }),
+}));
+jest.mock('src/hooks/anchor.hook', () => ({ useAnchor: jest.fn() }));
+jest.mock('src/hooks/guard.hook', () => ({ useUserGuard: jest.fn() }));
+jest.mock('src/hooks/layout-config.hook', () => ({ useLayoutOptions: jest.fn() }));
+jest.mock('src/hooks/navigation.hook', () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+jest.mock('src/util/utils', () => ({
+  blankedAddress: (a: string) => a,
+  sortAddressesByBlockchain: () => 0,
+}));
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { PhoneCallTime } from '@dfx.swiss/react';
+import SettingsScreen from 'src/screens/settings.screen';
+
+/** useApi().call throws ApiException which extends Error — not a plain object. */
+function apiError(message: string): Error {
+  return new Error(message);
+}
+
+function firstCustomerUser(overrides: Record<string, unknown> = {}) {
+  const kycOverride = (overrides.kyc as object) ?? {};
+  return {
+    disabledAddresses: [],
+    activeAddress: undefined,
+    ...overrides,
+    kyc: {
+      phoneCallAccepted: null,
+      preferredPhoneTimes: undefined,
+      phoneCallStatus: undefined,
+      ...kycOverride,
+    },
+  };
+}
+
+describe('SettingsScreen preferred call time visibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUser.mockReturnValue(firstCustomerUser());
+    mockUpdateCallSettings.mockResolvedValue(undefined);
+  });
+
+  it('shows preferred call time for a first-time customer without prior consent', () => {
+    render(<SettingsScreen />);
+
+    expect(screen.getByText('Verification Call')).toBeInTheDocument();
+    expect(screen.getByTestId('dropdown-preferredPhoneTimes')).toBeInTheDocument();
+    expect(screen.getByTestId('dropdown-preferredPhoneTimes-value')).toHaveTextContent('Select...');
+  });
+
+  it('selecting a time sends only preferredPhoneTimes (no acceptCall)', async () => {
+    render(<SettingsScreen />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('select-preferredPhoneTimes-09:00 - 10:00'));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(1));
+    expect(mockUpdateCallSettings).toHaveBeenCalledWith([PhoneCallTime.H_9_TO_10]);
+    expect(mockUpdateCallSettings.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('selecting No sends acceptCall false only', async () => {
+    mockUser.mockReturnValue(
+      firstCustomerUser({
+        kyc: { phoneCallAccepted: true, preferredPhoneTimes: [PhoneCallTime.H_9_TO_10] },
+      }),
+    );
+
+    render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-acceptCall-value')).toHaveTextContent('Yes, call me');
+    });
+
+    mockUpdateCallSettings.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(1));
+    expect(mockUpdateCallSettings).toHaveBeenCalledWith(undefined, false);
+  });
+
+  it('shows an error when preferred call time save fails', async () => {
+    mockUpdateCallSettings.mockRejectedValueOnce(apiError('Phone call status is already set'));
+
+    render(<SettingsScreen />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('select-preferredPhoneTimes-09:00 - 10:00'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('Phone call status is already set');
+    });
+  });
+
+  it('shows an error when acceptCall save fails', async () => {
+    mockUpdateCallSettings.mockRejectedValueOnce(apiError('Consent update rejected'));
+
+    render(<SettingsScreen />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('Consent update rejected');
+    });
+  });
+
+  it('keeps the acceptCall error when a later preferred-time save succeeds', async () => {
+    mockUpdateCallSettings.mockRejectedValueOnce(apiError('Consent update rejected')).mockResolvedValueOnce(undefined);
+
+    render(<SettingsScreen />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('Consent update rejected');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('select-preferredPhoneTimes-09:00 - 10:00'));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(2));
+    expect(mockUpdateCallSettings).toHaveBeenNthCalledWith(2, [PhoneCallTime.H_9_TO_10]);
+
+    expect(screen.getByTestId('error-hint')).toHaveTextContent('Consent update rejected');
+  });
+
+  it('clears the preferred-time error after a successful retry on the same field', async () => {
+    mockUpdateCallSettings
+      .mockRejectedValueOnce(apiError('Phone call status is already set'))
+      .mockResolvedValueOnce(undefined);
+
+    render(<SettingsScreen />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('select-preferredPhoneTimes-09:00 - 10:00'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error-hint')).toHaveTextContent('Phone call status is already set');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('select-preferredPhoneTimes-10:00 - 11:00'));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/settings-call-time-visible.test.tsx
+++ b/src/__tests__/settings-call-time-visible.test.tsx
@@ -1,5 +1,6 @@
 // SettingsScreen verification-call: preferred times visible without prior consent;
-// each field still saves independently; failed saves surface ErrorHint.
+// each field still saves independently; failed saves surface ErrorHint under that field
+// and roll the form value back to the server so the same choice can be retried.
 
 const mockUpdateCallSettings = jest.fn();
 const mockUser = jest.fn();
@@ -178,7 +179,7 @@ jest.mock('src/util/utils', () => ({
   sortAddressesByBlockchain: () => 0,
 }));
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { PhoneCallTime } from '@dfx.swiss/react';
 import SettingsScreen from 'src/screens/settings.screen';
 
@@ -195,7 +196,8 @@ function firstCustomerUser(overrides: Record<string, unknown> = {}) {
     ...overrides,
     kyc: {
       phoneCallAccepted: null,
-      preferredPhoneTimes: undefined,
+      // v2 always returns an array (empty when none chosen) — never undefined.
+      preferredPhoneTimes: [],
       phoneCallStatus: undefined,
       ...kycOverride,
     },
@@ -252,7 +254,7 @@ describe('SettingsScreen preferred call time visibility', () => {
     expect(mockUpdateCallSettings).toHaveBeenCalledWith(undefined, false);
   });
 
-  it('shows an error when preferred call time save fails', async () => {
+  it('shows preferred-time error under the time field when save fails', async () => {
     mockUpdateCallSettings.mockRejectedValueOnce(apiError('Phone call status is already set'));
 
     render(<SettingsScreen />);
@@ -262,11 +264,14 @@ describe('SettingsScreen preferred call time visibility', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('error-hint')).toHaveTextContent('Phone call status is already set');
+      expect(within(screen.getByTestId('preferred-phone-times-error')).getByTestId('error-hint')).toHaveTextContent(
+        'Phone call status is already set',
+      );
     });
+    expect(screen.queryByTestId('accept-call-error')).not.toBeInTheDocument();
   });
 
-  it('shows an error when acceptCall save fails', async () => {
+  it('shows acceptCall error under the consent field when save fails', async () => {
     mockUpdateCallSettings.mockRejectedValueOnce(apiError('Consent update rejected'));
 
     render(<SettingsScreen />);
@@ -276,8 +281,11 @@ describe('SettingsScreen preferred call time visibility', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('error-hint')).toHaveTextContent('Consent update rejected');
+      expect(within(screen.getByTestId('accept-call-error')).getByTestId('error-hint')).toHaveTextContent(
+        'Consent update rejected',
+      );
     });
+    expect(screen.queryByTestId('preferred-phone-times-error')).not.toBeInTheDocument();
   });
 
   it('keeps the acceptCall error when a later preferred-time save succeeds', async () => {
@@ -290,7 +298,9 @@ describe('SettingsScreen preferred call time visibility', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('error-hint')).toHaveTextContent('Consent update rejected');
+      expect(within(screen.getByTestId('accept-call-error')).getByTestId('error-hint')).toHaveTextContent(
+        'Consent update rejected',
+      );
     });
 
     await act(async () => {
@@ -300,7 +310,10 @@ describe('SettingsScreen preferred call time visibility', () => {
     await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(2));
     expect(mockUpdateCallSettings).toHaveBeenNthCalledWith(2, [PhoneCallTime.H_9_TO_10]);
 
-    expect(screen.getByTestId('error-hint')).toHaveTextContent('Consent update rejected');
+    expect(within(screen.getByTestId('accept-call-error')).getByTestId('error-hint')).toHaveTextContent(
+      'Consent update rejected',
+    );
+    expect(screen.queryByTestId('preferred-phone-times-error')).not.toBeInTheDocument();
   });
 
   it('clears the preferred-time error after a successful retry on the same field', async () => {
@@ -315,7 +328,7 @@ describe('SettingsScreen preferred call time visibility', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('error-hint')).toHaveTextContent('Phone call status is already set');
+      expect(screen.getByTestId('preferred-phone-times-error')).toBeInTheDocument();
     });
 
     await act(async () => {
@@ -324,7 +337,132 @@ describe('SettingsScreen preferred call time visibility', () => {
 
     await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(2));
     await waitFor(() => {
-      expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('preferred-phone-times-error')).not.toBeInTheDocument();
+    });
+  });
+
+  it('after a failed acceptCall save, the dropdown returns to the server value and shows the error', async () => {
+    mockUser.mockReturnValue(
+      firstCustomerUser({
+        kyc: { phoneCallAccepted: true, preferredPhoneTimes: [] },
+      }),
+    );
+    mockUpdateCallSettings.mockRejectedValueOnce(apiError('Consent update rejected'));
+
+    render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-acceptCall-value')).toHaveTextContent('Yes, call me');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('accept-call-error')).getByTestId('error-hint')).toHaveTextContent(
+        'Consent update rejected',
+      );
+    });
+    expect(screen.getByTestId('dropdown-acceptCall-value')).toHaveTextContent('Yes, call me');
+  });
+
+  it('after a failed acceptCall save, choosing the same option again sends another request', async () => {
+    mockUser.mockReturnValue(
+      firstCustomerUser({
+        kyc: { phoneCallAccepted: true, preferredPhoneTimes: [] },
+      }),
+    );
+    mockUpdateCallSettings
+      .mockRejectedValueOnce(apiError('Consent update rejected'))
+      .mockRejectedValueOnce(apiError('Consent update rejected'));
+
+    render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-acceptCall-value')).toHaveTextContent('Yes, call me');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-acceptCall-value')).toHaveTextContent('Yes, call me');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(2));
+    expect(mockUpdateCallSettings).toHaveBeenNthCalledWith(2, undefined, false);
+  });
+
+  it('after a failed preferred-time save, the dropdown returns to the server value and a retry sends another request', async () => {
+    mockUpdateCallSettings
+      .mockRejectedValueOnce(apiError('Phone call status is already set'))
+      .mockRejectedValueOnce(apiError('Phone call status is already set'));
+
+    render(<SettingsScreen />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('select-preferredPhoneTimes-09:00 - 10:00'));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(within(screen.getByTestId('preferred-phone-times-error')).getByTestId('error-hint')).toHaveTextContent(
+        'Phone call status is already set',
+      );
+    });
+    expect(screen.getByTestId('dropdown-preferredPhoneTimes-value')).toHaveTextContent('Select...');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('select-preferredPhoneTimes-09:00 - 10:00'));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(2));
+    expect(mockUpdateCallSettings).toHaveBeenNthCalledWith(2, [PhoneCallTime.H_9_TO_10]);
+  });
+
+  it('clears acceptCall error when the user starts another save on that field', async () => {
+    // After rollback the form already shows the server value, so a new choice always
+    // differs and enters the if — that is where the error is cleared (no outside-if sticky path).
+    mockUser.mockReturnValue(
+      firstCustomerUser({
+        kyc: { phoneCallAccepted: true, preferredPhoneTimes: [] },
+      }),
+    );
+    mockUpdateCallSettings
+      .mockRejectedValueOnce(apiError('Consent update rejected'))
+      .mockResolvedValueOnce(undefined);
+
+    render(<SettingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-acceptCall-value')).toHaveTextContent('Yes, call me');
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('accept-call-error')).getByTestId('error-hint')).toHaveTextContent(
+        'Consent update rejected',
+      );
+    });
+    expect(screen.getByTestId('dropdown-acceptCall-value')).toHaveTextContent('Yes, call me');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("select-acceptCall-No, don't call me"));
+    });
+
+    await waitFor(() => expect(mockUpdateCallSettings).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(screen.queryByTestId('accept-call-error')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/screens/settings.screen.tsx
+++ b/src/screens/settings.screen.tsx
@@ -1,4 +1,5 @@
 import {
+  ApiError,
   BankAccount,
   Fiat,
   Language,
@@ -25,6 +26,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { Trans } from 'react-i18next';
 import ActionableList from 'src/components/actionable-list';
+import { ErrorHint } from 'src/components/error-hint';
 import { ConfirmationOverlay } from 'src/components/overlay/confirmation-overlay';
 import { EditBankAccount } from 'src/components/overlay/edit-bank-overlay';
 import { EditOverlay } from 'src/components/overlay/edit-overlay';
@@ -81,6 +83,8 @@ export default function SettingsScreen(): JSX.Element {
 
   const [overlayData, setOverlayData] = useState<UserAddress | BankAccount>();
   const [overlayType, setOverlayType] = useState<OverlayType>(OverlayType.NONE);
+  const [acceptCallError, setAcceptCallError] = useState<string>();
+  const [preferredPhoneTimesError, setPreferredPhoneTimesError] = useState<string>();
 
   useUserGuard('/login');
 
@@ -132,13 +136,19 @@ export default function SettingsScreen(): JSX.Element {
       selectedPreferredPhoneTimes &&
       JSON.stringify(selectedPreferredPhoneTimes) !== JSON.stringify(user?.kyc.preferredPhoneTimes)
     ) {
-      updateCallSettings(selectedPreferredPhoneTimes);
+      setPreferredPhoneTimesError(undefined);
+      updateCallSettings(selectedPreferredPhoneTimes).catch((error: ApiError) =>
+        setPreferredPhoneTimesError(error.message ?? 'Unknown error'),
+      );
     }
   }, [selectedPreferredPhoneTimes]);
 
   useEffect(() => {
     if (acceptCall !== undefined && acceptCall !== user?.kyc.phoneCallAccepted) {
-      updateCallSettings(undefined, acceptCall);
+      setAcceptCallError(undefined);
+      updateCallSettings(undefined, acceptCall).catch((error: ApiError) =>
+        setAcceptCallError(error.message ?? 'Unknown error'),
+      );
     }
   }, [acceptCall]);
 
@@ -328,20 +338,20 @@ export default function SettingsScreen(): JSX.Element {
                     }
                   />
                 </Form>
+                {acceptCallError && <ErrorHint message={acceptCallError} />}
 
-                {acceptCall && (
-                  <Form control={control} errors={errors}>
-                    <StyledDropdownMultiChoice<PhoneCallTime>
-                      rootRef={rootRef}
-                      name="preferredPhoneTimes"
-                      label={translate('screens/settings', 'Preferred call time')}
-                      smallLabel={true}
-                      placeholder={translate('general/actions', 'Select') + '...'}
-                      items={Object.values(PhoneCallTime)}
-                      labelFunc={(item) => translate('screens/settings', PhoneCallTimeLabels[item])}
-                    />
-                  </Form>
-                )}
+                <Form control={control} errors={errors}>
+                  <StyledDropdownMultiChoice<PhoneCallTime>
+                    rootRef={rootRef}
+                    name="preferredPhoneTimes"
+                    label={translate('screens/settings', 'Preferred call time')}
+                    smallLabel={true}
+                    placeholder={translate('general/actions', 'Select') + '...'}
+                    items={Object.values(PhoneCallTime)}
+                    labelFunc={(item) => translate('screens/settings', PhoneCallTimeLabels[item])}
+                  />
+                </Form>
+                {preferredPhoneTimesError && <ErrorHint message={preferredPhoneTimesError} />}
               </StyledVerticalStack>
             </StyledVerticalStack>
           )}

--- a/src/screens/settings.screen.tsx
+++ b/src/screens/settings.screen.tsx
@@ -137,18 +137,20 @@ export default function SettingsScreen(): JSX.Element {
       JSON.stringify(selectedPreferredPhoneTimes) !== JSON.stringify(user?.kyc.preferredPhoneTimes)
     ) {
       setPreferredPhoneTimesError(undefined);
-      updateCallSettings(selectedPreferredPhoneTimes).catch((error: ApiError) =>
-        setPreferredPhoneTimesError(error.message ?? 'Unknown error'),
-      );
+      updateCallSettings(selectedPreferredPhoneTimes).catch((error: ApiError) => {
+        setPreferredPhoneTimesError(error.message ?? 'Unknown error');
+        setValue('preferredPhoneTimes', user?.kyc.preferredPhoneTimes ?? []);
+      });
     }
   }, [selectedPreferredPhoneTimes]);
 
   useEffect(() => {
     if (acceptCall !== undefined && acceptCall !== user?.kyc.phoneCallAccepted) {
       setAcceptCallError(undefined);
-      updateCallSettings(undefined, acceptCall).catch((error: ApiError) =>
-        setAcceptCallError(error.message ?? 'Unknown error'),
-      );
+      updateCallSettings(undefined, acceptCall).catch((error: ApiError) => {
+        setAcceptCallError(error.message ?? 'Unknown error');
+        setValue('acceptCall', user?.kyc.phoneCallAccepted as boolean);
+      });
     }
   }, [acceptCall]);
 
@@ -338,7 +340,11 @@ export default function SettingsScreen(): JSX.Element {
                     }
                   />
                 </Form>
-                {acceptCallError && <ErrorHint message={acceptCallError} />}
+                {acceptCallError && (
+                  <div data-testid="accept-call-error">
+                    <ErrorHint message={acceptCallError} />
+                  </div>
+                )}
 
                 <Form control={control} errors={errors}>
                   <StyledDropdownMultiChoice<PhoneCallTime>
@@ -351,7 +357,11 @@ export default function SettingsScreen(): JSX.Element {
                     labelFunc={(item) => translate('screens/settings', PhoneCallTimeLabels[item])}
                   />
                 </Form>
-                {preferredPhoneTimesError && <ErrorHint message={preferredPhoneTimesError} />}
+                {preferredPhoneTimesError && (
+                  <div data-testid="preferred-phone-times-error">
+                    <ErrorHint message={preferredPhoneTimesError} />
+                  </div>
+                )}
               </StyledVerticalStack>
             </StyledVerticalStack>
           )}


### PR DESCRIPTION
## Problem

The mail that asks a customer for a verification call links to `app.dfx.swiss/settings?a=call` and
tells them to pick a preferred time there. On that page the time dropdown was rendered only while
the consent dropdown above it said "Yes, call me":

```tsx
{acceptCall && (
  <StyledDropdownMultiChoice<PhoneCallTime> name="preferredPhoneTimes" … />
)}
```

`acceptCall` is only pre-filled from `user.kyc.phoneCallAccepted`, and that is `null` for everyone
who has never been called. So the customers the mail addresses arrive at the section it points them
to, see a single dropdown reading `Select...`, and have no way to pick a time.

More than ten support tickets in the last seven days say exactly that: *"I cannot select an
appointment."*

Measured in the browser against the Dev API with a freshly created account, before the change: the
"Verification Call" heading and the consent dropdown are visible, the label "Preferred call time"
is not.

## Change

Render the time dropdown unconditionally.

Both fields keep saving themselves independently through their own effect, exactly as before — the
consent dropdown sends `acceptCall`, the time dropdown sends `preferredPhoneTimes`. Nothing is
coupled.

A save that fails now shows the reason via `ErrorHint` instead of disappearing as an unhandled
rejection, and the dropdown returns to its saved value so the next choice is a real change again —
otherwise picking the same option twice produced no second request and the customer was stuck with
an error and no way to retry. Each field owns its error state and renders it under itself: with a
single shared state, a failed consent save followed by a successful time save would silently wipe
the message. The context functions in `@dfx.swiss/react` stay untouched: not catching there is the
convention across all of them, the caller is responsible — `transaction.screen.tsx` and
`tfa.screen.tsx` use the same `.catch((error: ApiError) => …)` one-liner.

The time dropdown is the field this change makes reachable for customers without consent; the
consent dropdown was always rendered, so its error path existed before. Both are handled here
because they are the same two lines in the same block.

## Verification

- New unit tests, 11 cases: the reported failure mode (time dropdown visible without prior consent),
  a time selection sends only `preferredPhoneTimes`, "No, don't call me" still sends `acceptCall`
  alone, each field surfaces its own save error under its own field, a failed save returns the
  dropdown to the server value, the same choice afterwards sends another request, and an error
  clears when the next save on that field starts.
- Five mutations, each on a different axis, all caught: restoring `{acceptCall && …}` → 6 of 11 red;
  removing the rollback in the consent `catch` → 3 of 11; removing the error resets → 2 of 11;
  rolling back to the rejected value instead of the saved one → 3 of 11; making the time effect
  write into the neighbouring field's error state → 1 of 11.
- Repo gate as the PR workflow runs it (`lint`, `test`, `build:dev`, `widget:dev`): lint clean,
  71 suites / 789 tests passing.
- `e2e/settings-call-time.spec.ts` covers the same visibility check in a real browser against the
  Dev API. Per CONTRIBUTING these specs are a local review aid and do not run in CI.

## Deliberately not in this PR

- The block is still hidden entirely when `phoneCallStatus` is `Completed` or `Failed`. That is
  existing, intended behaviour.
- No implicit consent: picking a time does not set `phoneCallAccepted`. It does not need to —
  `phoneCallAccepted` is only evaluated when `phoneCallStatus === UserRejected`, and customers are
  called from the AML reason of their transaction. Their chosen time is visible to the caller in the
  user detail panel.
- The section still renders when the user object failed to load, where saving is a silent no-op.
  That is pre-existing and unrelated to the visibility bug.
- Pre-existing and better fixed in the API: after a save that carries only `acceptCall`, the
  response comes back with `preferredPhoneTimes: []` even when times are stored, because
  `setUserDataSettings` assigns `undefined` onto the entity and the client adopts that response
  without refetching. Clearing all times right after such a save therefore sends no request. This
  was reachable before as well; it is not introduced here.
- The visual baseline for this screen dates from 2026-01-06 and predates the whole verification call
  section (added 2026-03-12, #989). Regenerating it would pull four months of unrelated drift into
  this diff, which CONTRIBUTING explicitly warns against.
