### PR TITLE
Write down the pull-request, coverage, handbook and SDK rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,14 @@ next reviewer then finds the same points again and the work is done twice.
 ### Report every bug you find, including pre-existing ones
 
 A defect in code a pull request touches is reported as a bug — with the same
-severity rating and the same evidence — whether the change introduced it or it
-was already there. Age does not make a defect milder, and "pre-existing" is not
-a category that demotes it to an observation or puts it out of scope.
+rigour and the same evidence — whether the change introduced it or it was
+already there. Age does not make a defect milder, and "pre-existing" is not a
+category that demotes it to an observation or puts it out of scope.
 
 Whether a pre-existing bug is fixed in the same pull request is a separate
-decision and has to be stated explicitly. It is never a reason to leave the bug
-unreported.
+decision, and it follows the same route as any other deferral above: the
+reviewer grants the exception in writing on the pull request. It is never a
+reason to leave the bug unreported.
 
 ## Testing
 
@@ -46,6 +47,12 @@ Partial coverage hides exactly what a code review cannot see either: error paths
 guard clauses and the state combinations a screen only reaches in production. If
 a line genuinely cannot be exercised, delete it rather than excluding it from the
 measurement.
+
+CI runs the suite without a coverage gate, so this is a review gate, not an
+automated one: state the per-file numbers in the pull-request description and let
+the reviewer check them against the diff. Most files in this repository are far
+below the mark today, so touching a long-neglected one means bringing that whole
+file up — plan for it rather than discovering it in review.
 
 ### Visual regression tests (Playwright)
 
@@ -108,7 +115,16 @@ changes has to be represented there:
 If the screen you touched has no baseline yet, create one. That is the case this
 rule exists for, and it does not conflict with "regenerate only the screenshots
 your change actually affects" above: a screen you changed is affected, whether or
-not it had a baseline before.
+not it had a baseline before. `--update-snapshots` writes missing baselines as
+well as changed ones, so the same command covers both. If the screen has no spec
+at all, add one next to the existing specs in `e2e/` — a spec that navigates to
+the screen and takes one `toHaveScreenshot` per visual variant is enough.
+
+The build itself does not enforce any of this: it guards a global screenshot and
+document floor, and a missing `metadata.json` entry only produces a stderr warning
+(see `docs/handbook/README.md`). Completeness is therefore checked in review, and
+`handbook-check.yaml` does not even run on a pull request that only touches
+`src/`, because its path filter does not cover it.
 
 ## API access goes through the SDK
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,16 @@ reason to leave the bug unreported.
 npm run test
 ```
 
-Unit tests run in CI on every pull request and must pass.
+Unit tests run in CI on every pull request and must pass. The one exception is a
+pull request whose head branch is `develop` — the release pull request — where the
+build job is skipped by design.
 
 #### Coverage
 
 Every file a pull request touches must reach **100 % statement, branch, function
-and line coverage**. Measure per file:
+and line coverage**, for every file Jest instruments — the `src/**/*.{ts,tsx,js,jsx}`
+set from `collectCoverageFrom` in `package.json`. Translations, lock files, assets
+and documentation carry no coverage and are not measured. Measure per file:
 
 ```
 npm run test -- --coverage --collectCoverageFrom='src/screens/example.screen.tsx'
@@ -121,10 +125,12 @@ at all, add one next to the existing specs in `e2e/` — a spec that navigates t
 the screen and takes one `toHaveScreenshot` per visual variant is enough.
 
 The build itself does not enforce any of this: it guards a global screenshot and
-document floor, and a missing `metadata.json` entry only produces a stderr warning
-(see `docs/handbook/README.md`). Completeness is therefore checked in review, and
-`handbook-check.yaml` does not even run on a pull request that only touches
-`src/`, because its path filter does not cover it.
+document floor, and a missing `metadata.json` entry is accepted silently, falling
+back to a title derived from the file name — only an orphaned entry, one with no
+matching screenshots, produces a stderr warning (see `docs/handbook/README.md`).
+Completeness is therefore checked in review, and `handbook-check.yaml` does not
+even run on a pull request that touches application code under `src/` and nothing
+else: its path filter covers `src/static/assets/**` and no other path below `src/`.
 
 ## API access goes through the SDK
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,16 +32,17 @@ reason to leave the bug unreported.
 npm run test
 ```
 
-Unit tests run in CI on every pull request and must pass. The one exception is a
-pull request whose head branch is `develop` — the release pull request — where the
-build job is skipped by design.
+Unit tests run in CI on every pull request against `develop` or `main` and must
+pass. The one exception is the release pull request, whose head branch is
+`develop` — there the build job is skipped by design.
 
 #### Coverage
 
 Every file a pull request touches must reach **100 % statement, branch, function
-and line coverage**, for every file Jest instruments — the `src/**/*.{ts,tsx,js,jsx}`
-set from `collectCoverageFrom` in `package.json`. Translations, lock files, assets
-and documentation carry no coverage and are not measured. Measure per file:
+and line coverage**, for every file Jest instruments — `src/**/*.{ts,tsx,js,jsx}`
+minus `src/**/*.d.ts`, the two globs `collectCoverageFrom` in `package.json` is
+built from. Translation JSON, lock files, assets, type declarations and
+documentation carry no coverage and are not measured. Measure per file:
 
 ```
 npm run test -- --coverage --collectCoverageFrom='src/screens/example.screen.tsx'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,28 @@
 # Contributing
 
+## Pull requests
+
+### Every pull request is self-contained
+
+A pull request lands complete or it does not land. Findings raised in review on
+your own pull request are fixed in that pull request — never deferred to a
+follow-up. Deferring a fix requires an explicit exception from the reviewer,
+granted in writing on the pull request.
+
+A follow-up that exists only as an intention is a follow-up nobody opens. The
+next reviewer then finds the same points again and the work is done twice.
+
+### Report every bug you find, including pre-existing ones
+
+A defect in code a pull request touches is reported as a bug — with the same
+severity rating and the same evidence — whether the change introduced it or it
+was already there. Age does not make a defect milder, and "pre-existing" is not
+a category that demotes it to an observation or puts it out of scope.
+
+Whether a pre-existing bug is fixed in the same pull request is a separate
+decision and has to be stated explicitly. It is never a reason to leave the bug
+unreported.
+
 ## Testing
 
 ### Unit tests
@@ -9,6 +32,20 @@ npm run test
 ```
 
 Unit tests run in CI on every pull request and must pass.
+
+#### Coverage
+
+Every file a pull request touches must reach **100 % statement, branch, function
+and line coverage**. Measure per file:
+
+```
+npm run test -- --coverage --collectCoverageFrom='src/screens/example.screen.tsx'
+```
+
+Partial coverage hides exactly what a code review cannot see either: error paths,
+guard clauses and the state combinations a screen only reaches in production. If
+a line genuinely cannot be exercised, delete it rather than excluding it from the
+measurement.
 
 ### Visual regression tests (Playwright)
 
@@ -51,3 +88,38 @@ platform-, font- and data-dependent — needlessly blocking PRs.
   is expected — these tests are not a regression gate and do not fail the build.
 - For a clean, reviewable diff, regenerate on a realistic data set so the
   screenshot isolates your actual UI change rather than seed-data noise.
+
+## Handbook
+
+The handbook assembles the committed Playwright baselines, the design tokens and
+the Markdown documentation of this repository into a static site. It is built by
+`scripts/handbook/build.js`; see `docs/handbook/README.md` for the sources and
+the build guards.
+
+**Handbook coverage must be complete.** Every screen or flow a pull request
+changes has to be represented there:
+
+- a committed Playwright baseline under `e2e/screenshots/baseline/`, covering each
+  visual variant the change introduces — for example both sides of a device or
+  mode split, not just the one you happened to look at, and
+- an entry in `scripts/handbook/metadata.json` giving the flow a title and a
+  description.
+
+If the screen you touched has no baseline yet, create one. That is the case this
+rule exists for, and it does not conflict with "regenerate only the screenshots
+your change actually affects" above: a screen you changed is affected, whether or
+not it had a baseline before.
+
+## API access goes through the SDK
+
+Every API call that `@dfx.swiss/react` already encapsulates must go through the
+SDK. Do not hand-build an API URL and fire it with `fetch`, and do not fall back
+to a raw `useApi().call` for a call the SDK covers.
+
+If an SDK hook is missing a parameter or an endpoint, the fix belongs in the SDK
+(DFXswiss/packages, `packages/react/src/hooks/`): add it additively so existing
+callers stay source-compatible, release it, then consume it here. Working around
+it at the call site moves endpoint knowledge — verb, query shape, response type —
+into this repository, where it goes stale silently: the SDK gets updated, the call
+site does not, and `call<T>()` type-checks against the generic you asserted
+yourself, so nothing fails at build time.

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -91,9 +91,10 @@ Ohne `HANDBOOK_USER` / `HANDBOOK_PASSWORD` startet der Container **nicht** (fail
    `e2e/screenshots/` ablegen und committen.
 2. Nächster Handbook-Build (lokal oder CI nach Merge auf `develop`) nimmt die Datei
    automatisch auf — **keine** Mapping-Tabelle und **keinen** Count anpassen.
-3. Optional: in `scripts/handbook/metadata.json` einen deutschen Titel/Beschreibung für
-   den Gruppenschlüssel ergänzen (Präfix vor `.spec.ts-` bzw. gemeinsamer Präfix bei
-   manuellen Screenshots).
+3. In `scripts/handbook/metadata.json` einen deutschen Titel/Beschreibung für den
+   Gruppenschlüssel ergänzen (Präfix vor `.spec.ts-` bzw. gemeinsamer Präfix bei
+   manuellen Screenshots). Für den Build ist das optional; für einen Screen, den ein
+   PR ändert, verlangt `CONTRIBUTING.md` den Eintrag.
 
 ## Deployment
 

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -107,6 +107,7 @@ Basic-Auth-Zugangsdaten werden **ausschliesslich** in der Deployment-Umgebung al
 `HANDBOOK_USER` / `HANDBOOK_PASSWORD` gesetzt. Weder Klartext noch Hash gehören in
 dieses öffentliche Repository.
 
-Pull Requests (nicht-Draft) laufen durch `.github/workflows/handbook-check.yaml`:
-Image-Build ohne Push, Container-Smoke (`/healthz`, Auth-Wand, Stichprobe aus
-`manifest.json`).
+Pull Requests (nicht-Draft) laufen durch `.github/workflows/handbook-check.yaml`,
+sofern sie einen Pfad aus dessen `paths`-Filter berühren — unterhalb von `src/` ist
+das nur `src/static/assets/**`. Der Check macht einen Image-Build ohne Push und
+einen Container-Smoke (`/healthz`, Auth-Wand, Stichprobe aus `manifest.json`).


### PR DESCRIPTION
## Problem

`CONTRIBUTING.md` described how to run the two test suites and nothing else. Five rules the team applies in review had no written source, so every one of them had to be restated by hand on each pull request — and a rule that only exists in review comments is a rule new contributors cannot follow before their first round.

## Change

Adds the five missing rules to `CONTRIBUTING.md` and leaves the existing testing guidance untouched:

- **A pull request is self-contained.** Findings on your own PR are fixed in that PR; deferring to a follow-up needs an explicit exception granted in writing by the reviewer.
- **Pre-existing bugs are reported as bugs**, with the same rigour and evidence as newly introduced ones. Not fixing one in the same PR routes through that same written exception.
- **100 % coverage on every touched file** — statements, branches, functions and lines — for the set Jest instruments (`src/**/*.{ts,tsx,js,jsx}` minus `src/**/*.d.ts`). Translation JSON, lock files, assets, type declarations and documentation carry no coverage. The per-file command is documented, and so is the fact that CI has no coverage gate: the numbers go into the PR description and the reviewer checks them.
- **Complete handbook coverage**: every changed screen needs a committed Playwright baseline for each visual variant plus an entry in `scripts/handbook/metadata.json`, including the case where the screen has no spec at all yet.
- **API access goes through the SDK**; a missing parameter or endpoint is added in DFXswiss/packages additively, released, then consumed here.

Two corrections fall out of writing this down:

- `docs/handbook/README.md` called the `metadata.json` entry simply "Optional" and described `handbook-check.yaml` as running on every non-draft pull request. It stays optional for the build, is required by review for a changed screen, and the check is path-filtered — below `src/` it covers only `src/static/assets/**`.
- "Unit tests run in CI on every pull request" ignored both the trigger branches (`develop`, `main`) and the release pull request, where `github.head_ref != 'develop'` skips the build job.

The Playwright section is unchanged. The handbook section states explicitly that creating a missing baseline for a screen you touched does not conflict with the existing "regenerate only the screenshots your change actually affects" rule — the first is about coverage that never existed, the second about not sweeping unrelated baselines into the diff.

## Deliberately not changed

- The coverage rule stays at 100 % of the whole touched file. No diff-coverage variant and no ratchet for long-neglected files; the text says plainly what that costs.
- `handbook-check.yaml` keeps its path filter. Extending it would still not verify per-PR coverage — the build has no diff awareness at all — so the document names the gap instead of implying an automated gate that does not exist.

## Verification

- Every factual claim in the text was checked against the source it names: the two `collectCoverageFrom` globs in `package.json`, the trigger branches and skip condition in `.github/workflows/pr.yml`, the path filter in `.github/workflows/handbook-check.yaml`, and the title fallback and orphan warning in `scripts/handbook/build.js`.
- The documented coverage command was run against both screens of the two open payment pull requests and produces the per-file table it promises.
- Docs-only change: no source file is touched, so there is nothing to cover. Both changed files are inside the handbook's Markdown source set, so the handbook build check runs on this PR once it leaves draft.

## Not verified

Nothing beyond the above — the change adds no code.
