### PR TITLE
Render a missing KYC file date as a gap, not as an invalid date

### DIFF
--- a/src/__tests__/realunit-compliance-kyc-file-date.test.tsx
+++ b/src/__tests__/realunit-compliance-kyc-file-date.test.tsx
@@ -38,13 +38,17 @@ import { render, screen, waitFor, within } from '@testing-library/react';
 import { RealUnitCustomerDetailDto } from 'src/dto/realunit-compliance.dto';
 import RealunitComplianceUserScreen from 'src/screens/realunit-compliance-user.screen';
 
+// Built from local components so the expectations hold in any timezone the suite runs in: the formatter renders in
+// local time, so a UTC literal would fall back to the previous day on negative offsets.
+const FILE_DATE = new Date(2024, 0, 2);
+
 const DOSSIER: RealUnitCustomerDetailDto = {
   id: 7101,
-  created: '2024-01-01T00:00:00.000Z',
+  created: new Date(2024, 0, 1).toISOString(),
   kycStatus: 'Completed',
   checks: {},
   kycFiles: [
-    { uid: 'file-1', type: 'Identification', name: 'passport.pdf', created: '2024-01-02T00:00:00.000Z' },
+    { uid: 'file-1', type: 'Identification', name: 'passport.pdf', created: FILE_DATE.toISOString() },
     // catalogued legacy document — the api could not establish its date and therefore omits the field
     { uid: 'file-2', type: 'NameCheck', name: 'legacy-name-check.pdf' },
   ],

--- a/src/__tests__/realunit-compliance-kyc-file-date.test.tsx
+++ b/src/__tests__/realunit-compliance-kyc-file-date.test.tsx
@@ -1,0 +1,81 @@
+// Component test for the KYC file list of the RealUnit compliance dossier: a file whose document date the api
+// could not establish (`created` omitted) must render as a gap, not as a formatted non-date. Heavy transitive deps
+// are mocked, but the date formatter is the real one — a stub would hide exactly the defect under test.
+
+jest.mock('@dfx.swiss/react', () => ({}));
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { SM: 'sm', LG: 'lg' },
+  StyledLoadingSpinner: () => null,
+}));
+jest.mock('src/components/error-hint', () => ({ ErrorHint: () => null }));
+jest.mock('src/components/support/info-panel', () => ({
+  InfoPanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  InfoRow: () => null,
+  SupportMessageList: () => null,
+}));
+jest.mock('src/hooks/guard.hook', () => ({ useRealunitGuard: () => undefined }));
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_ns: string, key: string) => key }),
+}));
+jest.mock('src/hooks/layout-config.hook', () => ({ useLayoutOptions: () => undefined }));
+jest.mock('react-router-dom', () => ({ useParams: () => ({ id: '7101' }) }));
+jest.mock('src/util/compliance-helpers', () => ({
+  statusBadge: (status: string) => status,
+  // real Swiss formatter: with a missing date it yields 'Invalid Date', which is what the screen must not reach
+  formatDate: (value: string) => jest.requireActual('src/util/utils').formatSwissDate(value),
+}));
+
+const mockGetCustomer = jest.fn();
+jest.mock('src/hooks/realunit-compliance.hook', () => ({
+  useRealunitCompliance: () => ({
+    getCustomer: mockGetCustomer,
+    downloadFile: jest.fn(),
+    downloadDossier: jest.fn(),
+  }),
+}));
+
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { RealUnitCustomerDetailDto } from 'src/dto/realunit-compliance.dto';
+import RealunitComplianceUserScreen from 'src/screens/realunit-compliance-user.screen';
+
+const DOSSIER: RealUnitCustomerDetailDto = {
+  id: 7101,
+  created: '2024-01-01T00:00:00.000Z',
+  kycStatus: 'Completed',
+  checks: {},
+  kycFiles: [
+    { uid: 'file-1', type: 'Identification', name: 'passport.pdf', created: '2024-01-02T00:00:00.000Z' },
+    // catalogued legacy document — the api could not establish its date and therefore omits the field
+    { uid: 'file-2', type: 'NameCheck', name: 'legacy-name-check.pdf' },
+  ],
+  kycSteps: [],
+  transactions: [],
+  bankDatas: [],
+  buyRoutes: [],
+  sellRoutes: [],
+  swapRoutes: [],
+  virtualIbans: [],
+  supportIssues: [],
+};
+
+describe('RealUnit compliance dossier KYC file date', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCustomer.mockResolvedValue(DOSSIER);
+  });
+
+  it('renders the date of a file that has one', async () => {
+    render(<RealunitComplianceUserScreen />);
+
+    const row = await waitFor(() => screen.getByText('passport.pdf').closest('tr') as HTMLElement);
+    expect(within(row).getByText('02.01.2024')).toBeInTheDocument();
+  });
+
+  it('renders a placeholder instead of an invalid date when the file has no date', async () => {
+    render(<RealunitComplianceUserScreen />);
+
+    const row = await waitFor(() => screen.getByText('legacy-name-check.pdf').closest('tr') as HTMLElement);
+    expect(within(row).getByText('-')).toBeInTheDocument();
+    expect(screen.queryByText('Invalid Date')).not.toBeInTheDocument();
+  });
+});

--- a/src/dto/realunit-compliance.dto.ts
+++ b/src/dto/realunit-compliance.dto.ts
@@ -105,7 +105,10 @@ export interface RealUnitKycFileDto {
   uid: string;
   type: string;
   name: string;
-  created: string;
+  // Optional: for legacy documents catalogued from the Spider era the real document date cannot be established, so
+  // the api omits the field instead of substituting the day of the catalogue run — that would present a years-old
+  // document as brand new, and a wrong date is worse than a visible gap.
+  created?: string;
 }
 
 // Reduced KYC step: raw result/comment and the recommendation/referral graph are omitted by the api.

--- a/src/screens/realunit-compliance-user.screen.tsx
+++ b/src/screens/realunit-compliance-user.screen.tsx
@@ -254,7 +254,10 @@ export default function RealunitComplianceUserScreen(): JSX.Element {
         columns={[
           { header: translate('screens/kyc', 'Name'), render: (f) => f.name },
           { header: translate('screens/compliance', 'Type'), render: (f) => f.type },
-          { header: translate('screens/compliance', 'Created'), render: (f) => formatDate(f.created) },
+          {
+            header: translate('screens/compliance', 'Created'),
+            render: (f) => (f.created ? formatDate(f.created) : '-'),
+          },
           {
             header: '',
             render: (f) => (


### PR DESCRIPTION
## Why

[DFXswiss/api#4695](https://github.com/DFXswiss/api/pull/4695) makes `RealUnitKycFileDto.created` optional. A one-off backfill catalogues legacy KYC documents from the Spider era; for a part of them (among others all name checks) the real document date cannot be established. Instead of sending an invented date — it would be the day of the backfill run and would present a years-old document as brand new — the api omits the field.

## What

- `src/dto/realunit-compliance.dto.ts`: `created` becomes optional, with a note on why a document may carry no date.
- `src/screens/realunit-compliance-user.screen.tsx`: the `Created` column of the KYC file list guards the value and falls back to `-`, the same pattern the neighbouring `Birthday` and `Chargeback` columns already use. Without the guard the missing value reaches `formatDate` and the cell renders the literal `Invalid Date` in the RealUnit compliance dossier's file list.
- `src/__tests__/realunit-compliance-kyc-file-date.test.tsx`: renders the dossier with one dated and one undated file. The test uses the real date formatter and was confirmed to fail (`Invalid Date`) without the guard.

## Scope

`RealUnitKycFileDto` is consumed only by the dossier screen and the RealUnit compliance hook. Nothing sorts, filters or exports on this `created` — the dossier ZIP is assembled api-side — so no other call site had to handle the absent value. The `KycFile` type used by the DFX-internal compliance screens is unrelated and untouched.

## Visual baselines

None affected. Per `CONTRIBUTING.md` the Playwright baselines are regenerated when a change affects the UI. This change alters the rendering only when `created` is absent, and the committed dossier baseline (`realunit-compliance-02-dossier`) is taken from a fixture in which every file has a date, so the screenshot is byte-identical. Nothing was regenerated.

## Merge order

Merge together with or after the api PR. Until that one is live the api always sends the field, so this change is a no-op in production.
