### PR TITLE
feat(support): add chargeback dates

### DIFF
--- a/src/components/compliance/transactions-tab.tsx
+++ b/src/components/compliance/transactions-tab.tsx
@@ -455,6 +455,8 @@ export function TransactionsTable({
                                   amlCheck={tx.amlCheck}
                                   amlReason={tx.amlReason}
                                   comment={tx.comment}
+                                  chargebackAllowedDate={tx.chargebackAllowedDate}
+                                  chargebackAllowedDateUser={tx.chargebackAllowedDateUser}
                                   scorechainLink={{
                                     userDataId,
                                     buyCryptoId: tx.buyCryptoId,

--- a/src/hooks/compliance.hook.ts
+++ b/src/hooks/compliance.hook.ts
@@ -21,12 +21,12 @@ import {
 } from '@dfx.swiss/react';
 import { electronicFormatIBAN, isValidIBAN } from 'ibantools';
 import { useMemo } from 'react';
-import { useGuardedApi } from './guarded-api.hook';
 import { CreateMrosDto, MrosListEntry, UpdateMrosDto } from 'src/dto/mros.dto';
 import { CustodyOrderListEntry } from 'src/dto/order.dto';
 import { CreateRecallDto, RecallListEntry } from 'src/dto/recall.dto';
 import { buildKycLogMessage, KycLogResult } from 'src/util/compliance-helpers';
 import { downloadFile, downloadPdfFromString, filenameDateFormat } from 'src/util/utils';
+import { useGuardedApi } from './guarded-api.hook';
 
 export interface RefundFeeData {
   dfx: number;
@@ -536,6 +536,8 @@ export interface TransactionInfo {
   amountInChf?: number;
   amountInEur?: number;
   amlCheck?: string;
+  chargebackAllowedDate?: string;
+  chargebackAllowedDateUser?: string;
   chargebackDate?: string;
   amlReason?: string;
   isCompleted: boolean;

--- a/src/util/compliance-helpers.tsx
+++ b/src/util/compliance-helpers.tsx
@@ -44,12 +44,16 @@ export function TransactionDetailRows({
   amlCheck,
   amlReason,
   comment,
+  chargebackAllowedDate,
+  chargebackAllowedDateUser,
   scorechainLink,
 }: {
   tx: Transaction;
   amlCheck?: string;
   amlReason?: string;
   comment?: string;
+  chargebackAllowedDate?: string;
+  chargebackAllowedDateUser?: string;
   // When set AND `comment` carries the ScorechainHighRisk token, the Comment value deep-links into the
   // customer's Scorechain screenings. Omit it and this component renders exactly as before.
   scorechainLink?: { userDataId: number; buyCryptoId?: number; buyFiatId?: number };
@@ -64,7 +68,10 @@ export function TransactionDetailRows({
       buyFiatId: scorechainLink.buyFiatId,
     });
     navigate(
-      { pathname: `/compliance/scorechain/user/${scorechainLink.userDataId}`, search: value ? `?highlight=${value}` : '' },
+      {
+        pathname: `/compliance/scorechain/user/${scorechainLink.userDataId}`,
+        search: value ? `?highlight=${value}` : '',
+      },
       { clearParams: ['status', 'search'] },
     );
   }
@@ -80,10 +87,7 @@ export function TransactionDetailRows({
           <tr>
             <td className="pr-3 py-0.5 font-medium whitespace-nowrap">Comment:</td>
             <td className="py-0.5">
-              <button
-                className="text-dfxBlue-300 underline hover:text-dfxBlue-800 text-left"
-                onClick={goToScorechain}
-              >
+              <button className="text-dfxBlue-300 underline hover:text-dfxBlue-800 text-left" onClick={goToScorechain}>
                 {comment}
               </button>
             </td>
@@ -130,12 +134,24 @@ export function TransactionDetailRows({
         )}
         {tx.chargebackAmount != null && (
           <>
-            <DetailRow label="Chargeback Amount" value={`${tx.chargebackAmount} ${tx.chargebackAsset ?? ''}`} />
-            <DetailRow label="Chargeback Target" value={tx.chargebackTarget} />
-            <DetailRow label="Chargeback TX" value={tx.chargeBackTxId} url={tx.chargeBackTxUrl} mono />
+            {tx.chargebackAmount != null && (
+              <>
+                <DetailRow label="Chargeback Amount" value={`${tx.chargebackAmount} ${tx.chargebackAsset ?? ''}`} />
+                <DetailRow label="Chargeback Target" value={tx.chargebackTarget} />
+                <DetailRow label="Chargeback TX" value={tx.chargeBackTxId} url={tx.chargeBackTxUrl} mono />
+                <DetailRow
+                  label="Chargeback Date"
+                  value={tx.chargebackDate ? formatSwissDateTimeWithSeconds(tx.chargebackDate) : undefined}
+                />
+              </>
+            )}
             <DetailRow
-              label="Chargeback Date"
-              value={tx.chargebackDate ? formatSwissDateTimeWithSeconds(tx.chargebackDate) : undefined}
+              label="Chargeback Allowed Date Compliance"
+              value={chargebackAllowedDate ? formatSwissDateTimeWithSeconds(chargebackAllowedDate) : undefined}
+            />
+            <DetailRow
+              label="Chargeback Allowed Date User"
+              value={chargebackAllowedDateUser ? formatSwissDateTimeWithSeconds(chargebackAllowedDateUser) : undefined}
             />
           </>
         )}


### PR DESCRIPTION
<h2>feat(support): expose chargebackAllowedDate fields in compliance transaction support info</h2>

<p>
  The compliance search transaction detail view needs to show when a chargeback was authorised
  (and when the user accepted it) before the actual chargeback has been executed.
  These two timestamps were already present on <code>BuyCrypto</code>, <code>BuyFiat</code>,
  and <code>BankTxReturn</code> but were never surfaced through the support API.
</p>

<h3>Changes</h3>
<ul>
  <li>
    <strong>user-data-support.dto.ts</strong> — added <code>chargebackAllowedDate?: Date</code>
    and <code>chargebackAllowedDateUser?: Date</code> to <code>TransactionSupportInfo</code>.
  </li>
  <li>
    <strong>support.service.ts</strong> — mapped both fields in
    <code>toTransactionSupportInfo()</code> from <code>bankTxReturn</code>,
    <code>buyCrypto</code>, and <code>buyFiat</code> (in that precedence order,
    consistent with the existing <code>chargebackDate</code> mapping).
  </li>
</ul>

<hr>

<h3>Release Checklist</h3>

<h4>Pre-Release</h4>
<ul>
  <li><input type="checkbox"> Check migrations
    <ul>
      <li>No database related infos (sqldb-xxx)</li>
      <li>Impact on GS (new/removed columns)</li>
    </ul>
  </li>
  <li><input type="checkbox"> Check for linter errors (in PR)</li>
  <li><input type="checkbox"> Test basic user operations (on <a href="https://dev.app.dfx.swiss">DFX services</a>)
    <ul>
      <li>Login/logout</li>
      <li>Buy/sell payment request</li>
      <li>KYC page</li>
    </ul>
  </li>
</ul>

<h4>Post-Release</h4>
<ul>
  <li>Test basic user operations</li>
  <li>Monitor application insights log</li>
</ul>
