### PR TITLE
Reject undeclared deviations from these guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Deviating from these guidelines
+
+These guidelines are binding. A pull request that knowingly does not meet one
+of them says so **explicitly in its description**, naming the guideline it
+departs from and the reason. An undeclared deviation is not a discussion point
+— the pull request is rejected.
+
+A declared deviation is the reviewer's call: they may accept it or refuse it at
+their own discretion. Declaring one is not the same as being granted one.
+
 ## Pull requests
 
 ### Every pull request is self-contained


### PR DESCRIPTION
Adds an overarching rule at the top of the guidelines: a pull request that knowingly does not meet one of them must name the guideline and the reason in its description. An undeclared deviation is rejected outright. A declared one is the reviewer's call, accepted or refused at their discretion.

It sits above the individual sections because it governs all of them, and it pairs with what this document already says elsewhere: deferring a fix or leaving a pre-existing bug unfixed both require an exception granted in writing by the reviewer. This states the general form of that — declare it, or the PR does not land.

The point is not to open a door. It is to keep the door visible: a rule with no declared way past it invites silent non-compliance, and silent non-compliance is what turns a guideline into decoration.

The same rule is being added to the api repository (DFXswiss/api#4762).

Documentation only. The wording follows this file's existing line width and voice.
