### PR TITLE
a1e7909f - Separate the action POST from the detail refresh in the compliance stop/resume flow

### DIFF
--- a/src/__tests__/compliance-transaction-action-refresh.test.tsx
+++ b/src/__tests__/compliance-transaction-action-refresh.test.tsx
@@ -1,0 +1,204 @@
+// Wiring test: stop/resume keep the action result when only the detail refresh fails.
+
+const mockGetTransactionByUid = jest.fn();
+const mockStopTransaction = jest.fn();
+const mockResumeTransaction = jest.fn();
+
+jest.mock('@dfx.swiss/react', () => ({
+  TransactionState: {
+    FAILED: 'Failed',
+    CHECK_PENDING: 'CheckPending',
+    KYC_REQUIRED: 'KycRequired',
+    LIMIT_EXCEEDED: 'LimitExceeded',
+    UNASSIGNED: 'Unassigned',
+    COMPLETED: 'Completed',
+  },
+  useTransaction: () => ({
+    getTransactionByUid: mockGetTransactionByUid,
+  }),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  StyledButton: ({ label, onClick, disabled, isLoading }: any) => (
+    <button type="button" onClick={onClick} disabled={disabled || isLoading}>
+      {label}
+    </button>
+  ),
+  StyledLoadingSpinner: () => <div>Loading</div>,
+  SpinnerSize: { SM: 'sm' },
+  StyledButtonWidth: { FULL: 'full' },
+  StyledButtonColor: { STURDY_WHITE: 'white', BLUE: 'blue', RED: 'red' },
+}));
+
+jest.mock('src/hooks/compliance.hook', () => ({
+  useCompliance: () => ({
+    downloadTransactionPdf: jest.fn(),
+    stopTransaction: mockStopTransaction,
+    resumeTransaction: mockResumeTransaction,
+  }),
+}));
+
+jest.mock('src/util/compliance-helpers', () => ({
+  statusBadge: (v: unknown) => v,
+  boolBadge: (v: unknown) => String(v),
+  formatDate: (v: unknown) => String(v ?? ''),
+  DetailRow: () => null,
+  TransactionDetailRows: () => null,
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_key: string, value: string) => value,
+  }),
+}));
+
+jest.mock('src/contexts/layout.context', () => ({
+  useLayoutContext: () => ({
+    rootRef: { current: document.body },
+    modalRootRef: { current: null },
+  }),
+}));
+
+jest.mock('src/components/compliance/chargeback-modal', () => ({
+  ChargebackModal: () => null,
+}));
+
+jest.mock('src/components/compliance/recall-modal', () => ({
+  RecallModal: () => null,
+}));
+
+jest.mock('src/components/compliance/recall-details-modal', () => ({
+  RecallDetailsModal: () => null,
+}));
+
+import type { Transaction } from '@dfx.swiss/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { TransactionsTable } from 'src/components/compliance/transactions-tab';
+import type { TransactionInfo } from 'src/hooks/compliance.hook';
+
+const tx = {
+  id: 130504,
+  uid: 'T2AC46F80RESUME01',
+  type: 'BuyCrypto',
+  sourceType: 'Bank',
+  isCompleted: false,
+  created: '2026-08-01T10:00:00Z',
+} as unknown as TransactionInfo;
+
+function renderTable(onStatusChanged?: () => void) {
+  function Wrapper() {
+    const [expandedTxUid, setExpandedTxUid] = useState<string | undefined>();
+    return (
+      <TransactionsTable
+        transactions={[tx]}
+        bankTxs={[]}
+        cryptoInputs={[]}
+        bankDatas={[]}
+        userData={{ id: 1 } as any}
+        userDataId={1}
+        onExpandBankTx={jest.fn()}
+        onExpandCryptoInput={jest.fn()}
+        onExpandBankData={jest.fn()}
+        onExpandTxUid={setExpandedTxUid}
+        expandedTxUid={expandedTxUid}
+        onStatusChanged={onStatusChanged}
+      />
+    );
+  }
+
+  return render(<Wrapper />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetTransactionByUid.mockResolvedValue({
+    uid: tx.uid,
+    state: 'Stopped',
+  } as unknown as Transaction);
+  mockStopTransaction.mockReset();
+  mockResumeTransaction.mockReset();
+});
+
+describe('TransactionsTable stop/resume refresh handling', () => {
+  it('keeps the resume result when only the detail refresh fails', async () => {
+    const onStatusChanged = jest.fn();
+    mockResumeTransaction.mockResolvedValue(undefined);
+    mockGetTransactionByUid
+      .mockResolvedValueOnce({
+        uid: tx.uid,
+        state: 'Stopped',
+      } as unknown as Transaction)
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    renderTable(onStatusChanged);
+
+    await userEvent.click(screen.getByText(tx.uid));
+    await userEvent.click(await screen.findByRole('button', { name: 'Resume' }));
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+    const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    await userEvent.click(resumeButtons[resumeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockResumeTransaction).toHaveBeenCalledTimes(1);
+      expect(onStatusChanged).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText('Resume failed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Transaktion fortsetzen')).not.toBeInTheDocument();
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
+  });
+
+  it('reports a failed resume and keeps the dialog open', async () => {
+    const onStatusChanged = jest.fn();
+    mockResumeTransaction.mockRejectedValue(new Error('Transaction is not stopped'));
+
+    renderTable(onStatusChanged);
+
+    await userEvent.click(screen.getByText(tx.uid));
+    await userEvent.click(await screen.findByRole('button', { name: 'Resume' }));
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+    const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    await userEvent.click(resumeButtons[resumeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Transaction is not stopped')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    expect(onStatusChanged).not.toHaveBeenCalled();
+    expect(mockGetTransactionByUid).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the stop result when only the detail refresh fails', async () => {
+    const onStatusChanged = jest.fn();
+    mockStopTransaction.mockResolvedValue(undefined);
+    mockGetTransactionByUid
+      .mockResolvedValueOnce({
+        uid: tx.uid,
+        state: 'Created',
+      } as unknown as Transaction)
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    renderTable(onStatusChanged);
+
+    await userEvent.click(screen.getByText(tx.uid));
+    await userEvent.click(await screen.findByRole('button', { name: 'Stop' }));
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion stoppen')).toBeInTheDocument();
+    });
+    const stopButtons = screen.getAllByRole('button', { name: 'Stop' });
+    await userEvent.click(stopButtons[stopButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(mockStopTransaction).toHaveBeenCalledTimes(1);
+      expect(onStatusChanged).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText('Stop failed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Transaktion stoppen')).not.toBeInTheDocument();
+    expect(await screen.findByText('Network error')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/compliance-transaction-action-refresh.test.tsx
+++ b/src/__tests__/compliance-transaction-action-refresh.test.tsx
@@ -3,6 +3,7 @@
 const mockGetTransactionByUid = jest.fn();
 const mockStopTransaction = jest.fn();
 const mockResumeTransaction = jest.fn();
+const mockRootRef: { current: HTMLElement | null } = { current: null };
 
 jest.mock('@dfx.swiss/react', () => ({
   TransactionState: {
@@ -41,7 +42,7 @@ jest.mock('src/hooks/compliance.hook', () => ({
 jest.mock('src/util/compliance-helpers', () => ({
   statusBadge: (v: unknown) => v,
   boolBadge: (v: unknown) => String(v),
-  formatDate: (v: unknown) => String(v ?? ''),
+  formatDate: (v: string) => v,
   DetailRow: () => null,
   TransactionDetailRows: () => null,
 }));
@@ -54,7 +55,7 @@ jest.mock('src/contexts/settings.context', () => ({
 
 jest.mock('src/contexts/layout.context', () => ({
   useLayoutContext: () => ({
-    rootRef: { current: document.body },
+    rootRef: mockRootRef,
     modalRootRef: { current: null },
   }),
 }));
@@ -72,7 +73,7 @@ jest.mock('src/components/compliance/recall-details-modal', () => ({
 }));
 
 import type { Transaction } from '@dfx.swiss/react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { TransactionsTable } from 'src/components/compliance/transactions-tab';
@@ -87,12 +88,43 @@ const tx = {
   created: '2026-08-01T10:00:00Z',
 } as unknown as TransactionInfo;
 
-function renderTable(onStatusChanged?: () => void) {
+const otherTx = {
+  id: 130505,
+  uid: 'T2AC46F80RESUME02',
+  type: 'BuyCrypto',
+  sourceType: 'Bank',
+  isCompleted: false,
+  created: '2026-08-01T11:00:00Z',
+} as unknown as TransactionInfo;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: Error) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  const controls = {
+    resolve: (_value: T) => {
+      throw new Error('deferred not initialized');
+    },
+    reject: (_reason: Error) => {
+      throw new Error('deferred not initialized');
+    },
+  };
+  const promise = new Promise<T>((resolve, reject) => {
+    controls.resolve = resolve;
+    controls.reject = reject;
+  });
+  return { promise, resolve: controls.resolve, reject: controls.reject };
+}
+
+function renderTable(onStatusChanged?: () => void, rows: TransactionInfo[] = [tx]) {
   function Wrapper() {
     const [expandedTxUid, setExpandedTxUid] = useState<string | undefined>();
     return (
       <TransactionsTable
-        transactions={[tx]}
+        transactions={rows}
         bankTxs={[]}
         cryptoInputs={[]}
         bankDatas={[]}
@@ -111,7 +143,14 @@ function renderTable(onStatusChanged?: () => void) {
   return render(<Wrapper />);
 }
 
+async function click(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    userEvent.click(element);
+  });
+}
+
 beforeEach(() => {
+  mockRootRef.current = document.body;
   jest.clearAllMocks();
   mockGetTransactionByUid.mockResolvedValue({
     uid: tx.uid,
@@ -124,31 +163,40 @@ beforeEach(() => {
 describe('TransactionsTable stop/resume refresh handling', () => {
   it('keeps the resume result when only the detail refresh fails', async () => {
     const onStatusChanged = jest.fn();
+    const refresh = createDeferred<Transaction>();
     mockResumeTransaction.mockResolvedValue(undefined);
     mockGetTransactionByUid
-      .mockResolvedValueOnce({
-        uid: tx.uid,
-        state: 'Stopped',
-      } as unknown as Transaction)
-      .mockRejectedValueOnce(new Error('Network error'));
+      .mockResolvedValueOnce({ uid: tx.uid, state: 'Stopped' } as unknown as Transaction)
+      .mockReturnValueOnce(refresh.promise);
 
     renderTable(onStatusChanged);
 
-    await userEvent.click(screen.getByText(tx.uid));
-    await userEvent.click(await screen.findByRole('button', { name: 'Resume' }));
+    await click(screen.getByText(tx.uid));
+    const resumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(resumeAction);
     await waitFor(() => {
       expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
     });
     const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
-    await userEvent.click(resumeButtons[resumeButtons.length - 1]);
+    await click(resumeButtons[resumeButtons.length - 1]);
 
     await waitFor(() => {
       expect(mockResumeTransaction).toHaveBeenCalledTimes(1);
       expect(onStatusChanged).toHaveBeenCalledTimes(1);
     });
-    expect(screen.queryByText('Resume failed')).not.toBeInTheDocument();
     expect(screen.queryByText('Transaktion fortsetzen')).not.toBeInTheDocument();
-    expect(await screen.findByText('Network error')).toBeInTheDocument();
+    expect(screen.queryByText('Resume failed')).not.toBeInTheDocument();
+    expect(mockGetTransactionByUid).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      refresh.reject(new Error('Network error'));
+      await refresh.promise.catch(() => undefined);
+    });
+
+    const refreshError = await screen.findByText('Network error');
+    expect(refreshError).toBeInTheDocument();
+    expect(refreshError.closest('td')).not.toBeNull();
+    expect(screen.queryByText('Resume failed')).not.toBeInTheDocument();
   });
 
   it('reports a failed resume and keeps the dialog open', async () => {
@@ -157,13 +205,14 @@ describe('TransactionsTable stop/resume refresh handling', () => {
 
     renderTable(onStatusChanged);
 
-    await userEvent.click(screen.getByText(tx.uid));
-    await userEvent.click(await screen.findByRole('button', { name: 'Resume' }));
+    await click(screen.getByText(tx.uid));
+    const resumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(resumeAction);
     await waitFor(() => {
       expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
     });
     const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
-    await userEvent.click(resumeButtons[resumeButtons.length - 1]);
+    await click(resumeButtons[resumeButtons.length - 1]);
 
     await waitFor(() => {
       expect(screen.getByText('Transaction is not stopped')).toBeInTheDocument();
@@ -175,30 +224,85 @@ describe('TransactionsTable stop/resume refresh handling', () => {
 
   it('keeps the stop result when only the detail refresh fails', async () => {
     const onStatusChanged = jest.fn();
+    const refresh = createDeferred<Transaction>();
     mockStopTransaction.mockResolvedValue(undefined);
     mockGetTransactionByUid
-      .mockResolvedValueOnce({
-        uid: tx.uid,
-        state: 'Created',
-      } as unknown as Transaction)
-      .mockRejectedValueOnce(new Error('Network error'));
+      .mockResolvedValueOnce({ uid: tx.uid, state: 'Created' } as unknown as Transaction)
+      .mockReturnValueOnce(refresh.promise);
 
     renderTable(onStatusChanged);
 
-    await userEvent.click(screen.getByText(tx.uid));
-    await userEvent.click(await screen.findByRole('button', { name: 'Stop' }));
+    await click(screen.getByText(tx.uid));
+    const stopAction = await screen.findByRole('button', { name: 'Stop' });
+    await click(stopAction);
     await waitFor(() => {
       expect(screen.getByText('Transaktion stoppen')).toBeInTheDocument();
     });
     const stopButtons = screen.getAllByRole('button', { name: 'Stop' });
-    await userEvent.click(stopButtons[stopButtons.length - 1]);
+    await click(stopButtons[stopButtons.length - 1]);
 
     await waitFor(() => {
       expect(mockStopTransaction).toHaveBeenCalledTimes(1);
       expect(onStatusChanged).toHaveBeenCalledTimes(1);
     });
-    expect(screen.queryByText('Stop failed')).not.toBeInTheDocument();
     expect(screen.queryByText('Transaktion stoppen')).not.toBeInTheDocument();
-    expect(await screen.findByText('Network error')).toBeInTheDocument();
+    expect(screen.queryByText('Stop failed')).not.toBeInTheDocument();
+    expect(mockGetTransactionByUid).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      refresh.reject(new Error('Network error'));
+      await refresh.promise.catch(() => undefined);
+    });
+
+    const refreshError = await screen.findByText('Network error');
+    expect(refreshError).toBeInTheDocument();
+    expect(refreshError.closest('td')).not.toBeNull();
+    expect(screen.queryByText('Stop failed')).not.toBeInTheDocument();
+  });
+
+  it('does not leak the loading state into a dialog for another transaction', async () => {
+    const onStatusChanged = jest.fn();
+    const refresh = createDeferred<Transaction>();
+    mockResumeTransaction.mockResolvedValue(undefined);
+    mockGetTransactionByUid
+      .mockResolvedValueOnce({ uid: tx.uid, state: 'Stopped' } as unknown as Transaction)
+      .mockReturnValueOnce(refresh.promise)
+      .mockResolvedValueOnce({ uid: otherTx.uid, state: 'Stopped' } as unknown as Transaction);
+
+    renderTable(onStatusChanged, [tx, otherTx]);
+
+    await click(screen.getByText(tx.uid));
+    const resumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(resumeAction);
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+    const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    await click(resumeButtons[resumeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Transaktion fortsetzen')).not.toBeInTheDocument();
+    });
+
+    await click(screen.getByText(otherTx.uid));
+    const otherResumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(otherResumeAction);
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+
+    const dialogResumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    expect(dialogResumeButtons[dialogResumeButtons.length - 1]).toBeEnabled();
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Transaktion fortsetzen')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      refresh.resolve({ uid: tx.uid, state: 'Created' } as unknown as Transaction);
+    });
   });
 });

--- a/src/__tests__/compliance-transaction-action-refresh.test.tsx
+++ b/src/__tests__/compliance-transaction-action-refresh.test.tsx
@@ -305,4 +305,94 @@ describe('TransactionsTable stop/resume refresh handling', () => {
       refresh.resolve({ uid: tx.uid, state: 'Created' } as unknown as Transaction);
     });
   });
+
+  it('keeps the loading state of a second action when the first refresh settles', async () => {
+    const onStatusChanged = jest.fn();
+    const refreshA = createDeferred<Transaction>();
+    const postB = createDeferred<void>();
+    mockResumeTransaction.mockResolvedValueOnce(undefined).mockReturnValueOnce(postB.promise);
+    mockGetTransactionByUid
+      .mockResolvedValueOnce({ uid: tx.uid, state: 'Stopped' } as unknown as Transaction)
+      .mockReturnValueOnce(refreshA.promise)
+      .mockResolvedValueOnce({ uid: otherTx.uid, state: 'Stopped' } as unknown as Transaction);
+
+    renderTable(onStatusChanged, [tx, otherTx]);
+
+    await click(screen.getByText(tx.uid));
+    const resumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(resumeAction);
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+    const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    await click(resumeButtons[resumeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Transaktion fortsetzen')).not.toBeInTheDocument();
+    });
+
+    await click(screen.getByText(otherTx.uid));
+    const otherResumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(otherResumeAction);
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+
+    const dialogResumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    await click(dialogResumeButtons[dialogResumeButtons.length - 1]);
+
+    await waitFor(() => {
+      const buttons = screen.getAllByRole('button', { name: 'Resume' });
+      expect(buttons[buttons.length - 1]).toBeDisabled();
+    });
+
+    await act(async () => {
+      refreshA.resolve({ uid: tx.uid, state: 'Created' } as unknown as Transaction);
+    });
+
+    const buttonsAfterRefreshA = screen.getAllByRole('button', { name: 'Resume' });
+    expect(buttonsAfterRefreshA[buttonsAfterRefreshA.length - 1]).toBeDisabled();
+    expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+
+    await act(async () => {
+      postB.resolve(undefined);
+    });
+  });
+
+  it('keeps a detail error of another transaction when a refresh succeeds', async () => {
+    const onStatusChanged = jest.fn();
+    const refreshA = createDeferred<Transaction>();
+    mockResumeTransaction.mockResolvedValue(undefined);
+    mockGetTransactionByUid
+      .mockResolvedValueOnce({ uid: tx.uid, state: 'Stopped' } as unknown as Transaction)
+      .mockReturnValueOnce(refreshA.promise)
+      .mockRejectedValueOnce(new Error('Detail load failed'));
+
+    renderTable(onStatusChanged, [tx, otherTx]);
+
+    await click(screen.getByText(tx.uid));
+    const resumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(resumeAction);
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+    const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    await click(resumeButtons[resumeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Transaktion fortsetzen')).not.toBeInTheDocument();
+    });
+
+    await click(screen.getByText(otherTx.uid));
+    const detailError = await screen.findByText('Detail load failed');
+    expect(detailError).toBeInTheDocument();
+
+    await act(async () => {
+      refreshA.resolve({ uid: tx.uid, state: 'Created' } as unknown as Transaction);
+    });
+
+    const detailErrorAfterRefreshA = screen.getByText('Detail load failed');
+    expect(detailErrorAfterRefreshA).toBeInTheDocument();
+    expect(detailErrorAfterRefreshA.closest('td')).not.toBeNull();
+  });
 });

--- a/src/__tests__/compliance-transaction-action-refresh.test.tsx
+++ b/src/__tests__/compliance-transaction-action-refresh.test.tsx
@@ -395,4 +395,43 @@ describe('TransactionsTable stop/resume refresh handling', () => {
     expect(detailErrorAfterRefreshA).toBeInTheDocument();
     expect(detailErrorAfterRefreshA.closest('td')).not.toBeNull();
   });
+
+  it('keeps a detail error of another transaction when a refresh fails', async () => {
+    const onStatusChanged = jest.fn();
+    const refreshA = createDeferred<Transaction>();
+    mockResumeTransaction.mockResolvedValue(undefined);
+    mockGetTransactionByUid
+      .mockResolvedValueOnce({ uid: tx.uid, state: 'Stopped' } as unknown as Transaction)
+      .mockReturnValueOnce(refreshA.promise)
+      .mockRejectedValueOnce(new Error('Detail load failed'));
+
+    renderTable(onStatusChanged, [tx, otherTx]);
+
+    await click(screen.getByText(tx.uid));
+    const resumeAction = await screen.findByRole('button', { name: 'Resume' });
+    await click(resumeAction);
+    await waitFor(() => {
+      expect(screen.getByText('Transaktion fortsetzen')).toBeInTheDocument();
+    });
+    const resumeButtons = screen.getAllByRole('button', { name: 'Resume' });
+    await click(resumeButtons[resumeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Transaktion fortsetzen')).not.toBeInTheDocument();
+    });
+
+    await click(screen.getByText(otherTx.uid));
+    const detailError = await screen.findByText('Detail load failed');
+    expect(detailError).toBeInTheDocument();
+
+    await act(async () => {
+      refreshA.reject(new Error('Refresh failed'));
+      await refreshA.promise.catch(() => undefined);
+    });
+
+    const detailErrorAfterRefreshA = screen.getByText('Detail load failed');
+    expect(detailErrorAfterRefreshA).toBeInTheDocument();
+    expect(detailErrorAfterRefreshA.closest('td')).not.toBeNull();
+    expect(screen.queryByText('Refresh failed')).not.toBeInTheDocument();
+  });
 });

--- a/src/__tests__/confirm-dialog-loading.test.tsx
+++ b/src/__tests__/confirm-dialog-loading.test.tsx
@@ -1,0 +1,88 @@
+// Direct test: ConfirmDialog blocks Escape/backdrop while isLoading is true.
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  StyledButton: ({ label, onClick, disabled, isLoading }: any) => (
+    <button type="button" onClick={onClick} disabled={disabled || isLoading}>
+      {label}
+    </button>
+  ),
+  StyledButtonWidth: { FULL: 'full' },
+  StyledButtonColor: { STURDY_WHITE: 'white', BLUE: 'blue', RED: 'red' },
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({
+    translate: (_key: string, value: string) => value,
+  }),
+}));
+
+jest.mock('src/contexts/layout.context', () => ({
+  useLayoutContext: () => ({
+    rootRef: { current: document.body },
+    modalRootRef: { current: null },
+  }),
+}));
+
+import { fireEvent, render } from '@testing-library/react';
+import { ConfirmDialog } from 'src/components/confirm-dialog';
+
+const mockOnCancel = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ConfirmDialog loading close handling', () => {
+  it('ignores escape while a request is running', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test title"
+        message="Test message"
+        isLoading={true}
+        onConfirm={jest.fn()}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(mockOnCancel).not.toHaveBeenCalled();
+  });
+
+  it('ignores a backdrop click while a request is running', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test title"
+        message="Test message"
+        isLoading={true}
+        onConfirm={jest.fn()}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    const backdrop = document.querySelector('.fixed.inset-0') as HTMLElement;
+    fireEvent.click(backdrop);
+
+    expect(mockOnCancel).not.toHaveBeenCalled();
+  });
+
+  it('closes on escape and backdrop click when idle', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test title"
+        message="Test message"
+        onConfirm={jest.fn()}
+        onCancel={mockOnCancel}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    const backdrop = document.querySelector('.fixed.inset-0') as HTMLElement;
+    fireEvent.click(backdrop);
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/__tests__/confirm-dialog-loading.test.tsx
+++ b/src/__tests__/confirm-dialog-loading.test.tsx
@@ -1,5 +1,7 @@
 // Direct test: ConfirmDialog blocks Escape/backdrop while isLoading is true.
 
+const mockRootRef: { current: HTMLElement | null } = { current: null };
+
 jest.mock('@dfx.swiss/react-components', () => ({
   StyledButton: ({ label, onClick, disabled, isLoading }: any) => (
     <button type="button" onClick={onClick} disabled={disabled || isLoading}>
@@ -18,7 +20,7 @@ jest.mock('src/contexts/settings.context', () => ({
 
 jest.mock('src/contexts/layout.context', () => ({
   useLayoutContext: () => ({
-    rootRef: { current: document.body },
+    rootRef: mockRootRef,
     modalRootRef: { current: null },
   }),
 }));
@@ -29,6 +31,7 @@ import { ConfirmDialog } from 'src/components/confirm-dialog';
 const mockOnCancel = jest.fn();
 
 beforeEach(() => {
+  mockRootRef.current = document.body;
   jest.clearAllMocks();
 });
 

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -58,7 +58,7 @@ export function TransactionsTable({
   const { downloadTransactionPdf, stopTransaction, resumeTransaction } = useCompliance();
   const [txDetailCache, setTxDetailCache] = useState<Map<string, Transaction>>(new Map());
   const [txDetailLoading, setTxDetailLoading] = useState<string>();
-  const [txDetailError, setTxDetailError] = useState<{ uid: string; message: string }>();
+  const [txDetailErrors, setTxDetailErrors] = useState<Map<string, string>>(new Map());
   const [isPdfDownloading, setIsPdfDownloading] = useState(false);
   const [pdfError, setPdfError] = useState<string>();
   const [stoppingTxId, setStoppingTxId] = useState<number>();
@@ -71,18 +71,30 @@ export function TransactionsTable({
   const [recallBankTxId, setRecallBankTxId] = useState<number>();
   const [viewingRecall, setViewingRecall] = useState<RecallInfo>();
 
+  function setTxDetailError(uid: string, message: string): void {
+    setTxDetailErrors((prev) => new Map(prev).set(uid, message));
+  }
+
+  function clearTxDetailError(uid: string): void {
+    setTxDetailErrors((prev) => {
+      const next = new Map(prev);
+      next.delete(uid);
+      return next;
+    });
+  }
+
   async function refreshTxDetail(uid: string): Promise<void> {
     try {
       const updatedDetail = await getTransactionByUid(uid);
       setTxDetailCache((prev) => new Map(prev).set(uid, updatedDetail));
-      setTxDetailError((current) => (current?.uid === uid ? undefined : current));
+      clearTxDetailError(uid);
     } catch (e) {
       setTxDetailCache((prev) => {
         const next = new Map(prev);
         next.delete(uid);
         return next;
       });
-      setTxDetailError({ uid, message: e instanceof Error ? e.message : 'Failed to refresh transaction details' });
+      setTxDetailError(uid, e instanceof Error ? e.message : 'Failed to refresh transaction details');
     }
   }
 
@@ -176,7 +188,7 @@ export function TransactionsTable({
     }
 
     onExpandTxUid(uid);
-    setTxDetailError(undefined);
+    clearTxDetailError(uid);
 
     if (txDetailCache.has(uid)) return;
 
@@ -186,7 +198,7 @@ export function TransactionsTable({
         setTxDetailCache((prev) => new Map(prev).set(uid, detail));
       })
       .catch((e: unknown) => {
-        setTxDetailError({ uid, message: e instanceof Error ? e.message : 'Failed to load transaction details' });
+        setTxDetailError(uid, e instanceof Error ? e.message : 'Failed to load transaction details');
       })
       .finally(() => setTxDetailLoading(undefined));
   }
@@ -247,6 +259,7 @@ export function TransactionsTable({
               const isBankTxExpanded = expandedBankTxId === bankTx?.id;
               const isCryptoExpanded = expandedCryptoInputId === cryptoInput?.id;
               const isBankDataExpanded = expandedBankDataId === bankData?.id;
+              const detailError = txDetailErrors.get(tx.uid);
 
               return (
                 <Fragment key={tx.id}>
@@ -429,8 +442,8 @@ export function TransactionsTable({
                       <td colSpan={15} className="px-6 py-3">
                         {txDetailLoading === tx.uid ? (
                           <StyledLoadingSpinner size={SpinnerSize.SM} />
-                        ) : txDetailError?.uid === tx.uid && !txDetailCache.has(tx.uid) ? (
-                          <p className="text-primary-red text-sm">{txDetailError.message}</p>
+                        ) : detailError != null && !txDetailCache.has(tx.uid) ? (
+                          <p className="text-primary-red text-sm">{detailError}</p>
                         ) : txDetailCache.has(tx.uid) ? (
                           (() => {
                             const detail = txDetailCache.get(tx.uid) as Transaction;

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -71,6 +71,21 @@ export function TransactionsTable({
   const [recallBankTxId, setRecallBankTxId] = useState<number>();
   const [viewingRecall, setViewingRecall] = useState<RecallInfo>();
 
+  async function refreshTxDetail(uid: string): Promise<void> {
+    try {
+      const updatedDetail = await getTransactionByUid(uid);
+      setTxDetailCache((prev) => new Map(prev).set(uid, updatedDetail));
+      setTxDetailError(undefined);
+    } catch (e) {
+      setTxDetailCache((prev) => {
+        const next = new Map(prev);
+        next.delete(uid);
+        return next;
+      });
+      setTxDetailError(e instanceof Error ? e.message : 'Failed to refresh transaction details');
+    }
+  }
+
   async function confirmStop(): Promise<void> {
     const txId = stopConfirmTxId;
     if (!txId) return;
@@ -78,15 +93,16 @@ export function TransactionsTable({
     setStoppingTxId(txId);
     setStopError(undefined);
     try {
-      await stopTransaction(txId);
-      if (tx) {
-        const updatedDetail = await getTransactionByUid(tx.uid);
-        setTxDetailCache((prev) => new Map(prev).set(tx.uid, updatedDetail));
+      try {
+        await stopTransaction(txId);
+      } catch (e) {
+        setStopError(e instanceof Error ? e.message : 'Stop failed');
+        return;
       }
-      onStatusChanged?.();
+
       setStopConfirmTxId(undefined);
-    } catch (e) {
-      setStopError(e instanceof Error ? e.message : 'Stop failed');
+      onStatusChanged?.();
+      if (tx) await refreshTxDetail(tx.uid);
     } finally {
       setStoppingTxId(undefined);
     }
@@ -99,15 +115,16 @@ export function TransactionsTable({
     setResumingTxId(txId);
     setResumeError(undefined);
     try {
-      await resumeTransaction(txId);
-      if (tx) {
-        const updatedDetail = await getTransactionByUid(tx.uid);
-        setTxDetailCache((prev) => new Map(prev).set(tx.uid, updatedDetail));
+      try {
+        await resumeTransaction(txId);
+      } catch (e) {
+        setResumeError(e instanceof Error ? e.message : 'Resume failed');
+        return;
       }
-      onStatusChanged?.();
+
       setResumeConfirmTxId(undefined);
-    } catch (e) {
-      setResumeError(e instanceof Error ? e.message : 'Resume failed');
+      onStatusChanged?.();
+      if (tx) await refreshTxDetail(tx.uid);
     } finally {
       setResumingTxId(undefined);
     }
@@ -560,7 +577,7 @@ export function TransactionsTable({
         message="Möchtest du diese Transaktion wirklich stoppen? Nach dem Stopp muss sie manuell weiterbearbeitet werden."
         confirmLabel="Stop"
         destructive
-        isLoading={stoppingTxId != null}
+        isLoading={stoppingTxId != null && stoppingTxId === stopConfirmTxId}
         onConfirm={confirmStop}
         onCancel={() => setStopConfirmTxId(undefined)}
       />
@@ -569,7 +586,7 @@ export function TransactionsTable({
         title="Transaktion fortsetzen"
         message="Möchtest du diese Transaktion wirklich fortsetzen? Sie geht zurück in die automatische Verarbeitung."
         confirmLabel="Resume"
-        isLoading={resumingTxId != null}
+        isLoading={resumingTxId != null && resumingTxId === resumeConfirmTxId}
         onConfirm={confirmResume}
         onCancel={() => setResumeConfirmTxId(undefined)}
       />

--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -58,7 +58,7 @@ export function TransactionsTable({
   const { downloadTransactionPdf, stopTransaction, resumeTransaction } = useCompliance();
   const [txDetailCache, setTxDetailCache] = useState<Map<string, Transaction>>(new Map());
   const [txDetailLoading, setTxDetailLoading] = useState<string>();
-  const [txDetailError, setTxDetailError] = useState<string>();
+  const [txDetailError, setTxDetailError] = useState<{ uid: string; message: string }>();
   const [isPdfDownloading, setIsPdfDownloading] = useState(false);
   const [pdfError, setPdfError] = useState<string>();
   const [stoppingTxId, setStoppingTxId] = useState<number>();
@@ -75,14 +75,14 @@ export function TransactionsTable({
     try {
       const updatedDetail = await getTransactionByUid(uid);
       setTxDetailCache((prev) => new Map(prev).set(uid, updatedDetail));
-      setTxDetailError(undefined);
+      setTxDetailError((current) => (current?.uid === uid ? undefined : current));
     } catch (e) {
       setTxDetailCache((prev) => {
         const next = new Map(prev);
         next.delete(uid);
         return next;
       });
-      setTxDetailError(e instanceof Error ? e.message : 'Failed to refresh transaction details');
+      setTxDetailError({ uid, message: e instanceof Error ? e.message : 'Failed to refresh transaction details' });
     }
   }
 
@@ -104,7 +104,7 @@ export function TransactionsTable({
       onStatusChanged?.();
       if (tx) await refreshTxDetail(tx.uid);
     } finally {
-      setStoppingTxId(undefined);
+      setStoppingTxId((current) => (current === txId ? undefined : current));
     }
   }
 
@@ -126,7 +126,7 @@ export function TransactionsTable({
       onStatusChanged?.();
       if (tx) await refreshTxDetail(tx.uid);
     } finally {
-      setResumingTxId(undefined);
+      setResumingTxId((current) => (current === txId ? undefined : current));
     }
   }
 
@@ -186,7 +186,7 @@ export function TransactionsTable({
         setTxDetailCache((prev) => new Map(prev).set(uid, detail));
       })
       .catch((e: unknown) => {
-        setTxDetailError(e instanceof Error ? e.message : 'Failed to load transaction details');
+        setTxDetailError({ uid, message: e instanceof Error ? e.message : 'Failed to load transaction details' });
       })
       .finally(() => setTxDetailLoading(undefined));
   }
@@ -429,8 +429,8 @@ export function TransactionsTable({
                       <td colSpan={15} className="px-6 py-3">
                         {txDetailLoading === tx.uid ? (
                           <StyledLoadingSpinner size={SpinnerSize.SM} />
-                        ) : txDetailError && !txDetailCache.has(tx.uid) ? (
-                          <p className="text-primary-red text-sm">{txDetailError}</p>
+                        ) : txDetailError?.uid === tx.uid && !txDetailCache.has(tx.uid) ? (
+                          <p className="text-primary-red text-sm">{txDetailError.message}</p>
                         ) : txDetailCache.has(tx.uid) ? (
                           (() => {
                             const detail = txDetailCache.get(tx.uid) as Transaction;

--- a/src/components/confirm-dialog.tsx
+++ b/src/components/confirm-dialog.tsx
@@ -28,7 +28,7 @@ export function ConfirmDialog({
   const { translate } = useSettingsContext();
 
   return (
-    <Modal isOpen={isOpen} onClose={onCancel} variant="dialog">
+    <Modal isOpen={isOpen} onClose={isLoading ? undefined : onCancel} variant="dialog">
       <div className="bg-white rounded-lg shadow-xl p-6 max-w-md mx-auto w-full">
         {title && <h2 className="text-lg font-semibold text-dfxBlue-800 mb-3 text-left">{title}</h2>}
         <p className="text-sm text-dfxBlue-800 mb-6 text-left">{message}</p>


### PR DESCRIPTION
Closes #1256.

Two robustness gaps in the compliance transactions tab, both pre-existing in the stop flow and mirrored by the resume flow added in #1254.

## 1. A failing detail refresh no longer reports the action as failed

`confirmStop` / `confirmResume` ran the action POST and the follow-up `getTransactionByUid` refresh in one `try`. When only the refresh failed after a successful POST, the UI showed *Stop failed* / *Resume failed*, kept the dialog open, skipped `onStatusChanged` and left the stale cache entry in place — so the action was offered again although it had already succeeded server-side.

The POST now has its own `try/catch` and returns early on failure. On success the dialog closes and `onStatusChanged` fires immediately; the refresh runs afterwards through a new `refreshTxDetail` helper that, on failure, drops the cached detail and reports its own error instead of masking it as an action failure.

## 2. Escape and backdrop clicks are blocked while a request is running

`ConfirmDialog` passed `onCancel` straight through as the `Modal` `onClose`, and `Modal` invokes it on Escape and backdrop click without looking at `isLoading` — only the Cancel button was disabled. The dialog could therefore be dismissed mid-request and another one opened, leaking the shared `stoppingTxId` / `resumingTxId` loading state into the wrong dialog instance.

`ConfirmDialog` now forwards `onClose` only when it is not loading, and each dialog's `isLoading` is bound to the transaction it was opened for.

## 3. Two shared states that this made reachable

Because an action for a second transaction can now legitimately be started while the first one is still refreshing, two states shared across transactions needed the same scoping:

- **Loading state.** `stoppingTxId` / `resumingTxId` hold a single id, so the `finally` of the first action reset it while the POST of the second was still in flight and released that dialog early. Each action now clears the state only if it is still its own.
- **Detail error.** `txDetailError` was a single slot shared with `handleUidClick`, so a refresh settling late wiped or replaced the error of a transaction the user had opened in the meantime, leaving its detail row blank. Detail errors are now kept in a `Map` keyed by uid — mirroring the detail cache next to it — and every path only touches the entry of the transaction it belongs to.

## Tests

`src/__tests__/compliance-transaction-action-refresh.test.tsx`:
- a refresh that fails after a successful resume/stop keeps the result — no action error, dialog closed, `onStatusChanged` fired — and the refresh error is asserted to render inside the transaction detail row rather than in the action error field;
- the refresh is driven by a controlled promise, so the assertions run while it is still pending and therefore prove the ordering, not just the end state;
- a failing POST still reports the error and keeps the dialog open;
- with two transactions: the dialog for the second one is neither disabled nor locked shut while the refresh for the first is running; it keeps its own loading state when that refresh settles; and a detail error belonging to it survives both a succeeding and a failing refresh of the first.

`src/__tests__/confirm-dialog-loading.test.tsx`: Escape and backdrop click are ignored while loading and still close the dialog when idle.

Both suites were checked against deliberate mutations of the production code — loading state unscoped, `onClose` passed through unguarded, stale cache kept, dialog closed only after the refresh, refresh error routed into the action error field, `finally` clearing a foreign loading state, and the detail error cleared or overwritten across transactions — and each one is caught by the tests that cover it.