### PR TITLE
b9bedc67 - Ignore local CLAUDE.md agent instruction file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ yarn-error.log*
 next-env.d.ts
 .claude/settings.local.json
 
+# local agent instructions (never committed)
+CLAUDE.md
+
 # Synpress cache and test results
 .cache-synpress/
 e2e/synpress-results/


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` to `.gitignore`. The file holds local-only agent instructions and must never be tracked.

Automated checkpoint commits had pushed this file to two branches of this repository. Those branches have been deleted; this change removes the cause so it cannot happen again. `DFXswiss/api` already carries the same entry.

## Verification

- `git check-ignore -v CLAUDE.md` matches the new rule in the repository root and in subdirectories (`src/`, `e2e/`).
- No `CLAUDE.md` is tracked today, so the rule takes effect immediately rather than being shadowed by an existing entry.
- Creating a local `CLAUDE.md` leaves `git status` clean.

## Coverage

No instrumented source file is touched — the change is limited to `.gitignore`, which carries no coverage per CONTRIBUTING.md.

## Test plan

- [x] `git check-ignore` for root and nested paths
- [x] Local `CLAUDE.md` stays invisible to git
- [ ] Reviewer: confirm placement of the entry