### PR TITLE
137676bf - Guard every /compliance path, including ones no screen claims

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,7 @@ const ComplianceReviewScreen = lazy(() => import('./screens/compliance-review.sc
 const ComplianceCallQueuesScreen = lazy(() => import('./screens/compliance-call-queues.screen'));
 const ComplianceCallQueueScreen = lazy(() => import('./screens/compliance-call-queue.screen'));
 const ComplianceCallQueueDetailScreen = lazy(() => import('./screens/compliance-call-queue-detail.screen'));
+const ComplianceNotFoundScreen = lazy(() => import('./screens/compliance-not-found.screen'));
 const SupportDashboardOverviewScreen = lazy(() => import('./screens/support-dashboard-overview.screen'));
 const SupportDashboardScreen = lazy(() => import('./screens/support-dashboard.screen'));
 const SupportDashboardIssueScreen = lazy(() => import('./screens/support-dashboard-issue.screen'));
@@ -461,6 +462,12 @@ export const Routes = [
       {
         path: 'compliance/call-queues/:queue/:userDataId',
         element: withSuspense(<ComplianceCallQueueDetailScreen />),
+      },
+      // Must stay last among the compliance routes: React Router ranks static segments above a splat,
+      // so this only matches paths none of the screens above claim.
+      {
+        path: 'compliance/*',
+        element: withSuspense(<ComplianceNotFoundScreen />),
       },
       {
         path: 'sitemap',

--- a/src/__tests__/compliance-chargeback-list.screen.test.tsx
+++ b/src/__tests__/compliance-chargeback-list.screen.test.tsx
@@ -5,6 +5,7 @@
 let mockIsLoggedIn = true;
 const mockGetPendingChargebacks = jest.fn();
 const mockNavigate = jest.fn();
+const mockUseComplianceGuard = jest.fn();
 
 jest.mock('@dfx.swiss/react', () => ({
   useSessionContext: () => ({ isLoggedIn: mockIsLoggedIn }),
@@ -23,7 +24,7 @@ jest.mock('src/components/error-hint', () => ({
 }));
 
 jest.mock('src/hooks/guard.hook', () => ({
-  useComplianceGuard: () => undefined,
+  useComplianceGuard: () => mockUseComplianceGuard(),
 }));
 
 jest.mock('src/hooks/layout-config.hook', () => ({
@@ -102,6 +103,15 @@ describe('ComplianceChargebackListScreen', () => {
     jest.clearAllMocks();
     mockIsLoggedIn = true;
     mockGetPendingChargebacks.mockResolvedValue(asTransport([]));
+  });
+
+  // The role guard is all that stands between an unauthorised role and this screen; it is mocked out
+  // in every other test here. Without this assertion the screen could lose its guard call and the
+  // whole suite would stay green — see issue #1306, where exactly that was suspected.
+  it('calls the compliance guard on render', () => {
+    render(<ComplianceChargebackListScreen />);
+
+    expect(mockUseComplianceGuard).toHaveBeenCalled();
   });
 
   it('does not fetch when not logged in', () => {

--- a/src/__tests__/compliance-chargeback-list.screen.test.tsx
+++ b/src/__tests__/compliance-chargeback-list.screen.test.tsx
@@ -24,7 +24,7 @@ jest.mock('src/components/error-hint', () => ({
 }));
 
 jest.mock('src/hooks/guard.hook', () => ({
-  useComplianceGuard: () => mockUseComplianceGuard(),
+  useComplianceGuard: (...args: unknown[]) => mockUseComplianceGuard(...args),
 }));
 
 jest.mock('src/hooks/layout-config.hook', () => ({
@@ -105,13 +105,16 @@ describe('ComplianceChargebackListScreen', () => {
     mockGetPendingChargebacks.mockResolvedValue(asTransport([]));
   });
 
-  // The role guard is all that stands between an unauthorised role and this screen; it is mocked out
-  // in every other test here. Without this assertion the screen could lose its guard call and the
-  // whole suite would stay green — see issue #1306, where exactly that was suspected.
-  it('calls the compliance guard on render', () => {
+  // The role guard is all that stands between an unauthorised role and this screen, and it is mocked
+  // out in every other test here — so without this assertion the screen could lose the call and the
+  // whole suite would stay green (issue #1306 suspected exactly that). Asserting the argument list is
+  // empty covers the quieter mutation too: the hook's signature is
+  // `useComplianceGuard(redirectPath = '/', isActive = true)`, so `useComplianceGuard(undefined, false)`
+  // would keep the call and still leave the guard inert.
+  it('calls the compliance guard on render, with the guard left active', () => {
     render(<ComplianceChargebackListScreen />);
 
-    expect(mockUseComplianceGuard).toHaveBeenCalled();
+    expect(mockUseComplianceGuard).toHaveBeenCalledWith();
   });
 
   it('does not fetch when not logged in', () => {

--- a/src/__tests__/compliance-not-found.screen.test.tsx
+++ b/src/__tests__/compliance-not-found.screen.test.tsx
@@ -1,0 +1,47 @@
+// Unit tests for ComplianceNotFoundScreen: the guarded catch-all for unknown /compliance paths.
+
+const mockUseComplianceGuard = jest.fn();
+
+jest.mock('@dfx.swiss/react-components', () => ({
+  StyledVerticalStack: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/compliance/does-not-exist' }),
+}));
+
+jest.mock('src/contexts/settings.context', () => ({
+  useSettingsContext: () => ({ translate: (_ns: string, key: string) => key }),
+}));
+
+jest.mock('src/hooks/guard.hook', () => ({
+  useComplianceGuard: (...args: unknown[]) => mockUseComplianceGuard(...args),
+}));
+
+jest.mock('src/hooks/layout-config.hook', () => ({
+  useLayoutOptions: () => undefined,
+}));
+
+import { render, screen } from '@testing-library/react';
+import ComplianceNotFoundScreen from 'src/screens/compliance-not-found.screen';
+
+describe('ComplianceNotFoundScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // The whole point of this screen: an unknown compliance path must still run the role guard, so an
+  // unauthorised role is sent away instead of parked on a /compliance URL (issue #1306).
+  it('calls the compliance guard on render, with the guard left active', () => {
+    render(<ComplianceNotFoundScreen />);
+
+    expect(mockUseComplianceGuard).toHaveBeenCalledWith();
+  });
+
+  it('names the missing page and shows the path that was requested', () => {
+    render(<ComplianceNotFoundScreen />);
+
+    expect(screen.getByText('This compliance page does not exist')).toBeInTheDocument();
+    expect(screen.getByText('/compliance/does-not-exist')).toBeInTheDocument();
+  });
+});

--- a/src/screens/compliance-not-found.screen.tsx
+++ b/src/screens/compliance-not-found.screen.tsx
@@ -1,0 +1,24 @@
+import { StyledVerticalStack } from '@dfx.swiss/react-components';
+import { useLocation } from 'react-router-dom';
+import { useSettingsContext } from 'src/contexts/settings.context';
+import { useComplianceGuard } from 'src/hooks/guard.hook';
+import { useLayoutOptions } from 'src/hooks/layout-config.hook';
+
+// Catch-all for every unknown path below /compliance. Without it such a URL matches no route at all,
+// so the router falls back to its errorElement — a screen that runs outside every guard and leaves the
+// address bar untouched, which parks an unauthorised role on a /compliance URL (issue #1306). Guarding
+// the catch-all makes the role check independent of whether a given compliance screen exists.
+export default function ComplianceNotFoundScreen(): JSX.Element {
+  useComplianceGuard();
+  useLayoutOptions({ title: 'Not found', backButton: true });
+
+  const { translate } = useSettingsContext();
+  const { pathname } = useLocation();
+
+  return (
+    <StyledVerticalStack gap={4} full center>
+      <h2 className="text-dfxBlue-800">{translate('screens/compliance', 'This compliance page does not exist')}</h2>
+      <p className="text-dfxGray-700 text-sm">{pathname}</p>
+    </StyledVerticalStack>
+  );
+}


### PR DESCRIPTION
Closes #1306.

## The defect

A URL below `/compliance` that matches no route — a typo, a screen not deployed yet, a screen removed —
makes React Router raise a 404 `ErrorResponse` and render the root `errorElement` (`ErrorScreen`). That
screen runs **outside every guard**, and an error boundary does not change the URL. An unauthorised role
therefore sits on a `/compliance/…` address and is never sent away.

That is what #1306 observed. The report named `/compliance/pending-chargebacks`, and the guard on that
screen turned out to be intact — the run had been made against a build without the route
(`feat/e2e-stack` branches off #1282, the screen landed with #1285, and the harness builds the bundle from
its own working tree). But the hole underneath is real and independent of that one route: **the role check
for the compliance area only exists where a screen exists.**

## The fix

A guarded catch-all as the last compliance route:

- `src/screens/compliance-not-found.screen.tsx` — calls `useComplianceGuard()` like every other compliance
  screen, then states plainly that the page does not exist and shows the requested path.
- `src/App.tsx` — `path: 'compliance/*'`, placed after all compliance routes. React Router ranks static
  segments above a splat, so it only ever matches what no screen claims.
- `src/__tests__/compliance-not-found.screen.test.tsx` — pins both halves: the guard call (with an empty
  argument list) and the rendered message plus requested path.

The role check for `/compliance` no longer depends on whether a given screen exists, and an authorised
user gets "this compliance page does not exist" instead of "something went wrong".

Behaviour outside `/compliance` is untouched: an unknown path elsewhere still renders the generic error
screen exactly as before.

## Second change: the guard assertion the screen tests were missing

`src/__tests__/compliance-chargeback-list.screen.test.tsx` mocked `useComplianceGuard` away and never
asserted the call — deleting the guard from the screen left all eight tests green. It now asserts the call
**with an empty argument list**, because `useComplianceGuard(redirectPath = '/', isActive = true)`
navigates only while `isActive`: `useComplianceGuard(undefined, false)` would keep the call and still leave
the guard inert.

## Evidence

Measured against a running dev server, role taken from a JWT (the frontend decodes it client-side, so the
guard decision involves no backend), polling `location.pathname`:

| Path | Before | After |
| --- | --- | --- |
| `/compliance/definitiv-nicht-existent` (invented) | stays on the path, "something went wrong" | **redirected to `/`** |
| `/compliance/pending-chargebacks` | redirected to `/` | redirected to `/` |
| `/compliance/recalls` | redirected to `/` | redirected to `/` |
| `/voellig-unbekannt-ausserhalb` (outside `/compliance`) | stays, generic error | stays, generic error (unchanged) |

The splat claims nothing that belongs to a real screen — verified by which lazy chunk each URL loads:

```
/compliance/kyc-stats                → compliance-kyc-stats
/compliance/recalls                  → compliance-recall-list
/compliance/pending-chargebacks      → compliance-chargeback-list
/compliance/call-queues/foo/1        → compliance-call-queue-detail
/compliance/mros/create              → compliance-mros-create
/compliance/definitiv-nicht-existent → compliance-not-found
```

Mutation checks on the guard assertion, each restored afterwards: removing `useComplianceGuard();` and
changing it to `useComplianceGuard(undefined, false);` each fail that one test and only that test.

Full suite: 81 suites, 950 tests, all green. ESLint clean on both new files.

## Coverage

- `src/screens/compliance-not-found.screen.tsx` — **100 % statements / 100 % branches / 100 % functions /
  100 % lines**.
- `src/screens/compliance-chargeback-list.screen.tsx` (untouched, measured with the new assertion in
  place) — **100 % / 100 % / 100 % / 100 %**.
- `src/App.tsx` is touched by two insertions (a lazy import and a route entry). It is the routing table,
  has no test of its own in this repository, and is not brought to 100 % here — a **declared deviation**
  from the coverage rule in CONTRIBUTING.md, and the reviewer's call. The two added lines are exercised in
  the browser evidence above.

## Note for #1288

Once that branch is rebased onto a `develop` containing #1285, `/compliance/pending-chargebacks` belongs in
`ALL_COMPLIANCE_PATHS` as a normal assertion and both `test.fail()` markers can go: the redirect assertion
now passes through this catch-all even while a screen is missing, and the mount assertion passes once the
screen is present.
