### PR TITLE
feat(handbook): add static handbook served at handbook.app.dfx.swiss

### DIFF
--- a/.github/workflows/handbook-check.yaml
+++ b/.github/workflows/handbook-check.yaml
@@ -11,6 +11,7 @@ on:
       - 'scripts/handbook/**'
       - 'tailwind.config.js'
       - 'src/static/assets/**'
+      - 'public/logo.png'
       - 'docs/**'
       - 'README.md'
       - 'CONTRIBUTING.md'

--- a/.github/workflows/handbook-check.yaml
+++ b/.github/workflows/handbook-check.yaml
@@ -117,7 +117,10 @@ jobs:
             .filter((p) => p && p !== 'index.html');
           // Always include index.html as a gated page sample
           paths.unshift('index.html');
-          fs.writeFileSync('/tmp/handbook-sample-paths.txt', paths.join('\n') + '\n');
+          // Encode per segment: a filename may legitimately contain '#' or '?',
+          // which curl would otherwise read as fragment/query and cut the path short.
+          const encoded = paths.map((p) => p.split('/').map(encodeURIComponent).join('/'));
+          fs.writeFileSync('/tmp/handbook-sample-paths.txt', encoded.join('\n') + '\n');
           console.log('sampling paths:\n' + paths.join('\n'));
           NODE
 
@@ -125,12 +128,16 @@ jobs:
             [ -n "$path" ] || continue
             code=$(curl -sS -o /dev/null -w '%{http_code}' -u ci:ci --max-time 10 \
               "http://127.0.0.1:8080/${path}")
-            if [ "$code" = "404" ]; then
-              echo "artifact sample 404: ${path}" >&2
-              docker logs handbook-smoke >&2 || true
-              exit 1
-            fi
-            echo "ok ${code} ${path}"
+            # Anything outside 2xx is a failure. Checking only for 404 let a 401,
+            # 403 or 500 pass as if the artifact were served correctly.
+            case "$code" in
+              2*) echo "ok ${code} ${path}" ;;
+              *)
+                echo "artifact sample ${code}: ${path}" >&2
+                docker logs handbook-smoke >&2 || true
+                exit 1
+                ;;
+            esac
           done < /tmp/handbook-sample-paths.txt
 
           docker stop handbook-smoke

--- a/.github/workflows/handbook-check.yaml
+++ b/.github/workflows/handbook-check.yaml
@@ -1,0 +1,136 @@
+# PR check: build handbook image (no push) and run container smoke tests.
+# Draft PRs are skipped; ready_for_review re-triggers the check.
+
+name: Handbook Build Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'e2e/screenshots/**'
+      - 'scripts/handbook/**'
+      - 'tailwind.config.js'
+      - 'src/static/assets/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'Dockerfile.handbook'
+      - 'handbook.nginx.conf'
+      - '.github/workflows/handbook-deploy.yaml'
+      - '.github/workflows/handbook-check.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: handbook-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    name: Build handbook image + container smoke
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build handbook image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.handbook
+          push: false
+          load: true
+          tags: dfx-app-handbook:pr-check
+          platforms: linux/arm64
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+
+      - name: Entrypoint fails without credentials
+        run: |
+          set -euo pipefail
+          # Fail loud: container must not start an unauthenticated handbook.
+          if docker run --rm --name handbook-noauth dfx-app-handbook:pr-check; then
+            echo "expected container to exit non-zero without HANDBOOK_USER/PASSWORD" >&2
+            exit 1
+          fi
+          echo "entrypoint correctly refused start without credentials"
+
+      - name: Container smoke (healthz, auth wall, manifest sample)
+        run: |
+          set -euo pipefail
+          docker rm -f handbook-smoke >/dev/null 2>&1 || true
+          docker run -d --name handbook-smoke -p 8080:8080 \
+            -e HANDBOOK_USER=ci \
+            -e HANDBOOK_PASSWORD=ci \
+            dfx-app-handbook:pr-check
+
+          for i in $(seq 1 20); do
+            if curl -fsS --max-time 3 http://127.0.0.1:8080/healthz 2>/dev/null | grep -q OK; then
+              break
+            fi
+            sleep 1
+          done
+
+          # /healthz is outside auth_basic
+          body=$(curl -fsS --max-time 5 http://127.0.0.1:8080/healthz)
+          echo "$body" | grep -q OK
+
+          # Gated root must be 401 without credentials
+          code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 5 http://127.0.0.1:8080/)
+          if [ "$code" != "401" ]; then
+            echo "expected 401 from / without auth, got $code" >&2
+            docker logs handbook-smoke >&2 || true
+            exit 1
+          fi
+
+          # With test credentials: 200 (follow redirect to index.html)
+          code=$(curl -sS -o /dev/null -w '%{http_code}' -u ci:ci -L --max-time 5 http://127.0.0.1:8080/)
+          if [ "$code" != "200" ]; then
+            echo "expected 200 from / with auth, got $code" >&2
+            docker logs handbook-smoke >&2 || true
+            exit 1
+          fi
+
+          # Sample one artifact per category from the generated manifest
+          # (no hard-coded filenames — renames must not break this check).
+          docker cp handbook-smoke:/usr/share/nginx/html/manifest.json /tmp/handbook-manifest.json
+          node <<'NODE'
+          const fs = require('fs');
+          const m = JSON.parse(fs.readFileSync('/tmp/handbook-manifest.json', 'utf8'));
+          if (!m.artifacts || !m.artifacts.length) {
+            console.error('manifest has no artifacts');
+            process.exit(1);
+          }
+          const byCat = {};
+          for (const a of m.artifacts) {
+            if (!byCat[a.category]) byCat[a.category] = a;
+          }
+          const paths = Object.values(byCat)
+            .map((a) => a.outputPath)
+            .filter((p) => p && p !== 'index.html');
+          // Always include index.html as a gated page sample
+          paths.unshift('index.html');
+          fs.writeFileSync('/tmp/handbook-sample-paths.txt', paths.join('\n') + '\n');
+          console.log('sampling paths:\n' + paths.join('\n'));
+          NODE
+
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            code=$(curl -sS -o /dev/null -w '%{http_code}' -u ci:ci --max-time 10 \
+              "http://127.0.0.1:8080/${path}")
+            if [ "$code" = "404" ]; then
+              echo "artifact sample 404: ${path}" >&2
+              docker logs handbook-smoke >&2 || true
+              exit 1
+            fi
+            echo "ok ${code} ${path}"
+          done < /tmp/handbook-sample-paths.txt
+
+          docker stop handbook-smoke
+          docker rm handbook-smoke

--- a/.github/workflows/handbook-deploy.yaml
+++ b/.github/workflows/handbook-deploy.yaml
@@ -1,0 +1,110 @@
+# Build, push and deploy the DFX Services handbook on develop.
+# Image: dfxswiss/dfx-app-handbook:latest → handbook.app.dfx.swiss
+#
+# Credentials for Basic Auth are NOT in this repo; the container receives
+# HANDBOOK_USER / HANDBOOK_PASSWORD from the deployment environment only.
+
+name: Handbook Deploy
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'e2e/screenshots/**'
+      - 'scripts/handbook/**'
+      - 'tailwind.config.js'
+      - 'src/static/assets/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'CONTRIBUTING.md'
+      - 'Dockerfile.handbook'
+      - 'handbook.nginx.conf'
+      - '.github/workflows/handbook-deploy.yaml'
+      - '.github/workflows/handbook-check.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: handbook-deploy
+  cancel-in-progress: false
+
+env:
+  DOCKER_TAGS: dfxswiss/dfx-app-handbook:latest
+  DEPLOY_SERVICE: dfx-app-handbook
+  SMOKE_URL: https://handbook.app.dfx.swiss/healthz
+
+jobs:
+  build-and-deploy:
+    name: Build, push, deploy, smoke
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.handbook
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+          platforms: linux/arm64
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+
+      # Pin cloudflared and verify SHA256 (release binary, not "latest").
+      - name: Install cloudflared
+        env:
+          CLOUDFLARED_VERSION: '2025.4.0'
+          CLOUDFLARED_SHA256: '2561391ee9abdc828afcc52f5ac314b6551a9a6a31ff59cbc64efc63aec04615'
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-arm64" -o /usr/local/bin/cloudflared
+          echo "${CLOUDFLARED_SHA256}  /usr/local/bin/cloudflared" | sha256sum -c -
+          chmod +x /usr/local/bin/cloudflared
+
+      # IdentitiesOnly + IdentityAgent=none pin SSH to the explicit deploy key
+      # so OpenSSH does not probe default/agent keys first and exhaust
+      # MaxAuthTries on the server.
+      - name: Deploy via SSH
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o IdentitiesOnly=yes \
+            -o IdentityAgent=none \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "${{ env.DEPLOY_SERVICE }}"
+
+      # Poll public /healthz so a green job cannot lie when the container is up
+      # but nginx is not answering.
+      - name: Smoke test public endpoint
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            code=$(curl -sS -L --max-redirs 3 -o /dev/null -w '%{http_code}' --max-time 10 "$SMOKE_URL" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "handbook responded 200 after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "[$i/30] $SMOKE_URL -> ${code} (waiting 10 s)"
+            sleep 10
+          done
+          echo "::error::handbook never returned 200 within ~5 min after deploy"
+          exit 1

--- a/.github/workflows/handbook-deploy.yaml
+++ b/.github/workflows/handbook-deploy.yaml
@@ -14,6 +14,7 @@ on:
       - 'scripts/handbook/**'
       - 'tailwind.config.js'
       - 'src/static/assets/**'
+      - 'public/logo.png'
       - 'docs/**'
       - 'README.md'
       - 'CONTRIBUTING.md'

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ e2e/screenshots/debug/
 # Chrome for testing (installed via @puppeteer/browsers)
 /chrome/
 playwright-report-local/
+
+# Handbook build scratch (isolated marked install + generated site)
+_handbook-deps/
+docs/handbook/build/
+

--- a/Dockerfile.handbook
+++ b/Dockerfile.handbook
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+#
+# Static nginx host for the DFX Services handbook.
+# Multi-stage: Node discovers baselines + docs and generates index.html;
+# nginx serves the result behind Basic Auth (credentials from env at start).
+
+FROM node:20-alpine AS builder
+WORKDIR /work
+
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
+# marked is installed in isolation — never added to the app package.json.
+RUN npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7
+
+# Only paths needed for discovery/build (keep context small).
+COPY scripts/handbook/ ./scripts/handbook/
+COPY e2e/screenshots/ ./e2e/screenshots/
+COPY tailwind.config.js ./
+COPY src/static/assets/ ./src/static/assets/
+COPY public/logo.png ./public/logo.png
+COPY docs/ ./docs/
+COPY README.md CONTRIBUTING.md ./
+
+RUN NODE_PATH=./_handbook-deps/node_modules node scripts/handbook/build.js /out
+
+FROM nginx:1.27-alpine
+
+# htpasswd binary for runtime credential file generation.
+RUN apk add --no-cache apache2-utils
+
+COPY handbook.nginx.conf /etc/nginx/conf.d/default.conf
+COPY scripts/handbook/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+COPY --from=builder /out/ /usr/share/nginx/html/
+
+# Do not bake htpasswd into the image — entrypoint creates it from env.
+ENTRYPOINT ["/docker-entrypoint.sh"]
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD wget -qO- --timeout=3 http://127.0.0.1:8080/healthz >/dev/null || exit 1

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -1,0 +1,105 @@
+# DFX Services Handbook
+
+Statische, deutschsprachige Übersichtsseite aller committeten Screenshot-Baselines,
+Design-Tokens und Markdown-Dokumentation dieses Repos. Ausgeliefert von nginx in einem
+Docker-Image hinter Basic Auth unter [handbook.app.dfx.swiss](https://handbook.app.dfx.swiss).
+
+## Wie es funktioniert
+
+Das Assembly-Script `scripts/handbook/build.js` **findet** Artefakte selbst (kein
+handgepflegtes Mapping):
+
+| Quelle | Pfad | Inhalt |
+|--------|------|--------|
+| A | `e2e/screenshots/baseline/*.png` | Playwright Visual-Baselines (flach) |
+| B | `e2e/screenshots/*.png` | Top-Level-Screenshots (nicht rekursiv; `baseline/` und `debug/` ausgenommen) |
+| C | `tailwind.config.js` | Farben und Schriftgrössen |
+| D | `src/static/assets/*`, `public/logo.png` | Logos |
+| E | `README.md`, `CONTRIBUTING.md`, `docs/*.md` | Markdown-Doku (gerendert mit `marked`) |
+
+Ausgabe pro Build:
+
+```
+<out>/
+  index.html
+  manifest.json
+  screenshots/…
+  docs/…
+  assets/…
+```
+
+Guards (Build bricht ab bei Verletzung):
+
+- **Floor:** mindestens `MIN_SCREENSHOTS` (170) PNGs
+- **PNG-Integrität:** Magic-Bytes `\x89PNG…` und Grösse > 1000 Bytes
+- **HTML-Integrität:** jedes lokale `src`/`href` in der generierten Seite muss existieren
+
+Überschreitung der Mindestzahl ist **kein** Fehler — neue Baselines landen automatisch.
+
+Metadaten in `scripts/handbook/metadata.json` sind **nur Anreicherung** (deutsche Titel/
+Beschreibungen pro Gruppe). Fehlende Einträge sind kein Fehler; verwaiste Einträge
+erzeugen nur eine Warnung auf stderr.
+
+## Lokal bauen
+
+`marked` wird **isoliert** installiert — nicht in `package.json` / Lockfile des Repos:
+
+```bash
+npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7
+NODE_PATH=./_handbook-deps/node_modules node scripts/handbook/build.js docs/handbook/build
+```
+
+Anschliessend `docs/handbook/build/index.html` im Browser öffnen.
+
+Das Scratch-Verzeichnis `_handbook-deps/` und `docs/handbook/build/` sind gitignored.
+
+Optional: `GIT_SHA=…` (oder `HANDBOOK_GIT_SHA`) setzt den Stand im Seitenkopf.
+Optional: `HANDBOOK_REPO_ROOT=/pfad/zum/repo` überschreibt die Root-Erkennung
+(Standard: zwei Ebenen über dem Script).
+
+## Docker-Image lokal
+
+```bash
+# _handbook-deps darf nicht im Build-Kontext liegen
+rm -rf _handbook-deps
+
+docker build -f Dockerfile.handbook \
+  --build-arg GIT_SHA="$(git rev-parse HEAD)" \
+  -t dfx-app-handbook:local .
+
+# Credentials nur zur lokalen Prüfung — echte Werte kommen von der Deployment-Umgebung
+docker run --rm -p 8080:8080 \
+  -e HANDBOOK_USER=local \
+  -e HANDBOOK_PASSWORD=local \
+  dfx-app-handbook:local
+```
+
+- `http://127.0.0.1:8080/healthz` → `200 OK` ohne Auth
+- `http://127.0.0.1:8080/` → `401` ohne Auth, `200` mit Basic Auth
+
+Ohne `HANDBOOK_USER` / `HANDBOOK_PASSWORD` startet der Container **nicht** (fail loud).
+
+## Neue Baseline hinzufügen
+
+1. PNG unter `e2e/screenshots/baseline/` (Playwright) oder als Top-Level-Datei unter
+   `e2e/screenshots/` ablegen und committen.
+2. Nächster Handbook-Build (lokal oder CI nach Merge auf `develop`) nimmt die Datei
+   automatisch auf — **keine** Mapping-Tabelle und **keinen** Count anpassen.
+3. Optional: in `scripts/handbook/metadata.json` einen deutschen Titel/Beschreibung für
+   den Gruppenschlüssel ergänzen (Präfix vor `.spec.ts-` bzw. gemeinsamer Präfix bei
+   manuellen Screenshots).
+
+## Deployment
+
+Bei Push auf `develop` (relevante Pfade) baut `.github/workflows/handbook-deploy.yaml`
+das Image `dfxswiss/dfx-app-handbook:latest` (linux/arm64), pusht es und löst den
+serverseitigen Deploy-Hook aus. Anschliessend Smoke gegen
+`https://handbook.app.dfx.swiss/healthz`.
+
+Basic-Auth-Zugangsdaten werden **ausschliesslich** in der Deployment-Umgebung als
+`HANDBOOK_USER` / `HANDBOOK_PASSWORD` gesetzt. Weder Klartext noch Hash gehören in
+dieses öffentliche Repository.
+
+Pull Requests (nicht-Draft) laufen durch `.github/workflows/handbook-check.yaml`:
+Image-Build ohne Push, Container-Smoke (`/healthz`, Auth-Wand, Stichprobe aus
+`manifest.json`).

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -32,7 +32,9 @@ Guards (Build bricht ab bei Verletzung):
 
 - **Floor:** mindestens `MIN_SCREENSHOTS` (170) PNGs
 - **PNG-Integrität:** Magic-Bytes `\x89PNG…` und Grösse > 1000 Bytes
-- **HTML-Integrität:** jedes lokale `src`/`href` in der generierten Seite muss existieren
+- **HTML-Integrität:** jedes Artefakt im Manifest muss im Ausgabeverzeichnis liegen; zusätzlich
+  muss jedes lokale `src`/`href` in den gerenderten Markdown-Seiten auflösen. Die `index.html`
+  wird dafür nicht erneut geparst — ihre Artefakte deckt die Manifest-Prüfung ab
 
 Überschreitung der Mindestzahl ist **kein** Fehler — neue Baselines landen automatisch.
 

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -1,0 +1,73 @@
+server {
+    listen 8080 default_server;
+    server_name _;
+
+    # Emit relative Location headers so redirects work behind a reverse
+    # proxy — otherwise nginx prepends the internal listen address and
+    # the browser follows a host it cannot reach.
+    absolute_redirect off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Hide nginx version in Server header.
+    server_tokens off;
+
+    # Access gate. The htpasswd file is generated at container start from
+    # HANDBOOK_USER / HANDBOOK_PASSWORD (see docker-entrypoint.sh) and is
+    # never baked into the image. /healthz bypasses auth so HEALTHCHECK
+    # and CI smoke stay credential-free.
+    auth_basic "DFX Services Handbook";
+    auth_basic_user_file /etc/nginx/handbook.htpasswd;
+
+    # Security headers for a static, embed-safe handbook.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # Behind Basic Auth: never let a shared edge cache store responses.
+    # With max-age, intermediaries have been observed caching 401s (then
+    # served to authenticated clients) and authenticated 200s. Vary on
+    # Authorization is ignored by common edge caches outside Enterprise
+    # plans. The only safe answer for gated content is no-store.
+    add_header Cache-Control "private, no-store" always;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    # text/html is gzipped by default; do not list it again.
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        application/javascript
+        application/json
+        image/svg+xml;
+
+    # Unauthenticated health endpoint — Dockerfile HEALTHCHECK and CI
+    # smoke. nginx add_header is all-or-nothing per location, so server-
+    # level security headers are restated here.
+    location = /healthz {
+        auth_basic off;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cache-Control "no-store" always;
+        default_type text/plain;
+        return 200 "OK\n";
+    }
+
+    # PDFs inline in the browser (not forced download). Restate headers
+    # because add_header is all-or-nothing per location.
+    location ~* \.pdf$ {
+        add_header Content-Disposition "inline" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cache-Control "private, no-store" always;
+        try_files $uri =404;
+    }
+
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -254,6 +254,13 @@ function normalizeFontSize(value) {
   return null;
 }
 
+// Matches any absolute URI scheme (RFC 3986 §3.1: ALPHA *( ALPHA / DIGIT /
+// "+" / "-" / "." ) ":"), e.g. "https:", "mailto:", "data:", "javascript:",
+// "vbscript:", "file:", "tel:", and anything not yet invented. A generic
+// scheme check instead of an enumeration of known-bad prefixes so nothing
+// can be missed (fixes CodeQL "Incomplete URL scheme check").
+const ABSOLUTE_URI_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
 function collectRelativeRefs(html) {
   const refs = [];
   const re = /\b(?:src|href)="([^"]+)"/g;
@@ -261,13 +268,9 @@ function collectRelativeRefs(html) {
   while ((m = re.exec(html)) !== null) {
     const raw = m[1];
     if (
-      raw.startsWith('http://') ||
-      raw.startsWith('https://') ||
+      ABSOLUTE_URI_SCHEME_RE.test(raw) ||
       raw.startsWith('//') ||
-      raw.startsWith('mailto:') ||
-      raw.startsWith('data:') ||
-      raw.startsWith('#') ||
-      raw.startsWith('javascript:')
+      raw.startsWith('#')
     ) {
       continue;
     }

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -266,10 +266,14 @@ const ABSOLUTE_URI_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 
 function collectRelativeRefs(html) {
   const refs = [];
-  const re = /\b(?:src|href)="([^"]+)"/g;
+  // Only match real attribute names, after start-of-string, whitespace or '<'.
+  // A word boundary alone also matches after '-' and ':', so data-src,
+  // xlink:href and ng-src would be checked as if a browser resolved them.
+  // Both quote styles are accepted: inline HTML in Markdown may use either.
+  const re = /(?:^|[\s<])(?:src|href)=("|')([^"']+)\1/g;
   let m;
   while ((m = re.exec(html)) !== null) {
-    const raw = m[1];
+    const raw = m[2];
     if (
       ABSOLUTE_URI_SCHEME_RE.test(raw) ||
       raw.startsWith('//') ||

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -90,11 +90,14 @@ function decodeHtmlEntities(str) {
 }
 
 // URL-encode a relative output path for safe use inside an href/src
-// attribute (spaces, quotes, angle brackets, …). Applied BEFORE escapeHtml —
-// encodeURI leaves '&' and others untouched, so escapeHtml is still needed
-// as a separate step to make the attribute value HTML-safe.
+// attribute. encodeURIComponent is applied per path segment so '/' stays a
+// separator, while reserved characters like '#' and '?' (left alone by
+// encodeURI) are encoded — otherwise a filename containing them silently
+// produces a broken link. Applied BEFORE escapeHtml — encodeURIComponent
+// still leaves '&' untouched, so escapeHtml is still needed as a separate
+// step to make the attribute value HTML-safe.
 function encodeHtmlPath(p) {
-  return encodeURI(String(p));
+  return String(p).split('/').map(encodeURIComponent).join('/');
 }
 
 function ensureDir(dir) {
@@ -1144,7 +1147,8 @@ function main() {
     const html = fs.readFileSync(path.join(outDir, d.out), 'utf8');
     const refs = collectRelativeRefs(html);
     for (const rawRef of refs) {
-      const ref = decodeHtmlEntities(rawRef);
+      let ref = decodeHtmlEntities(rawRef);
+      try { ref = decodeURI(ref); } catch { /* malformed escape: keep as-is */ }
       const underOut = path.join(path.dirname(path.join(outDir, d.out)), ref);
       if (
         !ref.startsWith('/') &&

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -1,0 +1,1130 @@
+#!/usr/bin/env node
+/**
+ * Handbook assembly for DFXswiss/services.
+ *
+ * Auto-discovers screenshot baselines, design tokens, logos and markdown
+ * docs; generates a single deterministic index.html + manifest.json.
+ *
+ * No hand-maintained mapping table: new baselines appear automatically.
+ * Floor guards catch empty/corrupt checkouts; exact counts are never enforced.
+ *
+ * Usage:
+ *   npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7
+ *   NODE_PATH=./_handbook-deps/node_modules node scripts/handbook/build.js <output-dir>
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// --- Floor guards (today's counts minus a small buffer; never exact) ---
+const MIN_SCREENSHOTS = 170;
+const MIN_PNG_BYTES = 1000;
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const MARKED_INSTALL =
+  'npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7';
+
+const SORT_LOCALE = 'en';
+
+function sortStrings(a, b) {
+  return a.localeCompare(b, SORT_LOCALE);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+// marked: hard fail with install instructions (no fallback renderer — that
+// would make output environment-dependent and break determinism).
+function loadMarked() {
+  try {
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    return require('marked');
+  } catch (err) {
+    fail(
+      'handbook: marked is required but could not be loaded.\n' +
+        'Install it in isolation (do not add to package.json):\n' +
+        '  ' +
+        MARKED_INSTALL +
+        '\n' +
+        'Then re-run:\n' +
+        '  NODE_PATH=./_handbook-deps/node_modules node scripts/handbook/build.js <out>\n' +
+        'Original error: ' +
+        (err && err.message ? err.message : String(err)),
+    );
+  }
+}
+
+const markedModule = loadMarked();
+const markedParse =
+  typeof markedModule.parse === 'function'
+    ? (md) => markedModule.parse(md)
+    : typeof markedModule.marked?.parse === 'function'
+      ? (md) => markedModule.marked.parse(md)
+      : null;
+if (!markedParse) {
+  fail('handbook: marked loaded but no parse() API found (expected marked@15).');
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function copyFile(src, dest) {
+  ensureDir(path.dirname(dest));
+  fs.copyFileSync(src, dest);
+}
+
+function listPngFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.toLowerCase().endsWith('.png'))
+    .map((d) => d.name)
+    .sort(sortStrings);
+}
+
+function assertValidPng(filePath) {
+  let st;
+  try {
+    st = fs.statSync(filePath);
+  } catch (err) {
+    fail(`handbook PNG guard: cannot stat ${filePath}: ${err.message}`);
+  }
+  if (st.size <= MIN_PNG_BYTES) {
+    fail(
+      `handbook PNG guard: ${filePath} is ${st.size} bytes (must be > ${MIN_PNG_BYTES}). ` +
+        'Possible incomplete checkout or LFS pointer.',
+    );
+  }
+  const fd = fs.openSync(filePath, 'r');
+  const buf = Buffer.alloc(8);
+  try {
+    fs.readSync(fd, buf, 0, 8, 0);
+  } finally {
+    fs.closeSync(fd);
+  }
+  if (!buf.equals(PNG_MAGIC)) {
+    fail(
+      `handbook PNG guard: ${filePath} does not start with PNG magic bytes. ` +
+        'Possible incomplete checkout or LFS pointer.',
+    );
+  }
+}
+
+/**
+ * Round-1 candidate group key from filename:
+ * - Playwright snapshots: part before ".spec.ts-"
+ * - Manual screenshots: shared prefix before a numeric step, else first segment
+ */
+function candidateKeyFromFilename(filename) {
+  const base = filename.replace(/\.png$/i, '');
+  const specMatch = base.match(/^(.+?)\.spec\.ts-/);
+  if (specMatch) return specMatch[1];
+  const stepMatch = base.match(/^(.+?)-\d+(?:-|$)/);
+  if (stepMatch) return stepMatch[1];
+  const dash = base.indexOf('-');
+  if (dash > 0) return base.slice(0, dash);
+  return base;
+}
+
+/**
+ * Comparison base for round-2 longest-prefix matching.
+ * Playwright: full raw name before ".spec.ts-"; manual: full basename.
+ */
+function comparisonBaseFromFilename(filename) {
+  const base = filename.replace(/\.png$/i, '');
+  const specMatch = base.match(/^(.+?)\.spec\.ts-/);
+  if (specMatch) return specMatch[1];
+  return base;
+}
+
+/**
+ * Two-pass deterministic group assignment.
+ * Round 1: collect candidate keys (spec / numbered step / first dash).
+ * Round 2: assign each file the longest candidate that equals its base or
+ * is a `<key>-` prefix; equal length → alphabetical (smaller string wins).
+ */
+function resolveGroupKeys(filenames) {
+  const candidates = new Set();
+  for (const name of filenames) {
+    candidates.add(candidateKeyFromFilename(name));
+  }
+  // Longer first; equal length → locale-stable ascending so first match wins.
+  const sortedCandidates = Array.from(candidates).sort((a, b) => {
+    if (b.length !== a.length) return b.length - a.length;
+    return sortStrings(a, b);
+  });
+
+  const groupsByName = new Map();
+  for (const name of filenames) {
+    const base = comparisonBaseFromFilename(name);
+    let best = null;
+    for (const key of sortedCandidates) {
+      if (base === key || base.startsWith(key + '-')) {
+        best = key;
+        break;
+      }
+    }
+    groupsByName.set(
+      name,
+      best !== null ? best : candidateKeyFromFilename(name),
+    );
+  }
+  return groupsByName;
+}
+
+/** Project / platform badges from Playwright naming conventions. */
+function parseBadges(filename) {
+  if (/-chromium-metamask-darwin\.png$/i.test(filename)) {
+    return { project: 'chromium-metamask', platform: 'darwin' };
+  }
+  if (/-chromium-darwin\.png$/i.test(filename)) {
+    return { project: 'chromium', platform: 'darwin' };
+  }
+  return { project: null, platform: null };
+}
+
+function titleFromFilename(filename) {
+  return filename.replace(/\.png$/i, '');
+}
+
+function slugify(key) {
+  return String(key)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'item';
+}
+
+function flattenColors(obj, prefix, out) {
+  const keys = Object.keys(obj).sort(sortStrings);
+  for (const k of keys) {
+    const v = obj[k];
+    const name = prefix ? `${prefix}-${k}` : k;
+    if (typeof v === 'string') {
+      out.push({ name, hex: v });
+    } else if (v && typeof v === 'object') {
+      flattenColors(v, name, out);
+    }
+  }
+  return out;
+}
+
+function collectRelativeRefs(html) {
+  const refs = [];
+  const re = /\b(?:src|href)="([^"]+)"/g;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const raw = m[1];
+    if (
+      raw.startsWith('http://') ||
+      raw.startsWith('https://') ||
+      raw.startsWith('//') ||
+      raw.startsWith('mailto:') ||
+      raw.startsWith('data:') ||
+      raw.startsWith('#') ||
+      raw.startsWith('javascript:')
+    ) {
+      continue;
+    }
+    const cleaned = raw.split('#')[0].split('?')[0];
+    if (cleaned) refs.push(cleaned);
+  }
+  return refs;
+}
+
+function integrityCheck(html, outDir, label) {
+  const refs = collectRelativeRefs(html);
+  for (const ref of refs) {
+    const full = path.join(outDir, ref);
+    if (!fs.existsSync(full)) {
+      fail(
+        `handbook integrity check failed (${label}): referenced path does not exist: ${ref}`,
+      );
+    }
+  }
+}
+
+function main() {
+  const outArg = process.argv[2];
+  if (!outArg) {
+    fail('Usage: node scripts/handbook/build.js <output-dir>');
+  }
+
+  const scriptDir = __dirname;
+  const repoRoot = process.env.HANDBOOK_REPO_ROOT
+    ? path.resolve(process.env.HANDBOOK_REPO_ROOT)
+    : path.resolve(scriptDir, '../..');
+  const outDir = path.resolve(outArg);
+  const gitSha = process.env.GIT_SHA || process.env.HANDBOOK_GIT_SHA || 'unknown';
+
+  const metadataPath = path.join(scriptDir, 'metadata.json');
+  let metadata = {};
+  if (fs.existsSync(metadataPath)) {
+    metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+  }
+
+  const artifacts = [];
+  const screenshotEntries = [];
+
+  // --- Source A: e2e/screenshots/baseline/*.png (flat) ---
+  const baselineDir = path.join(repoRoot, 'e2e/screenshots/baseline');
+  for (const name of listPngFiles(baselineDir)) {
+    const src = path.join(baselineDir, name);
+    assertValidPng(src);
+    const relOut = path.posix.join('screenshots', 'baseline', name);
+    const dest = path.join(outDir, 'screenshots', 'baseline', name);
+    copyFile(src, dest);
+    const badges = parseBadges(name);
+    const entry = {
+      category: 'screenshot',
+      outputPath: relOut,
+      sourcePath: path.posix.join('e2e/screenshots/baseline', name),
+      title: titleFromFilename(name),
+      group: null, // assigned after two-pass resolveGroupKeys
+      project: badges.project,
+      platform: badges.platform,
+      _filename: name,
+    };
+    screenshotEntries.push(entry);
+  }
+
+  // --- Source B: e2e/screenshots/*.png top-level only (exclude baseline/, debug/) ---
+  const shotsRoot = path.join(repoRoot, 'e2e/screenshots');
+  if (fs.existsSync(shotsRoot)) {
+    const top = fs
+      .readdirSync(shotsRoot, { withFileTypes: true })
+      .filter((d) => d.isFile() && d.name.toLowerCase().endsWith('.png'))
+      .map((d) => d.name)
+      .sort(sortStrings);
+    for (const name of top) {
+      const src = path.join(shotsRoot, name);
+      assertValidPng(src);
+      const relOut = path.posix.join('screenshots', name);
+      const dest = path.join(outDir, 'screenshots', name);
+      copyFile(src, dest);
+      const badges = parseBadges(name);
+      const entry = {
+        category: 'screenshot',
+        outputPath: relOut,
+        sourcePath: path.posix.join('e2e/screenshots', name),
+        title: titleFromFilename(name),
+        group: null, // assigned after two-pass resolveGroupKeys
+        project: badges.project,
+        platform: badges.platform,
+        _filename: name,
+      };
+      screenshotEntries.push(entry);
+    }
+  }
+
+  // Two-pass grouping: longest matching candidate key wins (deterministic).
+  {
+    const filenames = screenshotEntries.map((e) => e._filename);
+    const groupMap = resolveGroupKeys(filenames);
+    for (const entry of screenshotEntries) {
+      entry.group = groupMap.get(entry._filename);
+      delete entry._filename;
+      artifacts.push({
+        category: entry.category,
+        outputPath: entry.outputPath,
+        sourcePath: entry.sourcePath,
+        title: entry.title,
+        group: entry.group,
+      });
+    }
+  }
+
+  screenshotEntries.sort((a, b) => {
+    const g = sortStrings(a.group, b.group);
+    if (g !== 0) return g;
+    return sortStrings(a.title, b.title);
+  });
+
+  if (screenshotEntries.length < MIN_SCREENSHOTS) {
+    fail(
+      `handbook floor guard: found ${screenshotEntries.length} screenshots, ` +
+        `need at least MIN_SCREENSHOTS=${MIN_SCREENSHOTS}. ` +
+        'Check e2e/screenshots/baseline/ and e2e/screenshots/*.png paths.',
+    );
+  }
+
+  // --- Source C: design tokens from tailwind.config.js ---
+  const tailwindPath = path.join(repoRoot, 'tailwind.config.js');
+  if (!fs.existsSync(tailwindPath)) {
+    fail(`handbook: missing ${tailwindPath}`);
+  }
+  // Clear require cache for determinism when re-run in same process (tests).
+  delete require.cache[require.resolve(tailwindPath)];
+  const tailwind = require(tailwindPath);
+  const theme = tailwind.theme || {};
+  const colorList = flattenColors(theme.colors || {}, '', []);
+  const fontSizeEntries = Object.keys(theme.fontSize || {})
+    .sort(sortStrings)
+    .map((k) => ({ name: k, size: theme.fontSize[k] }));
+
+  artifacts.push({
+    category: 'token',
+    outputPath: 'index.html',
+    sourcePath: 'tailwind.config.js',
+    title: 'Design-Tokens (Farben)',
+  });
+  artifacts.push({
+    category: 'token',
+    outputPath: 'index.html',
+    sourcePath: 'tailwind.config.js',
+    title: 'Design-Tokens (Typografie)',
+  });
+
+  // --- Source D: logos / assets ---
+  const assetSpecs = [
+    { src: 'src/static/assets/logo.svg', out: 'assets/logo.svg' },
+    { src: 'src/static/assets/logo-dark.svg', out: 'assets/logo-dark.svg' },
+    { src: 'src/static/assets/path-arrow.svg', out: 'assets/path-arrow.svg' },
+    { src: 'public/logo.png', out: 'assets/logo.png' },
+  ];
+  for (const a of assetSpecs) {
+    const src = path.join(repoRoot, a.src);
+    if (!fs.existsSync(src)) {
+      fail(`handbook: missing asset ${a.src}`);
+    }
+    if (a.src.toLowerCase().endsWith('.png')) {
+      assertValidPng(src);
+    }
+    copyFile(src, path.join(outDir, a.out));
+    artifacts.push({
+      category: 'asset',
+      outputPath: a.out,
+      sourcePath: a.src,
+      title: path.basename(a.src),
+    });
+  }
+
+  // --- Source E: markdown docs ---
+  const docSpecs = [
+    { src: 'README.md', out: 'docs/README.html', title: 'README' },
+    { src: 'CONTRIBUTING.md', out: 'docs/CONTRIBUTING.html', title: 'CONTRIBUTING' },
+    {
+      src: 'docs/EIP7702-Implementierungsplan.md',
+      out: 'docs/EIP7702-Implementierungsplan.html',
+      title: 'EIP-7702 Implementierungsplan',
+    },
+    {
+      src: 'docs/gasless-token-transfer-analysis.md',
+      out: 'docs/gasless-token-transfer-analysis.html',
+      title: 'Gasless Token Transfer Analysis',
+    },
+  ];
+  const renderedDocs = [];
+  for (const d of docSpecs) {
+    const src = path.join(repoRoot, d.src);
+    if (!fs.existsSync(src)) {
+      fail(`handbook: missing markdown source ${d.src}`);
+    }
+    const md = fs.readFileSync(src, 'utf8');
+    const body = markedParse(md);
+    const page =
+      '<!DOCTYPE html>\n<html lang="de">\n<head>\n<meta charset="utf-8">\n' +
+      `<meta name="viewport" content="width=device-width, initial-scale=1">\n` +
+      `<title>${escapeHtml(d.title)} — DFX Services Handbook</title>\n` +
+      '<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;' +
+      'max-width:860px;margin:32px auto;padding:0 20px;line-height:1.55;color:#0a1f33;}' +
+      'pre{overflow:auto;background:#f3f4f7;padding:12px;border-radius:6px;}' +
+      'code{font-family:SF Mono,Menlo,Consolas,monospace;font-size:0.9em;}' +
+      'img{max-width:100%;height:auto;}a{color:#0A355C;}</style>\n</head>\n<body>\n' +
+      body +
+      '\n</body>\n</html>\n';
+    const dest = path.join(outDir, d.out);
+    ensureDir(path.dirname(dest));
+    fs.writeFileSync(dest, page, 'utf8');
+    renderedDocs.push({ ...d, body });
+    artifacts.push({
+      category: 'doc',
+      outputPath: d.out,
+      sourcePath: d.src,
+      title: d.title,
+    });
+  }
+
+  // --- Group screenshots ---
+  const groups = new Map();
+  for (const e of screenshotEntries) {
+    if (!groups.has(e.group)) groups.set(e.group, []);
+    groups.get(e.group).push(e);
+  }
+  for (const list of groups.values()) {
+    list.sort((a, b) => sortStrings(a.title, b.title));
+  }
+  const groupKeys = Array.from(groups.keys()).sort(sortStrings);
+
+  // Orphan metadata entries → warning only
+  for (const key of Object.keys(metadata).sort(sortStrings)) {
+    if (!groups.has(key)) {
+      console.error(
+        `handbook warning: metadata.json entry "${key}" has no matching screenshots (orphan).`,
+      );
+    }
+  }
+
+  // --- Build HTML ---
+  const css = `
+      :root {
+        --bg: #e8eef5;
+        --surface: #ffffff;
+        --surface-2: #f3f4f7;
+        --line: #d6dbe2;
+        --line-2: #b8c4d8;
+        --ink: #072440;
+        --ink-2: #0A355C;
+        --ink-3: #65728A;
+        --ink-4: #9AA5B8;
+        --brand: #F5516C;
+        --brand-blue: #5A81BB;
+        --warn: #EAB308;
+        --content-width: 960px;
+      }
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+        font-size: 14.5px;
+        line-height: 1.55;
+        -webkit-font-smoothing: antialiased;
+      }
+      a { color: var(--brand-blue); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      code {
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+        font-size: 0.88em;
+        background: var(--surface-2);
+        padding: 1.5px 5px;
+        border-radius: 3px;
+        border: 1px solid var(--line);
+        color: var(--ink);
+      }
+      .wrap {
+        display: grid;
+        grid-template-columns: 240px 1fr;
+        gap: 32px;
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 32px;
+      }
+      @media (max-width: 900px) {
+        .wrap { grid-template-columns: 1fr; }
+        aside { position: static !important; height: auto !important; }
+      }
+      aside {
+        position: sticky;
+        top: 32px;
+        align-self: start;
+        height: calc(100vh - 64px);
+        overflow-y: auto;
+        padding-right: 12px;
+      }
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
+        font-size: 15px;
+        color: var(--ink);
+        margin-bottom: 4px;
+      }
+      .brand .dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--brand);
+      }
+      .brand-sub {
+        font-size: 12.5px;
+        color: var(--ink-3);
+        margin: 0 0 20px 0;
+      }
+      .toc-label {
+        font-size: 10.5px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--ink-4);
+        margin: 18px 0 8px;
+      }
+      .toc ol { list-style: none; padding: 0; margin: 0; }
+      .toc li { margin: 2px 0; }
+      .toc a {
+        display: block;
+        padding: 4px 6px;
+        border-radius: 3px;
+        font-size: 13px;
+        color: var(--ink-2);
+      }
+      .toc a:hover {
+        background: var(--surface-2);
+        text-decoration: none;
+        color: var(--ink);
+      }
+      .toc .spec-num {
+        display: inline-block;
+        min-width: 22px;
+        font-variant-numeric: tabular-nums;
+        color: var(--ink-4);
+        font-size: 11.5px;
+        margin-right: 8px;
+      }
+      main { max-width: var(--content-width); }
+      .hero h1 {
+        margin: 0 0 14px 0;
+        font-size: 30px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+      .lede {
+        font-size: 16px;
+        color: var(--ink-2);
+        margin: 0 0 18px 0;
+      }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 18px;
+        font-size: 13px;
+        color: var(--ink-3);
+      }
+      .meta b { color: var(--ink); font-weight: 600; }
+      hr.sep {
+        border: 0;
+        border-top: 1px solid var(--line);
+        margin: 48px 0;
+      }
+      details.spec {
+        margin: 0 0 72px;
+        scroll-margin-top: 24px;
+      }
+      details.spec > summary {
+        list-style: none;
+        cursor: pointer;
+        user-select: none;
+        padding: 6px 0 4px;
+      }
+      details.spec > summary::-webkit-details-marker { display: none; }
+      details.spec > summary:focus-visible {
+        outline: 2px solid var(--brand);
+        outline-offset: 4px;
+        border-radius: 4px;
+      }
+      details.spec > summary:hover .spec-head .lhs h2 { color: var(--brand); }
+      .spec-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
+        gap: 24px;
+        margin-bottom: 14px;
+      }
+      .spec-head .lhs h2 {
+        margin: 0 0 4px 0;
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: -0.005em;
+        display: inline-flex;
+        align-items: baseline;
+        gap: 10px;
+        transition: color 0.15s;
+      }
+      .spec-head .lhs h2::before {
+        content: '▸';
+        display: inline-block;
+        width: 12px;
+        font-size: 14px;
+        color: var(--ink-4);
+        transition: transform 0.18s ease-out, color 0.15s;
+        transform: translateY(-1px);
+      }
+      details.spec[open] .spec-head .lhs h2::before {
+        transform: translateY(-1px) rotate(90deg);
+        color: var(--brand);
+      }
+      .spec-head .lhs h2 .num {
+        display: inline-block;
+        min-width: 38px;
+        color: var(--ink-4);
+        font-variant-numeric: tabular-nums;
+        font-weight: 500;
+      }
+      .spec-head .file {
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+        font-size: 12.5px;
+        color: var(--ink-3);
+      }
+      .spec-head .rhs {
+        text-align: right;
+        font-size: 12.5px;
+        color: var(--ink-3);
+      }
+      .spec-head .rhs b { color: var(--ink); font-weight: 600; }
+      .spec-intro {
+        color: var(--ink-2);
+        margin: 14px 0 24px;
+      }
+      .tests {
+        display: grid;
+        gap: 22px;
+        grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      }
+      .test {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        overflow: hidden;
+        scroll-margin-top: 20px;
+      }
+      .test:target {
+        outline: 2px solid var(--brand);
+        outline-offset: -1px;
+      }
+      .test .head {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 14px;
+        border-bottom: 1px solid var(--line);
+        background: var(--surface-2);
+      }
+      .test .name {
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--ink);
+        word-break: break-all;
+      }
+      .badge {
+        display: inline-block;
+        font-size: 10.5px;
+        font-weight: 600;
+        padding: 2px 7px;
+        border-radius: 999px;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        color: var(--ink-3);
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+      }
+      .badge.project { border-color: var(--brand-blue); color: var(--brand-blue); }
+      .badge.platform { border-color: var(--ink-4); }
+      .test .img {
+        background: var(--surface-2);
+        display: flex;
+        justify-content: center;
+        padding: 14px;
+      }
+      .test .img img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 6px;
+        box-shadow: 0 2px 8px rgba(7, 36, 64, 0.12);
+      }
+      .callout {
+        border-left: 3px solid var(--brand);
+        background: rgba(245, 81, 108, 0.06);
+        padding: 14px 18px;
+        margin: 24px 0;
+        border-radius: 0 4px 4px 0;
+      }
+      .callout.info {
+        border-color: var(--brand-blue);
+        background: rgba(90, 129, 187, 0.08);
+      }
+      .callout p {
+        margin: 0;
+        color: var(--ink-2);
+        font-size: 13.5px;
+      }
+      .callout b { color: var(--ink); }
+      .toc-actions { margin: 6px 0 16px; }
+      .toc-actions button {
+        appearance: none;
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        color: var(--ink-2);
+        cursor: pointer;
+        font: inherit;
+        font-size: 12px;
+        padding: 5px 10px;
+        margin-right: 6px;
+        transition: background 0.15s, border-color 0.15s, color 0.15s;
+      }
+      .toc-actions button:hover {
+        background: var(--surface-2);
+        border-color: var(--line-2);
+        color: var(--ink);
+      }
+      .swatches {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+        gap: 12px;
+      }
+      .swatch {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        overflow: hidden;
+      }
+      .swatch .chip {
+        height: 56px;
+        border-bottom: 1px solid var(--line);
+      }
+      .swatch .meta-sw {
+        padding: 8px 10px;
+        font-size: 12px;
+      }
+      .swatch .meta-sw .n {
+        font-weight: 600;
+        color: var(--ink);
+        word-break: break-all;
+      }
+      .swatch .meta-sw .h {
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+        color: var(--ink-3);
+        margin-top: 2px;
+      }
+      .typo-row {
+        display: flex;
+        align-items: baseline;
+        gap: 16px;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--line);
+      }
+      .typo-row .label {
+        min-width: 64px;
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+        font-size: 12px;
+        color: var(--ink-3);
+      }
+      .typo-row .sample { color: var(--ink); }
+      .asset-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+        gap: 16px;
+      }
+      .asset-card {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 16px;
+        text-align: center;
+      }
+      .asset-card img {
+        max-width: 120px;
+        max-height: 80px;
+        height: auto;
+      }
+      .asset-card .an {
+        margin-top: 10px;
+        font-family: 'SF Mono', Menlo, Consolas, monospace;
+        font-size: 12px;
+        color: var(--ink-2);
+        word-break: break-all;
+      }
+      .doc-preview {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 16px 20px;
+        max-height: 420px;
+        overflow: auto;
+      }
+      .doc-preview h1, .doc-preview h2, .doc-preview h3 { color: var(--ink); }
+      .doc-preview pre {
+        overflow: auto;
+        background: var(--surface-2);
+        padding: 12px;
+        border-radius: 6px;
+      }
+      .doc-preview img { max-width: 100%; height: auto; }
+  `;
+
+  const script = `
+    (function () {
+      function openTargetFromHash() {
+        var hash = location.hash ? location.hash.slice(1) : '';
+        if (!hash) return;
+        // IDs may start with a digit — use getElementById, not querySelector('#'+…).
+        var el = document.getElementById(hash);
+        if (!el) return;
+        var details = el.closest ? el.closest('details.spec') : null;
+        if (!details && el.tagName === 'DETAILS') details = el;
+        if (details) details.open = true;
+        if (typeof el.scrollIntoView === 'function') {
+          el.scrollIntoView({ block: 'start' });
+        }
+      }
+      document.addEventListener('DOMContentLoaded', openTargetFromHash);
+      window.addEventListener('hashchange', openTargetFromHash);
+
+      document.addEventListener('click', function (ev) {
+        var t = ev.target;
+        if (!t || !t.getAttribute) return;
+        if (t.id === 'toc-expand-all') {
+          document.querySelectorAll('details.spec').forEach(function (d) { d.open = true; });
+        }
+        if (t.id === 'toc-collapse-all') {
+          document.querySelectorAll('details.spec').forEach(function (d) { d.open = false; });
+        }
+      });
+    })();
+  `;
+
+  // TOC + sections
+  let tocItems = [];
+  let sectionsHtml = '';
+  let sectionNum = 0;
+
+  function pushSection(id, numLabel, title, fileHint, countLabel, intro, bodyHtml) {
+    sectionNum += 1;
+    const n = String(sectionNum).padStart(2, '0');
+    tocItems.push({ id, n, title });
+    sectionsHtml += `
+      <details class="spec" id="${escapeHtml(id)}" open>
+        <summary>
+          <div class="spec-head">
+            <div class="lhs">
+              <h2><span class="num">${escapeHtml(numLabel || n)}</span>${escapeHtml(title)}</h2>
+              ${fileHint ? `<div class="file">${escapeHtml(fileHint)}</div>` : ''}
+            </div>
+            <div class="rhs">${countLabel ? `<b>${escapeHtml(countLabel)}</b>` : ''}</div>
+          </div>
+        </summary>
+        ${intro ? `<p class="spec-intro">${intro}</p>` : ''}
+        ${bodyHtml}
+      </details>`;
+  }
+
+  // Design tokens
+  {
+    let sw = '<div class="swatches">';
+    for (const c of colorList) {
+      sw +=
+        `<div class="swatch"><div class="chip" style="background:${escapeHtml(c.hex)}"></div>` +
+        `<div class="meta-sw"><div class="n">${escapeHtml(c.name)}</div>` +
+        `<div class="h">${escapeHtml(c.hex)}</div></div></div>`;
+    }
+    sw += '</div>';
+    let typo = '<div class="typo">';
+    for (const f of fontSizeEntries) {
+      typo +=
+        `<div class="typo-row"><span class="label">${escapeHtml(f.name)}</span>` +
+        `<span class="sample" style="font-size:${escapeHtml(f.size)}">` +
+        `DFX Services — ${escapeHtml(f.name)} (${escapeHtml(f.size)})</span></div>`;
+    }
+    typo += '</div>';
+    pushSection(
+      'design-tokens',
+      null,
+      'Design-Tokens',
+      'tailwind.config.js',
+      `${colorList.length} Farben · ${fontSizeEntries.length} Schriftgrössen`,
+      'Farbpalette und Typografie aus <code>theme.colors</code> und <code>theme.fontSize</code>.',
+      '<h3>Farben</h3>' + sw + '<h3 style="margin-top:28px">Typografie</h3>' + typo,
+    );
+  }
+
+  // Assets
+  {
+    let ag = '<div class="asset-grid">';
+    for (const a of assetSpecs) {
+      ag +=
+        `<div class="asset-card"><a href="${escapeHtml(a.out)}">` +
+        `<img src="${escapeHtml(a.out)}" alt="${escapeHtml(path.basename(a.src))}" loading="lazy"></a>` +
+        `<div class="an">${escapeHtml(path.basename(a.src))}</div></div>`;
+    }
+    ag += '</div>';
+    pushSection(
+      'assets',
+      null,
+      'Logos & Assets',
+      'src/static/assets · public/logo.png',
+      `${assetSpecs.length} Dateien`,
+      'Committete Logos und Marken-Assets der Services-App.',
+      ag,
+    );
+  }
+
+  // Screenshot groups
+  for (const gKey of groupKeys) {
+    const list = groups.get(gKey);
+    const meta = metadata[gKey];
+    const title = meta && meta.title ? meta.title : gKey;
+    const desc =
+      meta && meta.description
+        ? escapeHtml(meta.description)
+        : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
+    const id = 'group-' + slugify(gKey);
+    let cards = '<div class="tests">';
+    for (const e of list) {
+      const cardId = 'shot-' + slugify(e.title);
+      let badges = '';
+      if (e.project) {
+        badges += `<span class="badge project">${escapeHtml(e.project)}</span>`;
+      }
+      if (e.platform) {
+        badges += `<span class="badge platform">${escapeHtml(e.platform)}</span>`;
+      }
+      cards +=
+        `<div class="test" id="${escapeHtml(cardId)}">` +
+        `<div class="head"><span class="name">${escapeHtml(e.title)}</span>${badges}</div>` +
+        `<div class="img"><a href="${escapeHtml(e.outputPath)}">` +
+        `<img src="${escapeHtml(e.outputPath)}" alt="${escapeHtml(e.title)}" loading="lazy"></a></div>` +
+        `</div>`;
+    }
+    cards += '</div>';
+    pushSection(
+      id,
+      null,
+      title,
+      gKey,
+      `${list.length} Screenshots`,
+      desc,
+      cards,
+    );
+  }
+
+  // Docs
+  {
+    let docsBody = '';
+    for (const d of renderedDocs) {
+      const docId = 'doc-' + slugify(d.title);
+      docsBody +=
+        `<div class="test" id="${escapeHtml(docId)}" style="margin-bottom:22px;grid-column:1/-1">` +
+        `<div class="head"><span class="name">${escapeHtml(d.title)}</span>` +
+        `<a class="badge" href="${escapeHtml(d.out)}">Vollständige Seite</a></div>` +
+        `<div class="doc-preview">${d.body}</div></div>`;
+    }
+    pushSection(
+      'documentation',
+      null,
+      'Dokumentation',
+      'README · CONTRIBUTING · docs/*',
+      `${renderedDocs.length} Dokumente`,
+      'Gerenderte Markdown-Dokumentation aus dem Repository (via <code>marked</code>).',
+      docsBody,
+    );
+  }
+
+  let tocHtml = '<ol>';
+  for (const t of tocItems) {
+    tocHtml +=
+      `<li><a href="#${escapeHtml(t.id)}"><span class="spec-num">${escapeHtml(t.n)}</span>` +
+      `${escapeHtml(t.title.replace(/&amp;/g, '&'))}</a></li>`;
+  }
+  tocHtml += '</ol>';
+
+  const indexHtml =
+    `<!DOCTYPE html>\n<html lang="de">\n<head>\n` +
+    `<meta charset="utf-8">\n` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1">\n` +
+    `<title>DFX Services Handbook</title>\n` +
+    `<style>${css}\n</style>\n` +
+    `</head>\n<body>\n` +
+    `<div class="wrap">\n` +
+    `<aside>\n` +
+    `<div class="brand"><span class="dot"></span> DFX Services</div>\n` +
+    `<p class="brand-sub">Visuelles Handbook</p>\n` +
+    `<div class="toc-label">Inhalt</div>\n` +
+    `<div class="toc-actions">` +
+    `<button type="button" id="toc-expand-all">Alle öffnen</button>` +
+    `<button type="button" id="toc-collapse-all">Alle schliessen</button>` +
+    `</div>\n` +
+    `<nav class="toc">${tocHtml}</nav>\n` +
+    `</aside>\n` +
+    `<main>\n` +
+    `<header class="hero">\n` +
+    `<h1>DFX Services Handbook</h1>\n` +
+    `<p class="lede">Alle committeten Screenshot-Baselines, Design-Tokens und Markdown-Dokumentation der Services-App an einem Ort. Die Seite wird bei jedem Build aus dem Repository erzeugt — neue Baselines erscheinen automatisch.</p>\n` +
+    `<div class="callout info"><p><b>Auto-Discovery.</b> Es gibt keine handgepflegte Mapping-Tabelle. Das Build-Script scannt <code>e2e/screenshots/</code>, Tokens und Docs und erzeugt diese Seite deterministisch.</p></div>\n` +
+    `<div class="meta">` +
+    `<span>Stand: <b>${escapeHtml(gitSha)}</b></span>` +
+    `<span>Screenshots: <b>${screenshotEntries.length}</b></span>` +
+    `<span>Gruppen: <b>${groupKeys.length}</b></span>` +
+    `<span>Dokumente: <b>${renderedDocs.length}</b></span>` +
+    `</div>\n` +
+    `</header>\n` +
+    `<hr class="sep">\n` +
+    sectionsHtml +
+    `</main>\n</div>\n` +
+    `<script>${script}\n</script>\n` +
+    `</body>\n</html>\n`;
+
+  ensureDir(outDir);
+  const indexPath = path.join(outDir, 'index.html');
+  fs.writeFileSync(indexPath, indexHtml, 'utf8');
+
+  // Stable artifact order for deterministic manifest
+  artifacts.sort((a, b) => {
+    const c = sortStrings(a.category, b.category);
+    if (c !== 0) return c;
+    const o = sortStrings(a.outputPath, b.outputPath);
+    if (o !== 0) return o;
+    return sortStrings(a.title, b.title);
+  });
+
+  const manifest = {
+    artifacts,
+    screenshotCount: screenshotEntries.length,
+    gitSha,
+  };
+  const manifestPath = path.join(outDir, 'manifest.json');
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+
+  // Integrity: every local src/href in generated HTML must exist
+  integrityCheck(indexHtml, outDir, 'index.html');
+  for (const d of renderedDocs) {
+    const html = fs.readFileSync(path.join(outDir, d.out), 'utf8');
+    const refs = collectRelativeRefs(html);
+    for (const ref of refs) {
+      const underOut = path.join(path.dirname(path.join(outDir, d.out)), ref);
+      if (
+        !ref.startsWith('/') &&
+        !fs.existsSync(underOut) &&
+        !fs.existsSync(path.join(outDir, ref))
+      ) {
+        // Markdown may reference external or missing images — only fail for
+        // paths that clearly target handbook output.
+        if (/^(screenshots|assets|docs)\//.test(ref)) {
+          fail(`handbook integrity check failed (${d.out}): missing ${ref}`);
+        }
+      }
+    }
+  }
+
+  // Also verify every screenshot/asset outputPath in manifest exists
+  for (const a of artifacts) {
+    if (a.category === 'token') continue;
+    const full = path.join(outDir, a.outputPath);
+    if (!fs.existsSync(full)) {
+      fail(`handbook integrity check failed (manifest): missing ${a.outputPath}`);
+    }
+  }
+
+  console.error(
+    `handbook: wrote ${screenshotEntries.length} screenshots, ` +
+      `${renderedDocs.length} docs, ${assetSpecs.length} assets → ${outDir}`,
+  );
+}
+
+main();

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -77,6 +77,26 @@ function escapeHtml(str) {
     .replace(/'/g, '&#39;');
 }
 
+// Inverse of escapeHtml, for re-reading paths out of already-escaped HTML.
+// Order matters: undo the single-character entities first, &amp; last —
+// otherwise "&amp;lt;" would incorrectly decode to "<".
+function decodeHtmlEntities(str) {
+  return String(str)
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+// URL-encode a relative output path for safe use inside an href/src
+// attribute (spaces, quotes, angle brackets, …). Applied BEFORE escapeHtml —
+// encodeURI leaves '&' and others untouched, so escapeHtml is still needed
+// as a separate step to make the attribute value HTML-safe.
+function encodeHtmlPath(p) {
+  return encodeURI(String(p));
+}
+
 function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
 }
@@ -221,6 +241,19 @@ function flattenColors(obj, prefix, out) {
   return out;
 }
 
+/**
+ * Normalize a Tailwind fontSize theme value to a plain CSS size string.
+ * Tailwind allows either a bare string or a `[size, { lineHeight, ... }]`
+ * tuple. Anything else is not a valid CSS font-size and is skipped — a
+ * future tailwind.config.js shape change must not crash the whole build
+ * over one design token.
+ */
+function normalizeFontSize(value) {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0];
+  return null;
+}
+
 function collectRelativeRefs(html) {
   const refs = [];
   const re = /\b(?:src|href)="([^"]+)"/g;
@@ -242,18 +275,6 @@ function collectRelativeRefs(html) {
     if (cleaned) refs.push(cleaned);
   }
   return refs;
-}
-
-function integrityCheck(html, outDir, label) {
-  const refs = collectRelativeRefs(html);
-  for (const ref of refs) {
-    const full = path.join(outDir, ref);
-    if (!fs.existsSync(full)) {
-      fail(
-        `handbook integrity check failed (${label}): referenced path does not exist: ${ref}`,
-      );
-    }
-  }
 }
 
 function main() {
@@ -372,7 +393,16 @@ function main() {
   const colorList = flattenColors(theme.colors || {}, '', []);
   const fontSizeEntries = Object.keys(theme.fontSize || {})
     .sort(sortStrings)
-    .map((k) => ({ name: k, size: theme.fontSize[k] }));
+    .map((k) => ({ name: k, size: normalizeFontSize(theme.fontSize[k]) }))
+    .filter((e) => {
+      if (e.size === null) {
+        console.error(
+          `handbook warning: tailwind fontSize "${e.name}" has an unsupported shape and was skipped.`,
+        );
+        return false;
+      }
+      return true;
+    });
 
   artifacts.push({
     category: 'token',
@@ -948,9 +978,10 @@ function main() {
   {
     let ag = '<div class="asset-grid">';
     for (const a of assetSpecs) {
+      const assetHref = escapeHtml(encodeHtmlPath(a.out));
       ag +=
-        `<div class="asset-card"><a href="${escapeHtml(a.out)}">` +
-        `<img src="${escapeHtml(a.out)}" alt="${escapeHtml(path.basename(a.src))}" loading="lazy"></a>` +
+        `<div class="asset-card"><a href="${assetHref}">` +
+        `<img src="${assetHref}" alt="${escapeHtml(path.basename(a.src))}" loading="lazy"></a>` +
         `<div class="an">${escapeHtml(path.basename(a.src))}</div></div>`;
     }
     ag += '</div>';
@@ -985,11 +1016,12 @@ function main() {
       if (e.platform) {
         badges += `<span class="badge platform">${escapeHtml(e.platform)}</span>`;
       }
+      const shotHref = escapeHtml(encodeHtmlPath(e.outputPath));
       cards +=
         `<div class="test" id="${escapeHtml(cardId)}">` +
         `<div class="head"><span class="name">${escapeHtml(e.title)}</span>${badges}</div>` +
-        `<div class="img"><a href="${escapeHtml(e.outputPath)}">` +
-        `<img src="${escapeHtml(e.outputPath)}" alt="${escapeHtml(e.title)}" loading="lazy"></a></div>` +
+        `<div class="img"><a href="${shotHref}">` +
+        `<img src="${shotHref}" alt="${escapeHtml(e.title)}" loading="lazy"></a></div>` +
         `</div>`;
     }
     cards += '</div>';
@@ -1012,7 +1044,7 @@ function main() {
       docsBody +=
         `<div class="test" id="${escapeHtml(docId)}" style="margin-bottom:22px;grid-column:1/-1">` +
         `<div class="head"><span class="name">${escapeHtml(d.title)}</span>` +
-        `<a class="badge" href="${escapeHtml(d.out)}">Vollständige Seite</a></div>` +
+        `<a class="badge" href="${escapeHtml(encodeHtmlPath(d.out))}">Vollständige Seite</a></div>` +
         `<div class="doc-preview">${d.body}</div></div>`;
     }
     pushSection(
@@ -1091,12 +1123,25 @@ function main() {
   const manifestPath = path.join(outDir, 'manifest.json');
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
 
-  // Integrity: every local src/href in generated HTML must exist
-  integrityCheck(indexHtml, outDir, 'index.html');
+  // Integrity: every non-token artifact outputPath must exist on disk
+  // (paths from the artifacts list — unescaped originals, not re-parsed HTML).
+  for (const a of artifacts) {
+    if (a.category === 'token') continue;
+    const full = path.join(outDir, a.outputPath);
+    if (!fs.existsSync(full)) {
+      fail(
+        `handbook integrity check failed (manifest): missing ${a.outputPath}` +
+          ` (sourcePath=${a.sourcePath}, title=${a.title})`,
+      );
+    }
+  }
+
+  // Integrity: local src/href in rendered markdown docs (not in artifacts list)
   for (const d of renderedDocs) {
     const html = fs.readFileSync(path.join(outDir, d.out), 'utf8');
     const refs = collectRelativeRefs(html);
-    for (const ref of refs) {
+    for (const rawRef of refs) {
+      const ref = decodeHtmlEntities(rawRef);
       const underOut = path.join(path.dirname(path.join(outDir, d.out)), ref);
       if (
         !ref.startsWith('/') &&
@@ -1109,15 +1154,6 @@ function main() {
           fail(`handbook integrity check failed (${d.out}): missing ${ref}`);
         }
       }
-    }
-  }
-
-  // Also verify every screenshot/asset outputPath in manifest exists
-  for (const a of artifacts) {
-    if (a.category === 'token') continue;
-    const full = path.join(outDir, a.outputPath);
-    if (!fs.existsSync(full)) {
-      fail(`handbook integrity check failed (manifest): missing ${a.outputPath}`);
     }
   }
 

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -58,14 +58,65 @@ function loadMarked() {
 }
 
 const markedModule = loadMarked();
-const markedParse =
-  typeof markedModule.parse === 'function'
-    ? (md) => markedModule.parse(md)
-    : typeof markedModule.marked?.parse === 'function'
-      ? (md) => markedModule.marked.parse(md)
+const MarkedRenderer =
+  typeof markedModule.Renderer === 'function'
+    ? markedModule.Renderer
+    : markedModule.marked && typeof markedModule.marked.Renderer === 'function'
+      ? markedModule.marked.Renderer
       : null;
-if (!markedParse) {
+const markedParseImpl =
+  typeof markedModule.parse === 'function'
+    ? (md, opts) => markedModule.parse(md, opts)
+    : typeof markedModule.marked?.parse === 'function'
+      ? (md, opts) => markedModule.marked.parse(md, opts)
+      : null;
+if (!markedParseImpl) {
   fail('handbook: marked loaded but no parse() API found (expected marked@15).');
+}
+if (!MarkedRenderer) {
+  fail('handbook: marked loaded but no Renderer class found (expected marked@15).');
+}
+
+// GitHub-compatible heading slug: lowercase; strip chars that are not letters
+// (\p{L}), digits (\p{N}), marks (\p{M}), underscore (\p{Pc}), hyphen or space;
+// spaces → '-'. No collapsing of multiple hyphens, no trim of leading/trailing
+// hyphens. Unicode letters/digits/marks/underscore are kept. Duplicate slugs
+// within one document get -1, -2, … (first occurrence keeps the bare slug).
+// Counter is per parse call only.
+function createHeadingRenderer() {
+  const renderer = new MarkedRenderer();
+  const seen = new Map();
+  renderer.heading = function ({ tokens, depth }) {
+    const text = this.parser.parseInline(tokens, this.parser.textRenderer);
+    let slug = String(text)
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\p{M}\p{Pc}\- ]/gu, '')
+      .replace(/ /g, '-');
+    if (seen.has(slug)) {
+      const n = seen.get(slug);
+      seen.set(slug, n + 1);
+      slug = slug + '-' + n;
+    } else {
+      seen.set(slug, 1);
+    }
+    return (
+      '<h' +
+      depth +
+      ' id="' +
+      slug +
+      '">' +
+      this.parser.parseInline(tokens) +
+      '</h' +
+      depth +
+      '>\n'
+    );
+  };
+  return renderer;
+}
+
+// Renderer is created per call so heading-id counters never leak across documents.
+function markedParse(md) {
+  return markedParseImpl(md, { renderer: createHeadingRenderer() });
 }
 
 function escapeHtml(str) {
@@ -98,6 +149,22 @@ function decodeHtmlEntities(str) {
 // step to make the attribute value HTML-safe.
 function encodeHtmlPath(p) {
   return String(p).split('/').map(encodeURIComponent).join('/');
+}
+
+// Inverse of encodeHtmlPath: decodeURIComponent per path segment. decodeURI
+// does not reverse encodeURIComponent for reserved characters (# ? & +), so
+// a filename like hash#tag.png encoded as hash%23tag.png would not round-trip.
+function decodeHtmlPath(p) {
+  return String(p)
+    .split('/')
+    .map((seg) => {
+      try {
+        return decodeURIComponent(seg);
+      } catch {
+        return seg;
+      }
+    })
+    .join('/');
 }
 
 function ensureDir(dir) {
@@ -269,11 +336,12 @@ function collectRelativeRefs(html) {
   // Only match real attribute names, after start-of-string, whitespace or '<'.
   // A word boundary alone also matches after '-' and ':', so data-src,
   // xlink:href and ng-src would be checked as if a browser resolved them.
-  // Both quote styles are accepted: inline HTML in Markdown may use either.
-  const re = /(?:^|[\s<])(?:src|href)=("|')([^"']+)\1/g;
+  // Alternation per quote style so a double-quoted value may contain apostrophes
+  // (e.g. href="docs/Bank's%20Guide.md" from marked link parsing).
+  const re = /(?:^|[\s<])(?:src|href)=(?:"([^"]*)"|'([^']*)')/g;
   let m;
   while ((m = re.exec(html)) !== null) {
-    const raw = m[2];
+    const raw = m[1] !== undefined ? m[1] : m[2];
     if (
       ABSOLUTE_URI_SCHEME_RE.test(raw) ||
       raw.startsWith('//') ||
@@ -281,6 +349,8 @@ function collectRelativeRefs(html) {
     ) {
       continue;
     }
+    // Fragment/query stripped on the still-encoded raw value so a %23 in a
+    // filename is not mistaken for a fragment separator.
     const cleaned = raw.split('#')[0].split('?')[0];
     if (cleaned) refs.push(cleaned);
   }
@@ -1151,8 +1221,9 @@ function main() {
     const html = fs.readFileSync(path.join(outDir, d.out), 'utf8');
     const refs = collectRelativeRefs(html);
     for (const rawRef of refs) {
-      let ref = decodeHtmlEntities(rawRef);
-      try { ref = decodeURI(ref); } catch { /* malformed escape: keep as-is */ }
+      // Segment-wise decodeURIComponent (mirrors encodeHtmlPath); decodeURI
+      // leaves %23/%3F/… intact and would miss files we encoded ourselves.
+      const ref = decodeHtmlPath(decodeHtmlEntities(rawRef));
       const underOut = path.join(path.dirname(path.join(outDir, d.out)), ref);
       if (
         !ref.startsWith('/') &&

--- a/scripts/handbook/docker-entrypoint.sh
+++ b/scripts/handbook/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Create Basic-Auth credentials from env at container start.
+# Credentials must never be baked into the image (public repo).
+set -eu
+
+if [ -z "${HANDBOOK_USER:-}" ] || [ -z "${HANDBOOK_PASSWORD:-}" ]; then
+  echo "handbook: HANDBOOK_USER and HANDBOOK_PASSWORD must both be set and non-empty." >&2
+  echo "handbook: refusing to start without authentication (fail loud)." >&2
+  exit 1
+fi
+
+htpasswd -bBc /etc/nginx/handbook.htpasswd "$HANDBOOK_USER" "$HANDBOOK_PASSWORD"
+
+# Hand PID 1 to nginx so signals (SIGTERM etc.) are delivered correctly.
+exec nginx -g 'daemon off;'

--- a/scripts/handbook/docker-entrypoint.sh
+++ b/scripts/handbook/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ -z "${HANDBOOK_USER:-}" ] || [ -z "${HANDBOOK_PASSWORD:-}" ]; then
   exit 1
 fi
 
-htpasswd -bBc /etc/nginx/handbook.htpasswd "$HANDBOOK_USER" "$HANDBOOK_PASSWORD"
+printf '%s' "$HANDBOOK_PASSWORD" | htpasswd -iBc /etc/nginx/handbook.htpasswd "$HANDBOOK_USER"
 
 # Hand PID 1 to nginx so signals (SIGTERM etc.) are delivered correctly.
 exec nginx -g 'daemon off;'

--- a/scripts/handbook/metadata.json
+++ b/scripts/handbook/metadata.json
@@ -1,0 +1,138 @@
+{
+  "buy-process": {
+    "title": "Kaufprozess",
+    "description": "Buy-Flow: Seitenladezustand, Betragseingabe, Zahlungsdetails und Collection-/Personal-IBAN-Umschaltung."
+  },
+  "buy-bitcoin": {
+    "title": "Bitcoin kaufen",
+    "description": "Buy-Flow für Bitcoin: geladene Seite, Betrag und Wechselkurs."
+  },
+  "buy-lightning": {
+    "title": "Lightning kaufen",
+    "description": "Buy-Flow für Lightning Network."
+  },
+  "buy-lightning-linked": {
+    "title": "Lightning kaufen (verknüpft)",
+    "description": "Buy-Flow für Lightning mit verknüpftem Wallet-Konto."
+  },
+  "buy-ethereum-linked": {
+    "title": "Ethereum kaufen (verknüpft)",
+    "description": "Buy-Flow für Ethereum mit verknüpftem Wallet-Konto."
+  },
+  "buy-crypto-fail-refund": {
+    "title": "Fehlgeschlagener Kauf & Refund",
+    "description": "Transaktionsliste, Details und Refund-Formular nach fehlgeschlagenem Crypto-Kauf."
+  },
+  "sell-process": {
+    "title": "Verkaufsprozess",
+    "description": "Sell-Flow: geladene Seite, Betrag und Sepolia-ETH/USDT-Verkaufsschritte."
+  },
+  "sell-bitcoin": {
+    "title": "Bitcoin verkaufen",
+    "description": "Sell-Flow für Bitcoin."
+  },
+  "sell-lightning": {
+    "title": "Lightning verkaufen",
+    "description": "Sell-Flow für Lightning Network."
+  },
+  "sell-lightning-linked": {
+    "title": "Lightning verkaufen (verknüpft)",
+    "description": "Sell-Flow für Lightning mit verknüpftem Wallet-Konto."
+  },
+  "sell-ethereum-linked": {
+    "title": "Ethereum verkaufen (verknüpft)",
+    "description": "Sell-Flow für Ethereum mit verknüpftem Wallet-Konto."
+  },
+  "sell-complete": {
+    "title": "Verkauf vollständig (MetaMask)",
+    "description": "End-to-End-Sell mit MetaMask: Seite, Betrag, Transaktion und Etherscan-Verifikation für zwei Wallets."
+  },
+  "compliance": {
+    "title": "Compliance",
+    "description": "Compliance-Suche, Trefferliste und Nutzerdossier mit Tabs (KYC, Transaktionen, Bankdaten, Routen)."
+  },
+  "compliance-recommendation-graph": {
+    "title": "Compliance-Empfehlungsgraph",
+    "description": "Initialansicht, Expansion, Load-More und Fehlerzustand des Empfehlungsgraphen."
+  },
+  "compliance-review-kyc-status": {
+    "title": "Compliance KYC-Status",
+    "description": "KYC-Status und AML-Reset in der Compliance-Review."
+  },
+  "realunit-compliance": {
+    "title": "RealUnit Compliance",
+    "description": "RealUnit-spezifische Compliance-Suche und Dossier."
+  },
+  "realunit-support": {
+    "title": "RealUnit Support",
+    "description": "RealUnit-Support: Fallliste und Issue-Detail."
+  },
+  "responsive": {
+    "title": "Responsive Layout",
+    "description": "Homepage, Buy und Login auf Mobile, Tablet und Desktop."
+  },
+  "refund-flow": {
+    "title": "Refund-Flow",
+    "description": "Refund von Transaktionsliste über Adresse und Land bis Submit und Pending-Status."
+  },
+  "safe": {
+    "title": "Safe",
+    "description": "Safe-Portfolio (CHF/USD), Einzahlung, Auszahlung, Swap und PDF-Modal."
+  },
+  "safe-accounts": {
+    "title": "Safe-Konten",
+    "description": "Kontoauswahl: eigenes Konto, Picker, geteilt read-only und mit Schreibmandat."
+  },
+  "user-flows": {
+    "title": "User-Flows",
+    "description": "Übergreifende Nutzerflüsse der Services-App."
+  },
+  "swap-process": {
+    "title": "Swap-Prozess",
+    "description": "Swap-Flow der Services-App."
+  },
+  "swap-btc-to-ln": {
+    "title": "Swap Bitcoin → Lightning",
+    "description": "Manuelle Screenshots: Swap von Bitcoin zu Lightning (geladen und abgeschlossen)."
+  },
+  "swap-ln-to-btc": {
+    "title": "Swap Lightning → Bitcoin",
+    "description": "Manuelle Screenshots: Swap von Lightning zu Bitcoin."
+  },
+  "swap-lightning-url-param": {
+    "title": "Swap Lightning (URL-Parameter)",
+    "description": "Swap-Flow mit Lightning-URL-Parameter."
+  },
+  "login-process": {
+    "title": "Login-Prozess",
+    "description": "Login und Home-Seite nach Authentifizierung."
+  },
+  "signature-login": {
+    "title": "Signatur-Login",
+    "description": "Wallet-Signatur-Login: Home, Buy, Sell, Settings, Transaktionen und Fehlerfall."
+  },
+  "sepolia-dual-wallet": {
+    "title": "Sepolia Dual-Wallet",
+    "description": "ETH- und USDT-Verkauf über zwei Sepolia-Testwallets."
+  },
+  "trading-flows": {
+    "title": "Trading-Flows",
+    "description": "Trading-bezogene End-to-End-Flows."
+  },
+  "support-dashboard": {
+    "title": "Support-Dashboard",
+    "description": "Support-Dashboard: Übersicht und Detailansichten."
+  },
+  "support-dashboard-overview": {
+    "title": "Support-Dashboard Übersicht",
+    "description": "Support-Dashboard-Übersicht und Statistiken."
+  },
+  "subpage": {
+    "title": "Unterseiten",
+    "description": "Buy-, Sell-, Swap- und Transaktions-Unterseiten."
+  },
+  "bug-session": {
+    "title": "Session-Wechsel (Debug)",
+    "description": "Debug-Screenshots zum Session-/Account-Wechsel."
+  }
+}


### PR DESCRIPTION
## What this adds

A static, German-language page that collects **every** committed screenshot baseline in this repo, served by nginx in a Docker image behind Basic Auth at `handbook.app.dfx.swiss`, rebuilt and rolled out on every merge to `develop`.

| Section | Count | Source |
|---|---|---|
| Playwright visual baselines | 154 | `e2e/screenshots/baseline/` |
| Manual E2E captures | 24 | top level of `e2e/screenshots/` |
| Design tokens | colours + type scale | `tailwind.config.js` |
| Logos & assets | 4 | `src/static/assets/`, `public/logo.png` |
| Documentation | 4 | `README.md`, `CONTRIBUTING.md`, `docs/*.md` |

**All 178 baselines are included.** The gitignored `e2e/screenshots/debug/` directory is excluded. Screenshots are grouped by originating spec, with project (`chromium` / `chromium-metamask`) and platform shown as badges derived from the `snapshotPathTemplate` naming convention.

## Discovery instead of a mapping table

The build script **finds** baselines; it does not read a hand-maintained list, and `index.html` is generated rather than edited by hand.

The reason is completeness. A mapping table cannot guarantee it — a baseline nobody remembers to register is silently missing, and nothing fails. Discovery inverts that: anything committed appears on the next build, with no counter to bump anywhere.

This matters more here than in most repos. `CONTRIBUTING.md` states plainly that these visual tests **intentionally do not run in CI** — they are a local development and review aid. So if the handbook silently dropped a baseline, nothing else in the pipeline would notice.

That does remove a safety net, so it is replaced with guards that fail on the cases that actually matter:

- **Floor guard** (`MIN_SCREENSHOTS=170`, current count 178). Falling below is an error; **exceeding it never is** — regenerating or adding a baseline locally can never turn a check red.
- **PNG magic bytes and a minimum size** on every file picked up — catches half-finished checkouts.
- **Referential integrity**: every artefact the build recorded must exist in the output, and every local reference inside the rendered Markdown pages must resolve. The check runs against the unescaped source map rather than by re-parsing the generated HTML — that is what makes it immune to filenames containing HTML metacharacters.

This is the one deliberate difference from the RealUnit handbook. Its exact `-ne` count guards are right *there*, because its baselines are CI-enforced and their number is a maintained quantity. Here they would only produce an unrelated red check for whoever regenerates a screenshot.

## One nginx subtlety worth knowing

`/` is resolved through `try_files`, **not** a redirect. An earlier revision used `return 302 /index.html`, which handed out the redirect **before** Basic Auth was ever evaluated — `return` runs in nginx's rewrite phase, which precedes the access phase where `auth_basic` lives. Resolving through `index`/`try_files` keeps `/` inside the access phase, so it correctly answers `401` without credentials.

## No new dependencies, nothing existing touched

`marked` is installed into an isolated `_handbook-deps/` prefix — `package.json` and the lockfile are untouched. No existing workflow, test, spec, lint config or application code is modified, and no baseline is regenerated or altered.

## Credentials appear nowhere in this repository

The entrypoint builds the htpasswd at container start from `HANDBOOK_USER` / `HANDBOOK_PASSWORD` and **refuses to start** if either is missing, so the handbook cannot come up unauthenticated. Neither the password nor a hash of it exists anywhere in this repo — the values come from the deployment environment only.

## Verification

| Check | Result |
|---|---|
| Build | 178 screenshots, 4 docs, 4 assets |
| Counts vs. source | 154 + 24 = 178, exact match |
| Grouping | `signature-login` complete with 9 files, no orphan group |
| Determinism (two builds, `diff -r`) | byte-identical |
| Referential integrity (artefact map + rendered doc pages) | 0 missing |
| Floor guard (forced underrun) | fails with a clear message, exit 1 |
| Container: `/healthz` | `200` without credentials |
| Container: `/` without credentials | `401` |
| Container: `/` with credentials | `200` |
| Container: `manifest.json` without credentials | `401` |
| Container without credentials set | refuses to start |
| `grep -ri DFX4ever` over the repo | no hits |

## Before this can deploy

The image also needs `HANDBOOK_USER` and `HANDBOOK_PASSWORD` in the target environment — it refuses to start without them, by design. Those are supplied by the accompanying infrastructure change, not by this repository, and no credential appears here.

This repo has no SSH deploy secrets yet — it currently deploys only to Cloudflare Pages. The handbook deploy step needs `DOCKER_USERNAME`, `DOCKER_PASSWORD`, `DEPLOY_PRD_SSH_KEY`, `DEPLOY_PRD_SSH_KNOWN_HOSTS`, `DEPLOY_PRD_USER` and `DEPLOY_PRD_HOST` to be set as repository secrets, and a deploy key to be registered for this repo in the infrastructure configuration. Until then the build and PR check work, but the deploy step will fail at the SSH stage.

## What review changed

The follow-up commits fix defects found after the first version, all reproduced before being fixed:

- **A filename could have blocked the entire build.** The integrity check re-parsed the rendered HTML with a regex and compared the still-escaped attribute value against the filesystem. A baseline named with an ampersand or an angle bracket — both valid on POSIX — therefore failed a check for a file that had been written correctly, aborting the build for all 178 screenshots with a message that pointed nowhere near the cause. It now runs against the unescaped artifact list the HTML was built from, and paths are URL-encoded so spaces and special characters produce valid attribute values. This mattered more than its low likelihood suggests: the whole promise of discovery is that committing a file is enough.
- **A legitimate Tailwind config would have produced broken CSS.** `fontSize` accepts a tuple of value plus line-height object; that shape was stringified straight into the style attribute as `font-size:0.875rem,[object Object]` — no warning, no failure. Values are normalized now, and an unsupported shape is skipped with a warning instead of reaching the output.
- **CodeQL flagged an incomplete URL scheme check.** The enumeration of known prefixes is replaced by matching any absolute URI scheme by grammar, which is the rule this check actually needs — nothing is left to enumerate.
- The entrypoint passes the password to `htpasswd` over stdin rather than as an argument, so it no longer appears in `/proc/<pid>/cmdline`. Fail-loud behaviour is unchanged and re-verified.


- **A file the build wrote could still be reported missing.** Paths are encoded per segment, but the integrity check decoded them with `decodeURI`, which by specification leaves escapes for reserved characters alone — so `%23` never became `#` again and the check failed for a file that exists and that the container serves with 200.
- **`public/logo.png` was missing from the workflow trigger** although the Dockerfile copies it and the build embeds it: changing that file alone would have altered the published handbook without rebuilding it.
- **Attribute matching was both too broad and too narrow.** A word boundary also matches after a hyphen or colon, so `data-src` and `xlink:href` were checked as if a browser resolved them; and only double quotes were accepted, so inline HTML written with single quotes went unchecked.
- **The PR check itself could fail on a correct artefact.** It sampled manifest paths straight into a curl URL, so a filename with `#` or `?` was truncated into a 404 — and it treated only 404 as a failure, letting a 401 or 500 pass as "ok".
