### PR TITLE
Stop resolving internal user IDs to display names on the expenses screen

### DIFF
--- a/src/__tests__/dashboard-financial-expenses.screen.test.tsx
+++ b/src/__tests__/dashboard-financial-expenses.screen.test.tsx
@@ -13,10 +13,12 @@ jest.mock('@dfx.swiss/react-components', () => ({
   StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
 }));
 
-const mockChartProps: { options: ApexOptions; series: { name: string; data: number[][] }[] }[] = [];
+type ChartProps = { type: string; height: number; options: ApexOptions; series: { name: string; data: number[][] }[] };
+
+const mockChartProps: ChartProps[] = [];
 jest.mock('react-apexcharts', () => ({
   __esModule: true,
-  default: (props: { options: ApexOptions; series: { name: string; data: number[][] }[] }) => {
+  default: (props: ChartProps) => {
     mockChartProps.push(props);
     return <div data-testid="chart" />;
   },
@@ -50,7 +52,7 @@ type Formatter = (val: number) => string;
 
 // The screen renders CHF amounts through toLocaleString('de-CH'). Building the expectation the same
 // way pins the locale and the digits while staying independent of the group separator the runtime's
-// ICU build emits (U+2019 on current Node, U+0027 on older ones).
+// ICU build emits (U+2019 on ICU 71, U+0027 on ICU 78).
 const chf = (value: number): string => `${value.toLocaleString('de-CH')} CHF`;
 
 // Fractional offsets: the first entry rounds down and the second rounds up, so the Math.round calls
@@ -118,6 +120,14 @@ describe('DashboardFinancialExpensesScreen', () => {
     expect(mockGetFinancialChanges).toHaveBeenCalledWith(undefined, true);
     expect(mockGetRefRecipients).toHaveBeenCalledWith();
 
+    // The headings are what tells the three sections apart once the charts themselves are mocked.
+    expect(screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent)).toEqual([
+      'Referral Expenses (cumulative)',
+      'Referral Recipients',
+      'Binance Expenses (cumulative)',
+      'Blockchain Expenses (cumulative)',
+    ]);
+
     const [ref, binance, blockchain] = mockChartProps.slice(-3);
     const at = timestamps();
 
@@ -138,7 +148,8 @@ describe('DashboardFinancialExpensesScreen', () => {
     expect(ref.options.colors).toEqual(['#ef4444', '#f97316']);
     expect(binance.options.colors).toEqual(['#f97316', '#8b5cf6']);
     expect(blockchain.options.colors).toEqual(['#3b82f6', '#ef4444', '#64748b']);
-    expect(ref.options.chart?.type).toBe('area');
+    // The type prop is what react-apexcharts honours; options.chart.type would be overwritten by it.
+    expect(mockChartProps.slice(-3).map((chart) => chart.type)).toEqual(['area', 'area', 'area']);
   });
 
   it('lists every referral recipient by its raw identifier, in column order', async () => {

--- a/src/__tests__/dashboard-financial-expenses.screen.test.tsx
+++ b/src/__tests__/dashboard-financial-expenses.screen.test.tsx
@@ -1,0 +1,164 @@
+// Component tests for the admin expenses detail screen: the logged-out and loading states, the
+// three cumulative expense charts, the referral recipient table and the shared axis/tooltip
+// formatters. ApexCharts, the SDK session and the screen's hooks are mocked so the screen renders
+// without the app shell; the chart mock records the props so the option formatters can be called.
+
+const mockUseSessionContext = jest.fn();
+jest.mock('@dfx.swiss/react', () => ({
+  useSessionContext: () => mockUseSessionContext(),
+}));
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  SpinnerSize: { LG: 'lg' },
+  StyledLoadingSpinner: () => <div data-testid="loading-spinner" />,
+}));
+
+const mockChartProps: { options: ApexOptions; series: { name: string; data: number[][] }[] }[] = [];
+jest.mock('react-apexcharts', () => ({
+  __esModule: true,
+  default: (props: { options: ApexOptions; series: { name: string; data: number[][] }[] }) => {
+    mockChartProps.push(props);
+    return <div data-testid="chart" />;
+  },
+}));
+
+const mockGetFinancialChanges = jest.fn();
+const mockGetRefRecipients = jest.fn();
+jest.mock('src/hooks/dashboard.hook', () => ({
+  useDashboard: () => ({
+    getFinancialChanges: mockGetFinancialChanges,
+    getRefRecipients: mockGetRefRecipients,
+  }),
+}));
+
+const mockUseAdminGuard = jest.fn();
+jest.mock('src/hooks/guard.hook', () => ({
+  useAdminGuard: () => mockUseAdminGuard(),
+}));
+
+const mockUseLayoutOptions = jest.fn();
+jest.mock('src/hooks/layout-config.hook', () => ({
+  useLayoutOptions: (options: unknown) => mockUseLayoutOptions(options),
+}));
+
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { ApexOptions } from 'apexcharts';
+import { FinancialChangesEntry, RefRewardRecipient } from 'src/dto/dashboard.dto';
+import DashboardFinancialExpensesScreen from 'src/screens/dashboard-financial-expenses.screen';
+
+type Formatter = (val: number) => string;
+
+function entry(timestamp: string, offset: number): FinancialChangesEntry {
+  return {
+    timestamp,
+    total: offset,
+    plus: { total: offset, buyCrypto: offset, buyFiat: offset, paymentLink: offset, trading: offset },
+    minus: {
+      total: offset,
+      bank: offset,
+      kraken: { total: offset, withdraw: offset, trading: offset },
+      ref: { total: offset, amount: offset + 1, fee: offset + 2 },
+      binance: { total: offset, withdraw: offset + 3, trading: offset + 4 },
+      blockchain: { total: offset, txIn: offset + 5, txOut: offset + 6, trading: offset + 7 },
+    },
+  };
+}
+
+const ENTRIES: FinancialChangesEntry[] = [entry('2026-01-01T00:00:00Z', 100), entry('2026-01-02T00:00:00Z', 200)];
+
+// Recipients are identified by their raw userDataId — the screen must never resolve one to a
+// display name (see issue #1281), so the fixture carries nothing but the numbers the API returns.
+const RECIPIENTS: RefRewardRecipient[] = [
+  { userDataId: 42, count: 3, totalChf: 1234.5 },
+  { userDataId: 4711, count: 1, totalChf: 7 },
+];
+
+function timestamps(): number[] {
+  return ENTRIES.map((e) => new Date(e.timestamp).getTime());
+}
+
+describe('DashboardFinancialExpensesScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChartProps.length = 0;
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: true });
+    mockGetFinancialChanges.mockResolvedValue({ entries: ENTRIES });
+    mockGetRefRecipients.mockResolvedValue(RECIPIENTS);
+  });
+
+  it('guards the screen for admins and keeps the spinner while logged out', async () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: false });
+
+    render(<DashboardFinancialExpensesScreen />);
+
+    expect(await screen.findByTestId('loading-spinner')).toBeInTheDocument();
+    expect(mockUseAdminGuard).toHaveBeenCalled();
+    expect(mockUseLayoutOptions).toHaveBeenCalledWith({ title: 'Expenses Detail', noMaxWidth: true });
+    expect(mockGetFinancialChanges).not.toHaveBeenCalled();
+    expect(mockGetRefRecipients).not.toHaveBeenCalled();
+  });
+
+  it('loads the daily sampled changes and renders one chart per expense group', async () => {
+    render(<DashboardFinancialExpensesScreen />);
+
+    await waitFor(() => expect(screen.getAllByTestId('chart')).toHaveLength(3));
+
+    expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+    expect(mockGetFinancialChanges).toHaveBeenCalledWith(undefined, true);
+    expect(mockGetRefRecipients).toHaveBeenCalledWith();
+
+    const [ref, binance, blockchain] = mockChartProps.slice(-3);
+    const at = timestamps();
+
+    expect(ref.series).toEqual([
+      { name: 'Ref Amount', data: [[at[0], 101], [at[1], 201]] },
+      { name: 'Ref Fee', data: [[at[0], 102], [at[1], 202]] },
+    ]);
+    expect(binance.series).toEqual([
+      { name: 'Trading', data: [[at[0], 104], [at[1], 204]] },
+      { name: 'Withdraw', data: [[at[0], 103], [at[1], 203]] },
+    ]);
+    expect(blockchain.series).toEqual([
+      { name: 'TX Out', data: [[at[0], 106], [at[1], 206]] },
+      { name: 'TX In', data: [[at[0], 105], [at[1], 205]] },
+      { name: 'Trading', data: [[at[0], 107], [at[1], 207]] },
+    ]);
+
+    expect(ref.options.colors).toEqual(['#ef4444', '#f97316']);
+    expect(binance.options.colors).toEqual(['#f97316', '#8b5cf6']);
+    expect(blockchain.options.colors).toEqual(['#3b82f6', '#ef4444', '#64748b']);
+    expect(ref.options.chart?.type).toBe('area');
+  });
+
+  it('lists every referral recipient by its raw identifier', async () => {
+    render(<DashboardFinancialExpensesScreen />);
+
+    const rows = await screen.findAllByRole('row');
+
+    expect(rows).toHaveLength(RECIPIENTS.length + 1);
+    expect(within(rows[0]).getByRole('columnheader', { name: 'UserData ID' })).toBeInTheDocument();
+    expect(within(rows[1]).getByRole('cell', { name: '42' })).toBeInTheDocument();
+    expect(within(rows[1]).getByRole('cell', { name: '3' })).toBeInTheDocument();
+    expect(within(rows[1]).getByRole('cell', { name: /^1.234\.5 CHF$/ })).toBeInTheDocument();
+    expect(within(rows[2]).getByRole('cell', { name: '4711' })).toBeInTheDocument();
+    expect(within(rows[2]).getByRole('cell', { name: '7 CHF' })).toBeInTheDocument();
+  });
+
+  it('abbreviates thousands on the y axis and formats tooltip values as CHF', async () => {
+    render(<DashboardFinancialExpensesScreen />);
+
+    await waitFor(() => expect(mockChartProps.length).toBeGreaterThan(0));
+
+    const { yaxis, tooltip } = mockChartProps[0].options;
+    const axisFormatter = (yaxis as unknown as { labels: { formatter: Formatter } }).labels.formatter;
+    const tooltipFormatter = (tooltip?.y as unknown as { formatter: Formatter }).formatter;
+
+    expect(axisFormatter(1000)).toBe('1k');
+    expect(axisFormatter(12500)).toBe('13k');
+    expect(axisFormatter(999.6)).toBe('1000');
+    expect(axisFormatter(0)).toBe('0');
+
+    expect(tooltipFormatter(1234.5)).toMatch(/^1.235 CHF$/);
+    expect(tooltipFormatter(12)).toBe('12 CHF');
+  });
+});

--- a/src/__tests__/dashboard-financial-expenses.screen.test.tsx
+++ b/src/__tests__/dashboard-financial-expenses.screen.test.tsx
@@ -48,6 +48,13 @@ import DashboardFinancialExpensesScreen from 'src/screens/dashboard-financial-ex
 
 type Formatter = (val: number) => string;
 
+// The screen renders CHF amounts through toLocaleString('de-CH'). Building the expectation the same
+// way pins the locale and the digits while staying independent of the group separator the runtime's
+// ICU build emits (U+2019 on current Node, U+0027 on older ones).
+const chf = (value: number): string => `${value.toLocaleString('de-CH')} CHF`;
+
+// Fractional offsets: the first entry rounds down and the second rounds up, so the Math.round calls
+// in the series builders are what makes the expected integers come out.
 function entry(timestamp: string, offset: number): FinancialChangesEntry {
   return {
     timestamp,
@@ -64,10 +71,10 @@ function entry(timestamp: string, offset: number): FinancialChangesEntry {
   };
 }
 
-const ENTRIES: FinancialChangesEntry[] = [entry('2026-01-01T00:00:00Z', 100), entry('2026-01-02T00:00:00Z', 200)];
+const ENTRIES: FinancialChangesEntry[] = [entry('2026-01-01T00:00:00Z', 100.4), entry('2026-01-02T00:00:00Z', 200.6)];
 
-// Recipients are identified by their raw userDataId — the screen must never resolve one to a
-// display name (see issue #1281), so the fixture carries nothing but the numbers the API returns.
+// RefRewardRecipient carries no name field, and the screen must not invent one (see issue #1281):
+// every row renders the identifier the API returned. The two ids are invented for this fixture.
 const RECIPIENTS: RefRewardRecipient[] = [
   { userDataId: 42, count: 3, totalChf: 1234.5 },
   { userDataId: 4711, count: 1, totalChf: 7 },
@@ -75,6 +82,10 @@ const RECIPIENTS: RefRewardRecipient[] = [
 
 function timestamps(): number[] {
   return ENTRIES.map((e) => new Date(e.timestamp).getTime());
+}
+
+function cellTexts(row: HTMLElement): (string | null)[] {
+  return within(row).getAllByRole('cell').map((cell) => cell.textContent);
 }
 
 describe('DashboardFinancialExpensesScreen', () => {
@@ -111,17 +122,17 @@ describe('DashboardFinancialExpensesScreen', () => {
     const at = timestamps();
 
     expect(ref.series).toEqual([
-      { name: 'Ref Amount', data: [[at[0], 101], [at[1], 201]] },
-      { name: 'Ref Fee', data: [[at[0], 102], [at[1], 202]] },
+      { name: 'Ref Amount', data: [[at[0], 101], [at[1], 202]] },
+      { name: 'Ref Fee', data: [[at[0], 102], [at[1], 203]] },
     ]);
     expect(binance.series).toEqual([
-      { name: 'Trading', data: [[at[0], 104], [at[1], 204]] },
-      { name: 'Withdraw', data: [[at[0], 103], [at[1], 203]] },
+      { name: 'Trading', data: [[at[0], 104], [at[1], 205]] },
+      { name: 'Withdraw', data: [[at[0], 103], [at[1], 204]] },
     ]);
     expect(blockchain.series).toEqual([
-      { name: 'TX Out', data: [[at[0], 106], [at[1], 206]] },
-      { name: 'TX In', data: [[at[0], 105], [at[1], 205]] },
-      { name: 'Trading', data: [[at[0], 107], [at[1], 207]] },
+      { name: 'TX Out', data: [[at[0], 106], [at[1], 207]] },
+      { name: 'TX In', data: [[at[0], 105], [at[1], 206]] },
+      { name: 'Trading', data: [[at[0], 107], [at[1], 208]] },
     ]);
 
     expect(ref.options.colors).toEqual(['#ef4444', '#f97316']);
@@ -130,18 +141,34 @@ describe('DashboardFinancialExpensesScreen', () => {
     expect(ref.options.chart?.type).toBe('area');
   });
 
-  it('lists every referral recipient by its raw identifier', async () => {
+  it('lists every referral recipient by its raw identifier, in column order', async () => {
     render(<DashboardFinancialExpensesScreen />);
 
     const rows = await screen.findAllByRole('row');
 
     expect(rows).toHaveLength(RECIPIENTS.length + 1);
-    expect(within(rows[0]).getByRole('columnheader', { name: 'UserData ID' })).toBeInTheDocument();
-    expect(within(rows[1]).getByRole('cell', { name: '42' })).toBeInTheDocument();
-    expect(within(rows[1]).getByRole('cell', { name: '3' })).toBeInTheDocument();
-    expect(within(rows[1]).getByRole('cell', { name: /^1.234\.5 CHF$/ })).toBeInTheDocument();
-    expect(within(rows[2]).getByRole('cell', { name: '4711' })).toBeInTheDocument();
-    expect(within(rows[2]).getByRole('cell', { name: '7 CHF' })).toBeInTheDocument();
+    expect(within(rows[0]).getAllByRole('columnheader').map((cell) => cell.textContent)).toEqual([
+      'UserData ID',
+      'Payouts',
+      'Total (CHF)',
+    ]);
+    expect(cellTexts(rows[1])).toEqual(['42', '3', chf(1234.5)]);
+    expect(cellTexts(rows[2])).toEqual(['4711', '1', chf(7)]);
+  });
+
+  it('starts fetching once the session becomes logged in', async () => {
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: false });
+    const { rerender } = render(<DashboardFinancialExpensesScreen />);
+
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    expect(mockGetFinancialChanges).not.toHaveBeenCalled();
+
+    mockUseSessionContext.mockReturnValue({ isLoggedIn: true });
+    rerender(<DashboardFinancialExpensesScreen />);
+
+    await waitFor(() => expect(screen.getAllByTestId('chart')).toHaveLength(3));
+    expect(mockGetFinancialChanges).toHaveBeenCalledTimes(1);
+    expect(mockGetRefRecipients).toHaveBeenCalledTimes(1);
   });
 
   it('abbreviates thousands on the y axis and formats tooltip values as CHF', async () => {
@@ -158,7 +185,7 @@ describe('DashboardFinancialExpensesScreen', () => {
     expect(axisFormatter(999.6)).toBe('1000');
     expect(axisFormatter(0)).toBe('0');
 
-    expect(tooltipFormatter(1234.5)).toMatch(/^1.235 CHF$/);
+    expect(tooltipFormatter(1234.5)).toBe(chf(1235));
     expect(tooltipFormatter(12)).toBe('12 CHF');
   });
 });

--- a/src/screens/dashboard-financial-expenses.screen.tsx
+++ b/src/screens/dashboard-financial-expenses.screen.tsx
@@ -4,11 +4,6 @@ import { ApexOptions } from 'apexcharts';
 import { useEffect, useMemo, useState } from 'react';
 import Chart from 'react-apexcharts';
 import { FinancialChangesEntry, RefRewardRecipient } from 'src/dto/dashboard.dto';
-
-const KNOWN_USERS: Record<number, string> = {
-  8938: 'Fab',
-  187402: 'Cake Wallet',
-};
 import { useDashboard } from 'src/hooks/dashboard.hook';
 import { useAdminGuard } from 'src/hooks/guard.hook';
 import { useLayoutOptions } from 'src/hooks/layout-config.hook';
@@ -153,7 +148,7 @@ export default function DashboardFinancialExpensesScreen(): JSX.Element {
             <tbody>
               {recipients.map((r) => (
                 <tr key={r.userDataId} className="border-b border-gray-100 hover:bg-gray-50">
-                  <td className="py-1.5 px-3">{KNOWN_USERS[r.userDataId] ?? r.userDataId}</td>
+                  <td className="py-1.5 px-3">{r.userDataId}</td>
                   <td className="py-1.5 px-3 text-right">{r.count}</td>
                   <td className="py-1.5 px-3 text-right font-medium">
                     {Number(r.totalChf).toLocaleString('de-CH')} CHF


### PR DESCRIPTION
Closes #1281.

The expenses screen resolved internal `userDataId` values to display names through a hardcoded table and rendered the result in the referral-recipients column. This repository is public, so the table published a correlation between internal account identifiers and the parties behind them — readable from the source alone, without any access to the application.

The map is gone and the cell now renders `r.userDataId`. Every recipient outside the table already rendered as a raw identifier, so this is the path the screen took for all but two rows, and nothing else about the screen changes. The endpoint behind it (`dashboard/financial/ref-recipients`, `AuthGuard + RoleGuard(ADMIN) + UserActiveGuard`) never returned a name; the disclosure existed only in the source.

If display names are wanted on this screen, they belong in that response, behind the guard that already protects it — not hardcoded in a public frontend. That is a separate decision and does not block this change.

## Coverage

The screen had no test at all, so this pull request brings the whole file up, as `CONTRIBUTING.md` requires.

```
npm run test -- --coverage --collectCoverageFrom='src/screens/dashboard-financial-expenses.screen.tsx'
```

| File | % Stmts | % Branch | % Funcs | % Lines |
| --- | --- | --- | --- | --- |
| `dashboard-financial-expenses.screen.tsx` | 100 | 100 | 100 | 100 |

`src/__tests__/dashboard-financial-expenses.screen.test.tsx` mocks ApexCharts, the SDK session and the screen's hooks; the chart mock records the props, which is the only way to reach the option formatters, since neither they nor the chart components are exported. Five tests cover the logged-out guard path and the spinner, the transition to logged in, the three chart series builders, the recipient table and both sides of the axis formatter's threshold.

Coverage alone says little about whether a test holds anything in place, so I checked it against mutations of the screen. Each of these fails the suite: dropping `Math.round` from the series builders, switching the CHF locale away from `de-CH`, emptying the effect's dependency array, swapping the first two table columns, swapping two chart headings, changing the chart type, and re-introducing an id-to-name lookup for an identifier the fixture uses.

That last one is worth stating precisely: the test can only catch a re-introduced lookup for identifiers it feeds in. It is not a general guard against the map coming back, and no unit-level fixture can be one without committing the identifiers this pull request removes. If a standing guard is wanted, it belongs in a repository-level check and is a separate decision.

Full suite and lint are green (74 suites, 795 tests), and `build:dev` compiles.

## Handbook coverage — exception requested

`CONTRIBUTING.md` addresses this exact case: *"Every screen or flow a pull request changes has to be represented there"*, and *"If the screen you touched has no baseline yet, create one. That is the case this rule exists for."* This screen has no spec, no baseline and no `metadata.json` entry — nor has any other screen under `/dashboard/**` — and this pull request adds none. So the handbook stays incomplete for this screen, and I am asking for that in writing rather than passing over it.

What the rule would cost here:

- The screen is behind `useAdminGuard`, so a spec needs the API, its database and an admin-seeded account running locally.
- A database created by the documented `npm run setup` has no referral payout rows, so the committed baseline would show an empty table. That is still a valid handbook page for a screen that has none today — but it documents nothing about *this* change, because before and after are identical.
- Making it show the change means seeding payouts for exactly the two identifiers this pull request removes, then committing that rendered payout table as a PNG into a public repository that the handbook republishes. That is the data class the change exists to remove.

So the choice is an empty-state page at the cost of standing up the admin stack, or a content-bearing page at the cost of re-committing what #1281 is about. I have taken neither, and the decision is yours: `handbook-check.yaml` does not run on a pull request that only touches `src/**`, and a `metadata.json` entry without a matching screenshot is an orphan the handbook build warns about, so nothing here is enforced automatically.

If you want the empty-state page, say so and I will add the spec, the baseline and the `metadata.json` entry in this pull request rather than in a follow-up.

## Pre-existing bug in this file (reported, not fixed)

The data load is `Promise.all([...]).then(...).finally(...)` with no `.catch`. If either call rejects, the rejection goes unhandled, the loading flag is cleared anyway, and the admin sees three empty charts and an empty table that look exactly like a successful load with no data. `dashboard-financial-history.screen.tsx` has the same gap; `dashboard-financial-liquidity.screen.tsx` already guards it with `.catch(() => undefined)`.

Filed as #1283 so the report outlives this pull request. Fixing it is a behaviour change unrelated to the disclosure this pull request closes, and doing it properly means deciding what a failed load should look like across all three screens — tell me if you want it here instead and I will add it with its test. The new test deliberately does not pin the current failure behaviour, since asserting it would write today's bug into the suite.

## Residue in the git history

Removing the table from `HEAD` does not remove it from the history of a public repository; it has been there since #978 (2026-03-19). Whether that is worth a history rewrite is a maintainer decision and deliberately not part of this pull request.
