### PR TITLE
fix: use native Clipboard API in useClipboard, fall back to copy-to-clipboard

### DIFF
--- a/src/__tests__/clipboard.hook.test.ts
+++ b/src/__tests__/clipboard.hook.test.ts
@@ -1,8 +1,11 @@
 import { renderHook, act } from '@testing-library/react';
+import copyToClipboard from 'copy-to-clipboard';
 import { useClipboard } from '../hooks/clipboard.hook';
 
 // Mock copy-to-clipboard
 jest.mock('copy-to-clipboard', () => jest.fn());
+
+const copyToClipboardMock = copyToClipboard as jest.Mock;
 
 describe('useClipboard', () => {
   beforeEach(() => {
@@ -56,11 +59,48 @@ describe('useClipboard', () => {
 
   it('should not copy if text is empty', () => {
     const { result } = renderHook(() => useClipboard());
-    
+
     act(() => {
       result.current.copy('');
     });
-    
+
     expect(result.current.isCopying).toBe(false);
+  });
+
+  describe('when navigator.clipboard.writeText is available', () => {
+    const writeText = jest.fn();
+
+    beforeEach(() => {
+      copyToClipboardMock.mockClear();
+      writeText.mockReset();
+      Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+    });
+
+    afterEach(() => {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    });
+
+    it('should copy via navigator.clipboard.writeText instead of copy-to-clipboard', async () => {
+      writeText.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useClipboard());
+
+      await act(async () => {
+        result.current.copy('test text');
+      });
+
+      expect(writeText).toHaveBeenCalledWith('test text');
+      expect(copyToClipboardMock).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to copy-to-clipboard when writeText rejects', async () => {
+      writeText.mockRejectedValue(new Error('denied'));
+      const { result } = renderHook(() => useClipboard());
+
+      await act(async () => {
+        result.current.copy('test text');
+      });
+
+      expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
+    });
   });
 });

--- a/src/__tests__/clipboard.hook.test.ts
+++ b/src/__tests__/clipboard.hook.test.ts
@@ -102,5 +102,66 @@ describe('useClipboard', () => {
 
       expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
     });
+
+    it('should not reset isCopying until the write settles', async () => {
+      let resolveWrite!: () => void;
+      writeText.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+      );
+      const { result } = renderHook(() => useClipboard());
+
+      act(() => {
+        result.current.copy('test text');
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(result.current.isCopying).toBe(true);
+
+      await act(async () => {
+        resolveWrite();
+        await Promise.resolve();
+      });
+      expect(result.current.isCopying).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(result.current.isCopying).toBe(false);
+    });
+
+    it('should not reset isCopying until the copy-to-clipboard fallback runs', async () => {
+      let rejectWrite!: (reason: unknown) => void;
+      writeText.mockReturnValue(
+        new Promise<void>((_, reject) => {
+          rejectWrite = reject;
+        }),
+      );
+      const { result } = renderHook(() => useClipboard());
+
+      act(() => {
+        result.current.copy('test text');
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(result.current.isCopying).toBe(true);
+
+      await act(async () => {
+        rejectWrite(new Error('denied'));
+        await Promise.resolve();
+      });
+      expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
+      expect(result.current.isCopying).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(result.current.isCopying).toBe(false);
+    });
   });
 });

--- a/src/__tests__/clipboard.hook.test.ts
+++ b/src/__tests__/clipboard.hook.test.ts
@@ -133,6 +133,25 @@ describe('useClipboard', () => {
       expect(result.current.isCopying).toBe(false);
     });
 
+    it('should still reset isCopying when the copy-to-clipboard fallback throws', async () => {
+      writeText.mockRejectedValue(new Error('denied'));
+      copyToClipboardMock.mockImplementationOnce(() => {
+        throw new Error('copy failed');
+      });
+      const { result } = renderHook(() => useClipboard());
+
+      await act(async () => {
+        result.current.copy('test text');
+      });
+
+      expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(result.current.isCopying).toBe(false);
+    });
+
     it('should not reset isCopying until the copy-to-clipboard fallback runs', async () => {
       let rejectWrite!: (reason: unknown) => void;
       writeText.mockReturnValue(

--- a/src/__tests__/clipboard.hook.test.ts
+++ b/src/__tests__/clipboard.hook.test.ts
@@ -183,4 +183,26 @@ describe('useClipboard', () => {
       expect(result.current.isCopying).toBe(false);
     });
   });
+
+  describe('when navigator.clipboard is unavailable', () => {
+    beforeEach(() => {
+      copyToClipboardMock.mockClear();
+      Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
+    });
+
+    afterEach(() => {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    });
+
+    it('should copy synchronously via copy-to-clipboard', () => {
+      const { result } = renderHook(() => useClipboard());
+
+      act(() => {
+        result.current.copy('test text');
+      });
+
+      expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
+      expect(result.current.isCopying).toBe(true);
+    });
+  });
 });

--- a/src/__tests__/clipboard.hook.test.ts
+++ b/src/__tests__/clipboard.hook.test.ts
@@ -23,37 +23,37 @@ describe('useClipboard', () => {
 
   it('should set isCopying to true when copying', () => {
     const { result } = renderHook(() => useClipboard());
-    
+
     act(() => {
       result.current.copy('test text');
     });
-    
+
     expect(result.current.isCopying).toBe(true);
   });
 
   it('should reset isCopying after 500ms', () => {
     const { result } = renderHook(() => useClipboard());
-    
+
     act(() => {
       result.current.copy('test text');
     });
-    
+
     expect(result.current.isCopying).toBe(true);
-    
+
     act(() => {
       jest.advanceTimersByTime(500);
     });
-    
+
     expect(result.current.isCopying).toBe(false);
   });
 
   it('should not copy if text is undefined', () => {
     const { result } = renderHook(() => useClipboard());
-    
+
     act(() => {
       result.current.copy(undefined);
     });
-    
+
     expect(result.current.isCopying).toBe(false);
   });
 

--- a/src/__tests__/clipboard.hook.test.ts
+++ b/src/__tests__/clipboard.hook.test.ts
@@ -133,23 +133,35 @@ describe('useClipboard', () => {
       expect(result.current.isCopying).toBe(false);
     });
 
-    it('should still reset isCopying when the copy-to-clipboard fallback throws', async () => {
+    it('should swallow the rejection and reset isCopying when the copy-to-clipboard fallback throws', async () => {
       writeText.mockRejectedValue(new Error('denied'));
       copyToClipboardMock.mockImplementationOnce(() => {
         throw new Error('copy failed');
       });
-      const { result } = renderHook(() => useClipboard());
+      const onUnhandledRejection = jest.fn();
+      process.on('unhandledRejection', onUnhandledRejection);
 
-      await act(async () => {
-        result.current.copy('test text');
-      });
+      try {
+        const { result } = renderHook(() => useClipboard());
 
-      expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
+        await act(async () => {
+          result.current.copy('test text');
+        });
 
-      act(() => {
-        jest.advanceTimersByTime(500);
-      });
-      expect(result.current.isCopying).toBe(false);
+        expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
+
+        act(() => {
+          jest.advanceTimersByTime(500);
+        });
+        expect(result.current.isCopying).toBe(false);
+
+        jest.useRealTimers();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection);
+      }
+
+      expect(onUnhandledRejection).not.toHaveBeenCalled();
     });
 
     it('should not reset isCopying until the copy-to-clipboard fallback runs', async () => {
@@ -203,6 +215,11 @@ describe('useClipboard', () => {
 
       expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
       expect(result.current.isCopying).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(result.current.isCopying).toBe(false);
     });
   });
 });

--- a/src/__tests__/clipboard.hook.test.ts
+++ b/src/__tests__/clipboard.hook.test.ts
@@ -69,15 +69,21 @@ describe('useClipboard', () => {
 
   describe('when navigator.clipboard.writeText is available', () => {
     const writeText = jest.fn();
+    let originalClipboardDescriptor: PropertyDescriptor | undefined;
 
     beforeEach(() => {
       copyToClipboardMock.mockClear();
       writeText.mockReset();
+      originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
       Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
     });
 
     afterEach(() => {
-      delete (navigator as { clipboard?: unknown }).clipboard;
+      if (originalClipboardDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+      } else {
+        delete (navigator as { clipboard?: unknown }).clipboard;
+      }
     });
 
     it('should copy via navigator.clipboard.writeText instead of copy-to-clipboard', async () => {
@@ -197,13 +203,20 @@ describe('useClipboard', () => {
   });
 
   describe('when navigator.clipboard is unavailable', () => {
+    let originalClipboardDescriptor: PropertyDescriptor | undefined;
+
     beforeEach(() => {
       copyToClipboardMock.mockClear();
+      originalClipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
       Object.defineProperty(navigator, 'clipboard', { value: undefined, configurable: true });
     });
 
     afterEach(() => {
-      delete (navigator as { clipboard?: unknown }).clipboard;
+      if (originalClipboardDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', originalClipboardDescriptor);
+      } else {
+        delete (navigator as { clipboard?: unknown }).clipboard;
+      }
     });
 
     it('should copy synchronously via copy-to-clipboard', () => {
@@ -215,6 +228,26 @@ describe('useClipboard', () => {
 
       expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
       expect(result.current.isCopying).toBe(true);
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(result.current.isCopying).toBe(false);
+    });
+
+    it('should still reset isCopying when copy-to-clipboard throws', () => {
+      copyToClipboardMock.mockImplementationOnce(() => {
+        throw new Error('copy failed');
+      });
+      const { result } = renderHook(() => useClipboard());
+
+      expect(() => {
+        act(() => {
+          result.current.copy('test text');
+        });
+      }).toThrow('copy failed');
+
+      expect(copyToClipboardMock).toHaveBeenCalledWith('test text');
 
       act(() => {
         jest.advanceTimersByTime(500);

--- a/src/hooks/clipboard.hook.ts
+++ b/src/hooks/clipboard.hook.ts
@@ -18,7 +18,8 @@ export function useClipboard(): ClipboardInterface {
       navigator.clipboard
         .writeText(text)
         .catch(() => copy(text))
-        .finally(resetIsCopying);
+        .finally(resetIsCopying)
+        .catch(() => undefined); // a throwing fallback must not reach the global unhandledrejection reporter
     } else {
       copy(text);
       resetIsCopying();

--- a/src/hooks/clipboard.hook.ts
+++ b/src/hooks/clipboard.hook.ts
@@ -11,7 +11,12 @@ export function useClipboard(): ClipboardInterface {
   function copyHelper(text?: string): void {
     if (!text) return;
     setIsCopying(true);
-    copy(text);
+
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(text).catch(() => copy(text));
+    } else {
+      copy(text);
+    }
 
     setTimeout(() => {
       setIsCopying(false);

--- a/src/hooks/clipboard.hook.ts
+++ b/src/hooks/clipboard.hook.ts
@@ -22,8 +22,11 @@ export function useClipboard(): ClipboardInterface {
         // settle deliberately: a throwing fallback would otherwise escape as an unhandled rejection
         .catch(() => undefined);
     } else {
-      copy(text);
-      resetIsCopying();
+      try {
+        copy(text);
+      } finally {
+        resetIsCopying();
+      }
     }
   }
 

--- a/src/hooks/clipboard.hook.ts
+++ b/src/hooks/clipboard.hook.ts
@@ -12,15 +12,17 @@ export function useClipboard(): ClipboardInterface {
     if (!text) return;
     setIsCopying(true);
 
+    const resetIsCopying = () => setTimeout(() => setIsCopying(false), 500);
+
     if (navigator.clipboard?.writeText) {
-      navigator.clipboard.writeText(text).catch(() => copy(text));
+      navigator.clipboard
+        .writeText(text)
+        .catch(() => copy(text))
+        .finally(resetIsCopying);
     } else {
       copy(text);
+      resetIsCopying();
     }
-
-    setTimeout(() => {
-      setIsCopying(false);
-    }, 500);
   }
 
   return { copy: copyHelper, isCopying };

--- a/src/hooks/clipboard.hook.ts
+++ b/src/hooks/clipboard.hook.ts
@@ -19,7 +19,8 @@ export function useClipboard(): ClipboardInterface {
         .writeText(text)
         .catch(() => copy(text))
         .finally(resetIsCopying)
-        .catch(() => undefined); // a throwing fallback must not reach the global unhandledrejection reporter
+        // settle deliberately: a throwing fallback would otherwise escape as an unhandled rejection
+        .catch(() => undefined);
     } else {
       copy(text);
       resetIsCopying();


### PR DESCRIPTION
## Summary

`useClipboard` (`src/hooks/clipboard.hook.ts`) copies via the `copy-to-clipboard` package, which on every call does a synchronous, non-React DOM write: `document.body.appendChild` a hidden node → `execCommand('copy')` → `document.body.removeChild` it, entirely self-contained (it never touches a node React itself is tracking).

On `/buy`, the payment-details view wires 11 separate copy buttons to this hook (`payment-info-buy.tsx`), each followed about a second later by a React-driven re-render (the button icon swapping back). Since the client-error boundary started reporting (#1227), telemetry has recorded a recurring crash on that route:

```
NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before
which the new node is to be inserted is not a child of this node.
```

The stack is entirely inside React's own DOM-commit internals — the signature of something outside React's control having removed or moved a node React still expected to own. `copy-to-clipboard`'s write doesn't collide with that node directly; the theory is that it opens a window, once per click, during which something else touching the page (a browser extension is the leading candidate) could interfere with nearby DOM structure before React's own follow-up commit runs. It's the only unmanaged DOM mutation reachable from `/buy` — everything else in that render tree, including the QR code, goes through React.

This PR switches `useClipboard` to `navigator.clipboard.writeText`, which needs no DOM node at all, and falls back to the existing `copy-to-clipboard` path only when the Clipboard API is unavailable or the write is rejected.

## What this is and isn't

- This removes the one identified raw-DOM-write window reachable from `/buy` for the primary path. It has **not** been proven to be the actual cause of the crash — no direct interference signal was captured, this is the only concrete lever available given the rest of the render tree is plain React. Not strictly true for the fallback: when `writeText` is unavailable or rejects, the fallback still routes through `copy-to-clipboard` and carries the same `removeChild`-based DOM write this PR otherwise removes.
- The synchronous fallback branch (`navigator.clipboard` unavailable) now runs `copy(text)` inside `try/finally`, so `isCopying` still resets even if that call throws — mirroring the guarantee the async branch already has via `.finally(resetIsCopying)`.
- `useClipboard`'s public interface (`copy`, `isCopying`) is unchanged, so the hook's other callers (payment-info-sell/-content, sell/swap-completion, connect-cli, user-data-panel, tfa, support-dashboard, payment-link-pos and the realunit screens) keep working as before.
- **Not covered:** 11 files import `copy` from `copy-to-clipboard` directly and keep the unchanged synchronous DOM write — the account, settings, transaction, payment-routes, invoice, payment-link and blockchain-tx screens, safe/receive, cointracking, the recommendations section and `qr-code.tsx` (`QrCopy`). None of them sit on the `/buy` payment-details view, so they are out of scope here.
- Known trade-off, not fixed here: the fallback (`.catch(() => copy(text))`) runs from a promise-rejection microtask rather than synchronously inside the click handler. On a browser where `writeText` rejects, this could run outside the strict synchronous-user-gesture window `execCommand('copy')` prefers on some engines — `copy-to-clipboard`'s own internal fallback chain (`execCommand` → `clipboardData` → `window.prompt()`) still applies if that happens, so the failure mode degrades to a manual-copy prompt rather than silently dropping. If that last-resort fallback itself throws, the chain now terminates in a deliberate swallow (`.catch(() => undefined)`) instead of escaping as an unhandled rejection. Not chasing this further here: on a top-level document a `writeText` rejection is uncommon, and the only way to fully close it would be reintroducing a synchronous DOM write on every click — the exact thing this PR removes. One deployment where the rejection is *not* uncommon: a cross-origin Iframe embed without `allow="clipboard-write"` never gets the native path, so every copy takes the fallback there — #1296 adds the attribute to the documented Iframe example.
- Doesn't touch the unrelated `key={index}` map in `exchange-rate.tsx` noted during investigation of this crash — that's a separate, lower-confidence smell that isn't itself known to cause this class of error.

## Test plan

- [x] `npm test` — 74 suites / 802 tests pass, including new coverage for both the `writeText` path and its fallback: an explicit `navigator.clipboard`-undefined context asserting `copy-to-clipboard` is called (and that the reset still fires there), a throwing-fallback case asserting the chain settles without an unhandled rejection and still resets `isCopying`, and a case where `copy-to-clipboard` itself throws synchronously, asserting `isCopying` still resets — all verified by mutation (removing the trailing `.catch`, the else-branch reset, or the sync branch's `try/finally` each fail the suite)
- [x] `npm run lint` on changed files
- [x] Coverage: `src/hooks/clipboard.hook.ts` — 100% stmt/branch/func/line
- [ ] Manual copy-button check on `/buy` in a real browser before merge


