### PR TITLE
fix(compliance): decide the call-queue AML action from the outcome

### DIFF
--- a/src/__tests__/call-queue-outcome-form.test.tsx
+++ b/src/__tests__/call-queue-outcome-form.test.tsx
@@ -1,6 +1,6 @@
-// Component tests for the call-queue outcome form: the AmlCheck action must be offered for
-// transaction-based queue items on all outcomes and must default to Reset when the call was
-// completed, while BuyCrypto reset eligibility remains fail-closed.
+// Component tests for the call-queue outcome form: Completed and Failed decide the transaction on
+// their own, so the AmlCheck selector disappears and the save sends an automatic Reset — but only
+// for the queues the API excludes from its AML recheck. Every other outcome keeps the selector.
 
 jest.mock('@dfx.swiss/react-components', () => ({
   StyledButton: ({ label, onClick, disabled }: any) => (
@@ -16,6 +16,9 @@ jest.mock('src/contexts/settings.context', () => ({
 }));
 
 const mockSaveCallOutcome = jest.fn();
+// The hook module is mocked wholesale (importing it for real pulls @dfx.swiss/react into the test
+// runtime). The queue mapping itself is pinned against the real implementation in
+// compliance-call-outcome.hook.test.ts.
 jest.mock('src/hooks/compliance.hook', () => ({
   CallOutcome: {
     COMPLETED: 'Completed',
@@ -24,6 +27,7 @@ jest.mock('src/hooks/compliance.hook', () => ({
     FAILED: 'Failed',
     REPEAT: 'Repeat',
   },
+  needsExplicitAmlReset: (queue: string) => queue === 'ManualCheckIpCountryPhone',
   useCompliance: () => ({ saveCallOutcome: mockSaveCallOutcome }),
 }));
 
@@ -39,6 +43,8 @@ const OUTCOMES = [
   CallOutcome.REPEAT,
 ];
 
+// ManualCheckIpCountryPhone is the queue whose AML reason the cron skips — the one that needs the
+// automatic reset. ManualCheckPhone is re-evaluated by the cron, so nothing must be sent there.
 const TX_CONTEXT = {
   queue: 'ManualCheckIpCountryPhone',
   userDataId: 1,
@@ -48,6 +54,7 @@ const TX_CONTEXT = {
   amlReason: 'NA',
   buyCryptoResetEligible: true,
 } as any;
+const PLAIN_PHONE_TX_CONTEXT = { ...TX_CONTEXT, queue: 'ManualCheckPhone' };
 const INELIGIBLE_TX_CONTEXT = { ...TX_CONTEXT, buyCryptoResetEligible: false };
 const USER_CONTEXT = { queue: 'UnavailableSuspicious', userDataId: 1 } as any;
 
@@ -71,46 +78,86 @@ function fillAndSubmit(outcome: CallOutcome, amlAction?: string) {
   fireEvent.click(screen.getByRole('button', { name: 'Save Outcome' }));
 }
 
+function submittedAmlAction(): string | undefined {
+  return mockSaveCallOutcome.mock.calls[0][2].amlAction;
+}
+
 describe('CallQueueOutcomeForm AmlCheck action', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSaveCallOutcome.mockResolvedValue({ success: true, completedSteps: ['transaction', 'userData', 'log'] });
   });
 
-  it('offers the AmlCheck action for transaction items and defaults to Reset on Completed', async () => {
+  it.each([[CallOutcome.COMPLETED], [CallOutcome.FAILED]])(
+    'hides the AmlCheck action on %s and resets the transaction on a recheck-blocked queue',
+    async (outcome) => {
+      renderForm(TX_CONTEXT);
+      expect(screen.getAllByRole('combobox')).toHaveLength(3);
+
+      fillAndSubmit(outcome);
+
+      expect(screen.getAllByRole('combobox')).toHaveLength(2);
+      await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+      expect(mockSaveCallOutcome).toHaveBeenCalledWith(TX_CONTEXT, outcome, {
+        signature: 'JR',
+        comment: 'called',
+        amlAction: 'Reset',
+      });
+    },
+  );
+
+  // The plain phone queue is picked up by the AML recheck cron once the check date is written, so
+  // touching the transaction from here would only pre-empt the API's own decision.
+  it.each([[CallOutcome.COMPLETED], [CallOutcome.FAILED]])(
+    'hides the AmlCheck action on %s and sends nothing for a queue the cron re-evaluates',
+    async (outcome) => {
+      renderForm(PLAIN_PHONE_TX_CONTEXT);
+
+      fillAndSubmit(outcome);
+
+      expect(screen.getAllByRole('combobox')).toHaveLength(2);
+      await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+      expect(submittedAmlAction()).toBeUndefined();
+    },
+  );
+
+  it('keeps the selector for open-ended outcomes and submits the choice', async () => {
     renderForm(TX_CONTEXT);
+
+    fillAndSubmit(CallOutcome.UNAVAILABLE, 'Pass');
+
     expect(screen.getAllByRole('combobox')).toHaveLength(3);
-
-    fillAndSubmit(CallOutcome.COMPLETED);
-
-    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
-    expect(mockSaveCallOutcome).toHaveBeenCalledWith(TX_CONTEXT, CallOutcome.COMPLETED, {
-      signature: 'JR',
-      comment: 'called',
-      amlAction: 'Reset',
-    });
-  });
-
-  it('keeps the Reset default overridable', async () => {
-    renderForm(TX_CONTEXT);
-
-    fillAndSubmit(CallOutcome.COMPLETED, '');
-
-    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
-    expect(mockSaveCallOutcome.mock.calls[0][2].amlAction).toBeUndefined();
-  });
-
-  it('resets the AmlCheck action to no change for other outcomes', async () => {
-    renderForm(TX_CONTEXT);
-    const selects = screen.getAllByRole('combobox');
-    fireEvent.change(selects[1], { target: { value: CallOutcome.COMPLETED } });
-    expect((screen.getAllByRole('combobox')[2] as HTMLSelectElement).value).toBe('Reset');
-
-    fillAndSubmit(CallOutcome.UNAVAILABLE);
-
     await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
     expect(mockSaveCallOutcome.mock.calls[0][1]).toBe(CallOutcome.UNAVAILABLE);
-    expect(mockSaveCallOutcome.mock.calls[0][2].amlAction).toBeUndefined();
+    expect(submittedAmlAction()).toBe('Pass');
+  });
+
+  it('defaults an open-ended outcome to no change', async () => {
+    renderForm(TX_CONTEXT);
+
+    fillAndSubmit(CallOutcome.REPEAT);
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(submittedAmlAction()).toBeUndefined();
+  });
+
+  // A choice made before switching to Completed/Failed is not submitted; switching back must not
+  // silently re-arm it either.
+  it('drops a previous selection when the outcome changes', async () => {
+    renderForm(TX_CONTEXT);
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[1], { target: { value: CallOutcome.UNAVAILABLE } });
+    fireEvent.change(screen.getAllByRole('combobox')[2], { target: { value: 'Fail' } });
+
+    fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: CallOutcome.COMPLETED } });
+    fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: CallOutcome.UNAVAILABLE } });
+    expect((screen.getAllByRole('combobox')[2] as HTMLSelectElement).value).toBe('');
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'called' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Outcome' }));
+
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(submittedAmlAction()).toBeUndefined();
   });
 
   it('does not offer an AmlCheck action for user-based queue items', async () => {
@@ -123,7 +170,7 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save Outcome' }));
 
     await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
-    expect(mockSaveCallOutcome.mock.calls[0][2].amlAction).toBeUndefined();
+    expect(submittedAmlAction()).toBeUndefined();
   });
 
   it('hides Reset and explains the prerequisite when BuyCrypto is ineligible', () => {
@@ -131,6 +178,18 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
 
     expect(screen.queryByRole('option', { name: 'Reset' })).not.toBeInTheDocument();
     expect(screen.getByText(/Reset is available only after KYC is set to Check/)).toBeInTheDocument();
+  });
+
+  // Fail-closed: an ineligible BuyCrypto must not silently swallow the automatic reset — the clerk
+  // has to learn that the transaction is still pending.
+  it('warns instead of resetting when the automatic reset is unavailable', async () => {
+    renderForm(INELIGIBLE_TX_CONTEXT);
+
+    fillAndSubmit(CallOutcome.COMPLETED);
+
+    expect(screen.getByText(/excluded from the AML recheck/)).toBeInTheDocument();
+    await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
+    expect(submittedAmlAction()).toBeUndefined();
   });
 
   it('offers Reset when BuyCrypto is eligible', () => {

--- a/src/__tests__/call-queue-outcome-form.test.tsx
+++ b/src/__tests__/call-queue-outcome-form.test.tsx
@@ -180,14 +180,26 @@ describe('CallQueueOutcomeForm AmlCheck action', () => {
     expect(screen.getByText(/Reset is available only after KYC is set to Check/)).toBeInTheDocument();
   });
 
-  // Fail-closed: an ineligible BuyCrypto must not silently swallow the automatic reset — the clerk
-  // has to learn that the transaction is still pending.
-  it('warns instead of resetting when the automatic reset is unavailable', async () => {
+  // Fail-closed: an ineligible BuyCrypto must not silently swallow the automatic reset. Saving a
+  // no-op would report success and navigate away while the transaction stays pending, so the form
+  // blocks the save until KYC is set to Check.
+  it('disables the save and explains why when the automatic reset is unavailable', async () => {
     renderForm(INELIGIBLE_TX_CONTEXT);
 
     fillAndSubmit(CallOutcome.COMPLETED);
 
-    expect(screen.getByText(/excluded from the AML recheck/)).toBeInTheDocument();
+    expect(screen.getByText(/Saving is disabled/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save Outcome' })).toBeDisabled();
+    await waitFor(() => expect(mockSaveCallOutcome).not.toHaveBeenCalled());
+  });
+
+  // The block is specific to the recheck-excluded queue: on a cron-re-evaluated queue the save
+  // legitimately sends nothing, so an ineligible BuyCrypto must not get in the way there.
+  it('keeps the save enabled for an ineligible BuyCrypto on a cron-re-evaluated queue', async () => {
+    renderForm({ ...INELIGIBLE_TX_CONTEXT, queue: 'ManualCheckPhone' });
+
+    fillAndSubmit(CallOutcome.COMPLETED);
+
     await waitFor(() => expect(mockSaveCallOutcome).toHaveBeenCalledTimes(1));
     expect(submittedAmlAction()).toBeUndefined();
   });

--- a/src/__tests__/compliance-call-outcome.hook.test.ts
+++ b/src/__tests__/compliance-call-outcome.hook.test.ts
@@ -27,7 +27,8 @@ jest.mock('@dfx.swiss/react', () => ({
 }));
 
 import { renderHook } from '@testing-library/react';
-import { CallOutcome, useCompliance } from 'src/hooks/compliance.hook';
+import { CallQueue } from '@dfx.swiss/react';
+import { CallOutcome, needsExplicitAmlReset, useCompliance } from 'src/hooks/compliance.hook';
 
 const TX_CONTEXT = {
   queue: 'ManualCheckIpCountryPhone',
@@ -84,5 +85,23 @@ describe('saveCallOutcome write order', () => {
     expect(res.success).toBe(true);
     expect(mockCalls.map((c) => `${c.method} ${c.url}`)).toEqual(['PUT userData/7', 'POST kyc/admin/log']);
     expect(mockCalls[0].data.phoneCallIpCountryCheckDate).toBeUndefined();
+  });
+});
+
+// Which queues need the outcome form to clear the transaction itself: exactly those whose AML reason
+// sits in the API's BlockAmlReasons, because the recheck cron never picks them up again. Everything
+// else must stay untouched so the API keeps deciding.
+describe('needsExplicitAmlReset', () => {
+  it('is true only for the recheck-blocked queue', () => {
+    expect(needsExplicitAmlReset(CallQueue.MANUAL_CHECK_IP_COUNTRY_PHONE)).toBe(true);
+  });
+
+  it.each([
+    [CallQueue.MANUAL_CHECK_PHONE],
+    [CallQueue.MANUAL_CHECK_IP_PHONE],
+    [CallQueue.MANUAL_CHECK_EXTERNAL_ACCOUNT_PHONE],
+    [CallQueue.UNAVAILABLE_SUSPICIOUS],
+  ])('is false for %s', (queue) => {
+    expect(needsExplicitAmlReset(queue)).toBe(false);
   });
 });

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -11,6 +11,11 @@ import {
   useCompliance,
 } from 'src/hooks/compliance.hook';
 
+// Completed and Failed leave nothing to decide: the phone-call status written in the same save
+// already determines the transaction — the API passes it on the check date a completed call writes,
+// and fails it on a failed one (`UserDataFailedCall`).
+const OutcomesImplyingAmlAction: (CallOutcome | '')[] = [CallOutcome.COMPLETED, CallOutcome.FAILED];
+
 interface Props {
   context: CallOutcomeContext;
   availableOutcomes: CallOutcome[];
@@ -36,11 +41,9 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
 
   const hasTx = context.txId != null && context.sourceType != null;
   const buyCryptoResetUnavailable = context.sourceType === 'BuyCrypto' && !context.buyCryptoResetEligible;
-  // Completed and Failed leave nothing to decide: the phone-call status written in the same save
-  // already determines the transaction — the API passes it on the check date a completed call
-  // writes, and fails it on a failed one (`UserDataFailedCall`). So the clerk is not asked for an
-  // AML action there. Every other outcome is open-ended and keeps the selector.
-  const outcomeImpliesAmlAction = outcome === CallOutcome.COMPLETED || outcome === CallOutcome.FAILED;
+  // The clerk is not asked for an AML action on those outcomes; every other one is open-ended and
+  // keeps the selector.
+  const outcomeImpliesAmlAction = OutcomesImplyingAmlAction.includes(outcome);
   const showAmlCheck = hasTx && !outcomeImpliesAmlAction;
   const impliedResetUnavailable =
     hasTx && outcomeImpliesAmlAction && needsExplicitAmlReset(context.queue) && buyCryptoResetUnavailable;

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -7,6 +7,7 @@ import {
   CallOutcome,
   CallOutcomeContext,
   CallOutcomeResult,
+  needsExplicitAmlReset,
   useCompliance,
 } from 'src/hooks/compliance.hook';
 
@@ -34,17 +35,31 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
   }, [clerks]);
 
   const hasTx = context.txId != null && context.sourceType != null;
-  const showAmlCheck = hasTx;
   const buyCryptoResetUnavailable = context.sourceType === 'BuyCrypto' && !context.buyCryptoResetEligible;
+  // Completed and Failed leave nothing to decide: the phone-call status written in the same save
+  // already determines the transaction — the API passes it on the check date a completed call
+  // writes, and fails it on a failed one (`UserDataFailedCall`). So the clerk is not asked for an
+  // AML action there. Every other outcome is open-ended and keeps the selector.
+  const outcomeImpliesAmlAction = outcome === CallOutcome.COMPLETED || outcome === CallOutcome.FAILED;
+  const showAmlCheck = hasTx && !outcomeImpliesAmlAction;
+  const impliedResetUnavailable =
+    hasTx && outcomeImpliesAmlAction && needsExplicitAmlReset(context.queue) && buyCryptoResetUnavailable;
   const canSubmit = !!signature && !!outcome && !!comment.trim() && !isSaving;
 
-  // Some queue reasons (e.g. ManualCheckIpCountryPhone) are excluded from the AML recheck cron, so a
-  // completed call must act on the transaction explicitly. Default to Reset (not Pass): it clears
-  // amlCheck + amlReason so the cron re-runs the FULL AML check, which only passes the tx if no
-  // other errors remain. Overridable.
+  // What the save sends for a Completed/Failed outcome. Only the queues whose AML reason the API
+  // excludes from the recheck cron need an explicit action: their transaction would otherwise stay
+  // Pending forever. Reset (never Pass/Fail) clears amlCheck + amlReason so the cron re-runs the FULL
+  // AML check on the state the call just produced — the API decides the outcome, not the tool.
+  function impliedAmlAction(): AmlAction | undefined {
+    if (!needsExplicitAmlReset(context.queue) || buyCryptoResetUnavailable) return undefined;
+    return 'Reset';
+  }
+
   function handleOutcomeChange(value: CallOutcome | '') {
     setOutcome(value);
-    if (hasTx) setAmlAction(value === CallOutcome.COMPLETED && !buyCryptoResetUnavailable ? 'Reset' : '');
+    // Drop a selection made before the outcome was known; it is not submitted for Completed/Failed
+    // and must not reappear when the clerk switches back to another outcome.
+    setAmlAction('');
   }
 
   async function handleSubmit() {
@@ -54,7 +69,7 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
     const res = await saveCallOutcome(context, outcome, {
       signature,
       comment,
-      amlAction: showAmlCheck && amlAction ? amlAction : undefined,
+      amlAction: hasTx ? (outcomeImpliesAmlAction ? impliedAmlAction() : amlAction || undefined) : undefined,
     });
     setIsSaving(false);
     setResult(res);
@@ -118,6 +133,12 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
             </p>
           )}
         </div>
+      )}
+      {impliedResetUnavailable && (
+        <p className="mt-4 text-xs text-dfxGray-700">
+          This queue is excluded from the AML recheck, and the automatic reset is unavailable for this BuyCrypto: set
+          KYC to Check and reload Compliance review, otherwise the transaction stays pending.
+        </p>
       )}
       <div className="mt-4">
         <label className="block text-sm font-medium text-dfxBlue-800 mb-1">

--- a/src/components/compliance/call-queue/call-queue-outcome-form.tsx
+++ b/src/components/compliance/call-queue/call-queue-outcome-form.tsx
@@ -45,9 +45,11 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
   // keeps the selector.
   const outcomeImpliesAmlAction = OutcomesImplyingAmlAction.includes(outcome);
   const showAmlCheck = hasTx && !outcomeImpliesAmlAction;
+  // Blocks the save: without the reset the transaction stays Pending forever on a recheck-blocked
+  // queue, while the form would still report success and navigate away.
   const impliedResetUnavailable =
     hasTx && outcomeImpliesAmlAction && needsExplicitAmlReset(context.queue) && buyCryptoResetUnavailable;
-  const canSubmit = !!signature && !!outcome && !!comment.trim() && !isSaving;
+  const canSubmit = !!signature && !!outcome && !!comment.trim() && !isSaving && !impliedResetUnavailable;
 
   // What the save sends for a Completed/Failed outcome. Only the queues whose AML reason the API
   // excludes from the recheck cron need an explicit action: their transaction would otherwise stay
@@ -138,9 +140,10 @@ export function CallQueueOutcomeForm({ context, availableOutcomes, clerks, onSav
         </div>
       )}
       {impliedResetUnavailable && (
-        <p className="mt-4 text-xs text-dfxGray-700">
-          This queue is excluded from the AML recheck, and the automatic reset is unavailable for this BuyCrypto: set
-          KYC to Check and reload Compliance review, otherwise the transaction stays pending.
+        <p className="mt-4 text-xs text-primary-red">
+          Saving is disabled: this queue is excluded from the AML recheck and the automatic reset is unavailable for
+          this BuyCrypto, so the transaction would stay pending. Set KYC to Check and reload Compliance review, then
+          save the outcome.
         </p>
       )}
       <div className="mt-4">

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -732,6 +732,17 @@ function checkDateFieldForQueue(queue: CallQueue): string {
   return checkDateFieldByQueue[queue];
 }
 
+// Queues whose AML reason the API keeps out of the recheck cron (`BlockAmlReasons`, which of the
+// call queues covers only ManualCheckIpCountryPhone): a pending transaction there is never
+// re-evaluated on its own, so a saved call outcome has to clear it explicitly. Every other queue is
+// re-run by the cron, which then passes the transaction on a written check date and fails it on a
+// failed call (`UserDataFailedCall`) — in both cases without the tool touching it.
+const cronBlockedQueues: CallQueue[] = [CallQueue.MANUAL_CHECK_IP_COUNTRY_PHONE];
+
+export function needsExplicitAmlReset(queue: CallQueue): boolean {
+  return cronBlockedQueues.includes(queue);
+}
+
 export type AmlAction = 'Pass' | 'Fail' | 'Reset';
 
 export function useCompliance() {


### PR DESCRIPTION
Follow-up to #1225, per review feedback: the AmlCheck selector is offered where there is nothing to decide.

## Problem

#1225 made the AmlCheck action available on every outcome and pre-selected `Reset` on **Completed**. But Completed and Failed already determine what happens to the transaction — the phone-call status written in the same save says it all. Asking the clerk for an AML action there is redundant, invites a wrong pick (`Pass` on a failed call), and is the kind of decision that belongs to the API, not to the tool.

## Change

- **Completed / Failed** → the AmlCheck field is hidden and the action is derived:
  - queue whose AML reason the API keeps out of the recheck cron (`BlockAmlReasons`, i.e. `ManualCheckIpCountryPhone`) → automatic `Reset`,
  - every other queue → nothing is sent; the cron re-evaluates the transaction once the check date is written.
- **Any other outcome** (Unavailable, Suspicious, Repeat) → unchanged: the selector is shown and the chosen action is submitted.
- Switching the outcome clears a previously chosen action, so a stale selection can neither be submitted nor silently reappear.
- The queue predicate lives next to the existing queue mapping in `compliance.hook.ts` as `needsExplicitAmlReset`, so the "which queues does the cron skip" knowledge stays in one place.

`Reset` (never `Pass` or `Fail`) remains the only action the tool sends by itself: it clears `amlCheck` + `amlReason` so the cron re-runs the **full** AML check on the state the call just produced. The decision stays in the API.

Verified against the API for both outcomes: a completed call writes the queue's check date, so the rule that queued the transaction no longer fires and it passes if nothing else is open. A failed call sets `phoneCallStatus = Failed`, and every phone rule in `AmlHelperService` then yields `UserDataFailedCall`, which is mapped to `amlCheck: Fail` / `amlReason: ManualCheckPhoneFailed` — the transaction is failed by the API, exactly as the review asked for.

The queue split is verified the same way: of the call queues, only `ManualCheckIpCountryPhone` carries a reason in `BlockAmlReasons`. `ManualCheckPhone`, `ManualCheckIpPhone` and `ManualCheckExternalAccountPhone` are re-run by the cron on their own, so sending anything for them would only pre-empt the API.

## Fail-closed detail

If the automatic reset is not available for a BuyCrypto on the recheck-blocked queue (KYC not on Check, `buyCryptoResetEligible` false), the save is **disabled** and the form explains the prerequisite. Saving anyway would report success and navigate away while the transaction stays pending forever — in practice this is the common state, not the edge case: the queue members typically sit on `kycStatus = Completed` until the clerk sets Check. On cron-re-evaluated queues an ineligible BuyCrypto does not block the save, since nothing is supposed to be sent there anyway.

## Known behavior on old transactions

For the cron-re-evaluated queues, a transaction whose `amlCheck` has been `Pending` for more than 14 days is failed outright by the API (`aml-helper.service.ts`) before the recheck logic runs. A Completed call on such an old transaction therefore ends in Fail, not in a re-evaluation. That is API behavior this PR does not change, just something to be aware of when working the queue backlog.

## Open question (carried over from #1225)

The recheck path depends on `doAmlCheck`, which is gated by `Process.AUTO_AML_CHECK`. Whether that process is enabled in prod is runtime config — needs a confirmation from @davidleomay/@Yannick1712 before merge, since with this PR there is no manual fallback on Completed/Failed anymore.

## Tests

- Completed and Failed: field hidden, `Reset` on the recheck-blocked queue, nothing on a queue the cron handles.
- Open-ended outcomes: field visible, choice submitted, default no change.
- Outcome switch drops a previous selection.
- User-based queue items never send an action.
- Ineligible BuyCrypto on the recheck-blocked queue: save disabled, reason shown, nothing sent; on a cron-re-evaluated queue the save stays available.
- `needsExplicitAmlReset` pinned against the real `CallQueue` enum: true only for `ManualCheckIpCountryPhone`.
- `npm run test` green, `npm run lint` clean.
