### PR TITLE
d3628eb0 - Mock chargeback API dates as ISO strings in unit tests

### DIFF
--- a/src/__tests__/compliance-chargeback-list.screen.test.tsx
+++ b/src/__tests__/compliance-chargeback-list.screen.test.tsx
@@ -42,10 +42,16 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ChargebackBlockReason, PendingChargebackEntry } from 'src/dto/chargeback.dto';
 import ComplianceChargebackListScreen from 'src/screens/compliance-chargeback-list.screen';
 
-const REQUESTED = new Date('2026-01-15T10:00:00.000Z');
-const DATE = new Date('2026-01-15T12:00:00.000Z');
+type PendingChargebackPayload = Omit<PendingChargebackEntry, 'requestedDate' | 'date' | 'chargebackDate'> & {
+  requestedDate: string;
+  date: string;
+  chargebackDate?: string;
+};
 
-function baseEntry(overrides: Partial<PendingChargebackEntry> = {}): PendingChargebackEntry {
+const REQUESTED = '2026-01-15T10:00:00.000Z';
+const DATE = '2026-01-15T12:00:00.000Z';
+
+function baseEntry(overrides: Partial<PendingChargebackPayload> = {}): PendingChargebackEntry {
   return {
     txId: 9001,
     uid: 'T-9001',
@@ -61,7 +67,7 @@ function baseEntry(overrides: Partial<PendingChargebackEntry> = {}): PendingChar
     requestedDate: REQUESTED,
     date: DATE,
     ...overrides,
-  };
+  } as unknown as PendingChargebackEntry;
 }
 
 interface Deferred<T> {
@@ -194,7 +200,7 @@ describe('ComplianceChargebackListScreen', () => {
       entityId: 1005,
       blockReasons: [ChargebackBlockReason.MISSING_CREDITOR_DATA],
       userName: 'Sentinel User',
-      chargebackDate: new Date('2026-02-01T00:00:00.000Z'),
+      chargebackDate: '2026-02-01T00:00:00.000Z',
     });
 
     const multiReason = baseEntry({

--- a/src/__tests__/compliance-chargeback-list.screen.test.tsx
+++ b/src/__tests__/compliance-chargeback-list.screen.test.tsx
@@ -48,6 +48,11 @@ type PendingChargebackPayload = Omit<PendingChargebackEntry, 'requestedDate' | '
   chargebackDate?: string;
 };
 
+// JSON round-trip: mirrors real HTTP transport (drops undefined keys, keeps ISO strings, breaks aliasing)
+function asTransport<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
 const REQUESTED = '2026-01-15T10:00:00.000Z';
 const DATE = '2026-01-15T12:00:00.000Z';
 
@@ -96,7 +101,7 @@ describe('ComplianceChargebackListScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsLoggedIn = true;
-    mockGetPendingChargebacks.mockResolvedValue([]);
+    mockGetPendingChargebacks.mockResolvedValue(asTransport([]));
   });
 
   it('does not fetch when not logged in', () => {
@@ -117,7 +122,7 @@ describe('ComplianceChargebackListScreen', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.queryByTestId('error-hint')).not.toBeInTheDocument();
 
-    deferred.resolve([]);
+    deferred.resolve(asTransport([]));
     await waitFor(() => {
       expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
     });
@@ -138,7 +143,7 @@ describe('ComplianceChargebackListScreen', () => {
   });
 
   it('shows the empty-state row when the response is a successful empty list', async () => {
-    mockGetPendingChargebacks.mockResolvedValue([]);
+    mockGetPendingChargebacks.mockResolvedValue(asTransport([]));
 
     render(<ComplianceChargebackListScreen />);
 
@@ -223,15 +228,17 @@ describe('ComplianceChargebackListScreen', () => {
       userName: 'No Reasons User',
     });
 
-    mockGetPendingChargebacks.mockResolvedValue([
-      plainMissing,
-      nameMismatch,
-      nameMismatchMissingNames,
-      userNotReleased,
-      sentinel,
-      multiReason,
-      noBlockReasons,
-    ]);
+    mockGetPendingChargebacks.mockResolvedValue(
+      asTransport([
+        plainMissing,
+        nameMismatch,
+        nameMismatchMissingNames,
+        userNotReleased,
+        sentinel,
+        multiReason,
+        noBlockReasons,
+      ]),
+    );
 
     render(<ComplianceChargebackListScreen />);
 
@@ -330,7 +337,7 @@ describe('ComplianceChargebackListScreen', () => {
       blockReasons: [ChargebackBlockReason.MISSING_CHARGEBACK_AMOUNT],
     });
 
-    mockGetPendingChargebacks.mockResolvedValue([withAsset, withoutAsset, nullAmounts, zeroAmount]);
+    mockGetPendingChargebacks.mockResolvedValue(asTransport([withAsset, withoutAsset, nullAmounts, zeroAmount]));
 
     render(<ComplianceChargebackListScreen />);
 
@@ -374,7 +381,7 @@ describe('ComplianceChargebackListScreen', () => {
       userName: 'Empty Uid',
     });
 
-    mockGetPendingChargebacks.mockResolvedValue([withUid, emptyUid]);
+    mockGetPendingChargebacks.mockResolvedValue(asTransport([withUid, emptyUid]));
 
     render(<ComplianceChargebackListScreen />);
 
@@ -392,7 +399,7 @@ describe('ComplianceChargebackListScreen', () => {
       entityId: 1301,
       userName: 'Clickable User',
     });
-    mockGetPendingChargebacks.mockResolvedValue([entry]);
+    mockGetPendingChargebacks.mockResolvedValue(asTransport([entry]));
 
     render(<ComplianceChargebackListScreen />);
 

--- a/src/__tests__/compliance-pending-chargebacks.hook.test.ts
+++ b/src/__tests__/compliance-pending-chargebacks.hook.test.ts
@@ -36,6 +36,12 @@ jest.mock('../hooks/navigation.hook', () => ({
 import { useCompliance } from '../hooks/compliance.hook';
 import { ChargebackBlockReason, PendingChargebackEntry } from '../dto/chargeback.dto';
 
+type PendingChargebackPayload = Omit<PendingChargebackEntry, 'requestedDate' | 'date' | 'chargebackDate'> & {
+  requestedDate: string;
+  date: string;
+  chargebackDate?: string;
+};
+
 describe('useCompliance().getPendingChargebacks', () => {
   beforeEach(() => {
     // react-scripts sets resetMocks:true, which wipes implementations before each test
@@ -43,7 +49,7 @@ describe('useCompliance().getPendingChargebacks', () => {
   });
 
   it('issues GET support/pending-chargebacks and returns the payload', async () => {
-    const payload: PendingChargebackEntry[] = [
+    const payload: PendingChargebackPayload[] = [
       {
         txId: 9001,
         uid: 'T-9001',
@@ -56,8 +62,8 @@ describe('useCompliance().getPendingChargebacks', () => {
         chargebackAmount: 100,
         chargebackAsset: 'EUR',
         blockReasons: [ChargebackBlockReason.MISSING_CHARGEBACK_AMOUNT],
-        requestedDate: new Date('2026-01-15T10:00:00.000Z'),
-        date: new Date('2026-01-15T10:00:00.000Z'),
+        requestedDate: '2026-01-15T10:00:00.000Z',
+        date: '2026-01-15T10:00:00.000Z',
       },
     ];
     mockCall.mockResolvedValue(payload);

--- a/src/__tests__/compliance-pending-chargebacks.hook.test.ts
+++ b/src/__tests__/compliance-pending-chargebacks.hook.test.ts
@@ -42,6 +42,11 @@ type PendingChargebackPayload = Omit<PendingChargebackEntry, 'requestedDate' | '
   chargebackDate?: string;
 };
 
+// JSON round-trip: mirrors real HTTP transport (drops undefined keys, keeps ISO strings, breaks aliasing)
+function asTransport<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
 describe('useCompliance().getPendingChargebacks', () => {
   beforeEach(() => {
     // react-scripts sets resetMocks:true, which wipes implementations before each test
@@ -66,7 +71,7 @@ describe('useCompliance().getPendingChargebacks', () => {
         date: '2026-01-15T10:00:00.000Z',
       },
     ];
-    mockCall.mockResolvedValue(payload);
+    mockCall.mockResolvedValue(asTransport(payload));
 
     const { result } = renderHook(() => useCompliance());
 
@@ -78,5 +83,6 @@ describe('useCompliance().getPendingChargebacks', () => {
       method: 'GET',
     });
     expect(entries).toEqual(payload);
+    expect(entries[0].requestedDate).toBe('2026-01-15T10:00:00.000Z');
   });
 });


### PR DESCRIPTION
## Why

Follow-up to #1285 (see https://github.com/DFXswiss/services/pull/1285#issuecomment-5237772521): the unit tests mock the API payload with `Date` instances, but over JSON transport `requestedDate`/`date`/`chargebackDate` arrive as ISO strings. The rendering path handles both today, yet the tests would stay green through a regression that only breaks on string input.

## What

- Introduce a local transport-shaped `PendingChargebackPayload` type (dates as `string`, mirroring the e2e spec's fixtures) in both test files.
- Screen test: the fixture date constants and the sentinel `chargebackDate` are ISO strings now; `baseEntry()` builds the transport shape and casts once at the mock boundary.
- Hook test: the mocked payload is typed transport-shaped; no cast needed at the untyped `jest.fn()` boundary.
- Every successful mock payload is routed through a JSON round-trip helper (`asTransport`) at the mock boundary — mirroring what `response.json()` actually delivers: keys set to `undefined` are dropped, and the resolved value is a fresh clone, so reference aliasing cannot mask an in-place mutation. Rejection paths stay untouched. The hook test additionally asserts the raw ISO string on the result.
- No production code changes.

Both suites pass locally (2 suites, 9 tests).