### PR TITLE
406da72e - Document the test architecture, require a reality declaration, and fix the E2E full-run flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,9 +42,12 @@ reason to leave the bug unreported.
 measured numbers for the current state, and points at the canonical
 cross-repository description in `DFXswiss/api`. Read it before adding a test
 layer, moving a test between layers, or extending the full-stack harness. (Given
-as a path rather than a link on purpose: the handbook build renders every
-markdown file to HTML and its integrity check rejects a link that resolves to a
-`.md` file, which is why no markdown file in this repository links to another.)
+as a path rather than a link on purpose: the handbook build renders every markdown
+file to HTML, and its integrity check then requires every relative reference
+beginning with `docs/`, `assets/` or `screenshots/` to exist in that output — which
+a reference to a `.md` file never does, since only the rendered `.html` is there.
+References outside those three prefixes are unaffected, which is why the link to
+`e2e-stack/README.md` further down is fine.)
 
 Two obligations follow from it for every pull request:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,13 @@ reason to leave the bug unreported.
 
 ### Test architecture
 
-[docs/test-architecture.md](docs/test-architecture.md) describes the test layers
-this repository owns, with measured numbers for the current state, and links to
-the canonical cross-repository description in `DFXswiss/api`. Read it before
-adding a test layer, moving a test between layers, or extending the full-stack
-harness.
+`docs/test-architecture.md` describes the test layers this repository owns, with
+measured numbers for the current state, and points at the canonical
+cross-repository description in `DFXswiss/api`. Read it before adding a test
+layer, moving a test between layers, or extending the full-stack harness. (Given
+as a path rather than a link on purpose: the handbook build renders every
+markdown file to HTML and its integrity check rejects a link that resolves to a
+`.md` file, which is why no markdown file in this repository links to another.)
 
 Two obligations follow from it for every pull request:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,28 @@ reason to leave the bug unreported.
 
 ## Testing
 
+### Test architecture
+
+[docs/test-architecture.md](docs/test-architecture.md) describes the test layers
+this repository owns, with measured numbers for the current state, and links to
+the canonical cross-repository description in `DFXswiss/api`. Read it before
+adding a test layer, moving a test between layers, or extending the full-stack
+harness.
+
+Two obligations follow from it for every pull request:
+
+- **A failure mode is tested at the lowest layer that can express it.** A case
+  reachable against a real database does not belong in a browser test, and the
+  processing chain behind the API is not testable from this repository at all.
+- **Reality declaration.** Whenever a pull request introduces, removes or changes
+  a fake — a faked external provider, a disabled cron job, a schema built without
+  the migration chain, state written directly with SQL, a placeholder value that
+  looks real, a suppressed side effect, or a seed correction that bends reality —
+  the declaration changes in the same pull request, and each entry says in one
+  plain sentence what a green run does **not** prove. Write the entry before
+  building the fake. A pull request that adds a fake without its declaration is
+  incomplete regardless of whether CI is green.
+
 ### Unit tests
 
 ```

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -52,13 +52,12 @@ the merge target had gained a route the registry did not claim yet. Re-measure a
 suite; the number of tests is not pinned anywhere.
 
 The harness runs the following for real: Postgres, the API, this frontend, a browser. It fakes every
-external provider, on two levels — the API mocks its own outbound calls, and the Docker network it sits
-on has no route to the internet at all. The second level is the load-bearing one, and
-`e2e-stack/env/api.env` records why: the `loc` mock covers only calls made through the API's central
-HTTP wrapper, so an integration reaching out through a vendor SDK, `graphql-request`, an ethers provider
-or bare `fetch` goes straight past it. What guarantees that no external system is contacted is therefore
-the network, not the mock. How many integrations bypass the wrapper is a property of the API and not
-verifiable from this repository.
+external provider twice over: the API mocks its own outbound calls, and the Docker network it sits on has
+no route to the internet at all. The isolation, not the mock, is what carries the guarantee — and
+`e2e-stack/env/api.env` says so itself: the `loc` mock "only covers calls made through the API's central
+HTTP wrapper", while "what guarantees no external system is ever contacted is the network the API sits
+on". Any call that reaches out without going through that wrapper is therefore outside the mock's scope.
+Which calls those are, and how many, is a property of the API and not verifiable from this repository.
 
 The details — the factories and the states that are deliberately not achievable — are in
 `e2e-stack/README.md` and `e2e-stack/docs/test-data.md`.
@@ -77,9 +76,9 @@ declaration.** Anything its parser cannot resolve is a hard failure rather than 
 
 ## Reality declaration — hard requirement
 
-Full definition, including all seven categories that count as a fake and the five mandatory fields
-per entry, is in `DFXswiss/api` under `docs/test-architecture.md`. The short form that binds every
-pull request here:
+Full definition, including the categories that count as a fake and the mandatory fields per entry, is in
+`DFXswiss/api` under `docs/test-architecture.md` — that document owns the taxonomy, and its exact extent
+is not verifiable from this repository. The short form that binds every pull request here:
 
 Whenever you introduce, remove or change a fake — a faked external provider, a disabled cron job, a
 schema built without the migration chain, state written directly with SQL, a placeholder value that
@@ -106,9 +105,9 @@ All four points below concern the full-stack harness.
 - **The harness lives in the wrong repository.** It tests the API as much as this frontend, and
   `DFXswiss/api` has to check this repository out to obtain it. See the target below.
 - **The suite is serialised.** All specs share one database and one API instance with no per-test
-  isolation, so it runs on a single worker with retries disabled — deliberately, since a retry would
-  mask exactly the order-dependent failure this arrangement produces. It bounds how far the suite can
-  grow.
+  isolation, so it runs on a single worker with retries disabled — `workers: 1` and `retries: 0` in
+  `e2e-stack/playwright.config.ts`, which explains the choice: a retry would mask exactly the
+  order-dependent failure this arrangement produces. It bounds how far the suite can grow.
 
 ## Target architecture
 
@@ -126,6 +125,7 @@ Each step is additive; none requires discarding what exists.
 
 ## Keeping this document honest
 
-Every number carries the commit it was measured on and the command that produces it. When a layer
-changes what it proves, or a fake is added, removed or altered, this document changes in the same
-pull request.
+Every **measured** number carries the commit it was measured on and the command that produces it; that
+is what keeps the figures maintainable. Counts that a reader can verify by looking — how many entries an
+adjacent list has, for instance — need no stamp. When a layer changes what it proves, or a fake is added,
+removed or altered, this document changes in the same pull request.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -53,9 +53,12 @@ suite; the number of tests is not pinned anywhere.
 
 The harness runs the following for real: Postgres, the API, this frontend, a browser. It fakes every
 external provider, on two levels — the API mocks its own outbound calls, and the Docker network it sits
-on has no route to the internet at all. The second level is the load-bearing one, because around twenty
-integrations use vendor SDKs, `graphql-request`, ethers providers or bare `fetch` and bypass the API's
-central HTTP wrapper entirely.
+on has no route to the internet at all. The second level is the load-bearing one, and
+`e2e-stack/env/api.env` records why: the `loc` mock covers only calls made through the API's central
+HTTP wrapper, so an integration reaching out through a vendor SDK, `graphql-request`, an ethers provider
+or bare `fetch` goes straight past it. What guarantees that no external system is contacted is therefore
+the network, not the mock. How many integrations bypass the wrapper is a property of the API and not
+verifiable from this repository.
 
 The details — the factories and the states that are deliberately not achievable — are in
 `e2e-stack/README.md` and `e2e-stack/docs/test-data.md`.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -52,12 +52,13 @@ the merge target had gained a route the registry did not claim yet. Re-measure a
 suite; the number of tests is not pinned anywhere.
 
 The harness runs the following for real: Postgres, the API, this frontend, a browser. It fakes every
-external provider twice over: the API mocks its own outbound calls, and the Docker network it sits on has
-no route to the internet at all. The isolation, not the mock, is what carries the guarantee — and
-`e2e-stack/env/api.env` says so itself: the `loc` mock "only covers calls made through the API's central
-HTTP wrapper", while "what guarantees no external system is ever contacted is the network the API sits
-on". Any call that reaches out without going through that wrapper is therefore outside the mock's scope.
-Which calls those are, and how many, is a property of the API and not verifiable from this repository.
+external provider through two independent mechanisms: the API mocks its own outbound calls, and the
+Docker network it sits on has no route to the internet at all. The second is what carries the guarantee,
+and `e2e-stack/env/api.env` says so itself: the `loc` mock "only covers calls made through the API's
+central HTTP wrapper", while "[w]hat guarantees no external system is ever contacted is the network the
+API sits on". Any call that reaches out without going through that wrapper is therefore outside the
+mock's scope. Which calls those are, and how many, is a property of the API and not verifiable from this
+repository.
 
 The details — the factories and the states that are deliberately not achievable — are in
 `e2e-stack/README.md` and `e2e-stack/docs/test-data.md`.
@@ -94,8 +95,9 @@ from memory, with omissions.
 
 All four points below concern the full-stack harness.
 
-- **No layer here verifies a payment end to end.** The harness sets `DISABLED_PROCESSES=*`, which
-  switches off every process-gated cron job in the API, so the processing chain never executes;
+- **No layer here verifies a payment end to end.** The harness sets `DISABLED_PROCESSES=*`
+  (`e2e-stack/env/api.env`); what that switches off in the API is described in the companion document
+  there — every process-gated cron job — so the processing chain never executes;
   transaction states are inserted with SQL instead. What is verified is the synchronous path:
   interaction, HTTP, validation, authorisation, persistence, display. (A cron without a `process` field
   is not covered by that switch and keeps running — see the companion document in `DFXswiss/api`.)
@@ -104,10 +106,11 @@ All four points below concern the full-stack harness.
   database. Migrations are covered in `DFXswiss/api` instead.
 - **The harness lives in the wrong repository.** It tests the API as much as this frontend, and
   `DFXswiss/api` has to check this repository out to obtain it. See the target below.
-- **The suite is serialised.** All specs share one database and one API instance with no per-test
-  isolation, so it runs on a single worker with retries disabled — `workers: 1` and `retries: 0` in
-  `e2e-stack/playwright.config.ts`, which explains the choice: a retry would mask exactly the
-  order-dependent failure this arrangement produces. It bounds how far the suite can grow.
+- **The suite is serialised.** All specs share one database and one API instance — `e2e-stack/compose.yml`
+  declares a single `db` and a single `api` service — with no per-test isolation, so it runs on a single
+  worker with retries disabled (`workers: 1` and `retries: 0` in `e2e-stack/playwright.config.ts`, whose
+  comment states the reason): a retry would mask exactly the order-dependent failure this arrangement
+  produces. It bounds how far the suite can grow.
 
 ## Target architecture
 

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -36,8 +36,8 @@ Measured on `develop` at `3ca38b33`, 2026-08-10, Node 20, with
 
 947 tests passing across 80 suites, 352 files instrumented.
 
-Read that number together with the coverage rule in
-[CONTRIBUTING.md](../CONTRIBUTING.md#coverage): every file a pull request touches must reach 100 % on
+Read that number together with the coverage rule in `CONTRIBUTING.md`, section
+"Coverage": every file a pull request touches must reach 100 % on
 all four metrics, and CI does not enforce it — it is a review gate. With the repository at 18 %, that
 means touching a long-neglected file makes its whole coverage your obligation. Plan for it rather
 than discovering it in review.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -68,9 +68,10 @@ The details — the factories and the states that are deliberately not achievabl
 The gate reads the route definitions out of `src/App.tsx`, resolves nested paths, and fails when a route
 has no registry claim or more than one — including two claims inside the same registry file — or when
 the spec file a claim names does not exist. When `E2E_FULL_RUN=1` is set, it additionally fails for a
-claimed route the browser never opened; note that this flag is self-declared by the run, not a measured
-completeness check. Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a
-test that navigates there.
+claimed route the browser never opened. That flag is declared by the run, not measured from it, so it may
+only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it exactly when it was
+given no arguments, and the CI workflow sets it for its own unfiltered invocation. Adding a route
+therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates there.
 
 That gate is the pattern the reality declaration follows: **measure the run, do not trust the
 declaration.** Anything its parser cannot resolve is a hard failure rather than a silent omission.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -10,11 +10,11 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 ## The layers this repository owns
 
-| Layer             | Location     | What it proves                                                               | What it cannot prove                                                     | Runs in CI |
-| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------- |
-| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                          | yes        |
-| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — all background jobs are switched off during the run | yes        |
-| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                                 | no         |
+| Layer                             | Location                             | What it proves                                                               | What it cannot prove                                                     | Runs in CI                |
+| --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------- |
+| Unit                              | `src/`                               | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                          | yes                       |
+| Full-stack E2E _(not yet merged)_ | `e2e-stack/` — absent on this branch | the seam between frontend, API and database: screens, contracts, persistence | any money movement — all background jobs are switched off during the run | only once #1288 is merged |
+| Visual regression                 | `e2e/`                               | appearance against committed screenshot baselines                            | function                                                                 | no                        |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
 payout, ledger booking — is **not** testable from this repository. It belongs to the integration
@@ -44,30 +44,35 @@ than discovering it in review.
 
 ### Full-stack E2E — `npm run e2e:stack`
 
-Introduced by pull request #1288. **Until that is merged, this layer does not exist on `develop`.**
+**This layer does not exist on this branch.** It arrives with pull request #1288; `e2e-stack/`, its
+registry and its route-coverage gate are absent until that merges. Everything in this section
+describes the state on that pull request, not the state here, and each paragraph below is written
+accordingly.
 
-Measured on the pull request head `acb6814a` in CI: 223 tests, 219 passing, 3 skipped, 1 failing, in
+Measured on the pull-request head `acb6814a` in CI: 223 tests, 219 passing, 3 skipped, 1 failing, in
 9.6 minutes on a single worker. The failing one is the route gate, correctly: the merge target has a
 route the registry does not claim yet.
 
-What the harness runs for real: Postgres, the API, this frontend, a browser. What it fakes: every
-external provider, on two levels — the API mocks its own outbound calls, and the Docker network it
-sits on has no route to the internet at all. The second level is the load-bearing one, because around
-twenty integrations use vendor SDKs, `graphql-request`, ethers providers or bare `fetch` and bypass
-the API's central HTTP wrapper entirely.
+On that pull request the harness runs the following for real: Postgres, the API, this frontend, a
+browser. It fakes every external provider, on two levels — the API mocks its own outbound calls, and
+the Docker network it sits on has no route to the internet at all. The second level is the
+load-bearing one, because around twenty integrations use vendor SDKs, `graphql-request`, ethers
+providers or bare `fetch` and bypass the API's central HTTP wrapper entirely.
 
-Details, including the factories and the states that are deliberately not achievable, are in
-`e2e-stack/README.md` and `e2e-stack/docs/test-data.md`.
+Once #1288 is merged, the details — the factories and the states that are deliberately not
+achievable — will live in `e2e-stack/README.md` and `e2e-stack/docs/test-data.md`. Neither path
+resolves before then.
 
-### Route coverage is enforced, not tracked by hand
+### Route coverage, once #1288 is merged
 
-The suite reads the route definitions out of `src/App.tsx`, resolves nested paths, and fails when a
-route is claimed by no test file or by more than one — and, on a full run, when a claimed route was
-never actually opened by the browser. Adding a route therefore means adding a claim in
-`e2e-stack/specs/registry/` and a test that navigates there.
+_The gate described here ships with #1288 and does not run on this branch._ It reads the route
+definitions out of `src/App.tsx` — which does already carry the nested, exported route list — resolves
+nested paths, and fails when a route is claimed by no test file or by more than one, and on a full run
+also when a claimed route was never actually opened by the browser. Adding a route will therefore mean
+adding a claim in `e2e-stack/specs/registry/` and a test that navigates there.
 
-This is the pattern the reality declaration follows too: **measure the run, do not trust the
-declaration.** Anything the parser cannot resolve is a hard failure rather than a silent omission.
+That gate is the pattern the reality declaration follows: **measure the run, do not trust the
+declaration.** Anything its parser cannot resolve is a hard failure rather than a silent omission.
 
 ## Reality declaration — hard requirement
 
@@ -86,6 +91,10 @@ Write the declaration entry **before** building the fake. Reversed, it becomes d
 from memory, with omissions.
 
 ## Known gaps
+
+All four points below concern the full-stack harness from #1288 and therefore describe that pull
+request's state rather than this branch, where the layer is absent altogether — which makes the first
+point true here in an even stronger sense.
 
 - **No layer here verifies a payment end to end.** Every cron job is disabled in the harness, so the
   processing chain never executes; transaction states are inserted with SQL instead. What is verified

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -1,0 +1,121 @@
+# Test architecture
+
+This document describes the test layers **this repository** owns, with measured numbers for the
+current state. The canonical, cross-repository description of all layers — what each one proves, what
+it deliberately does not prove, and the reality-declaration requirement — lives in
+`DFXswiss/api` under `docs/test-architecture.md`. Read that one first if you need the whole picture.
+
+Current state and target are kept apart on purpose. Sections marked _target_ describe what is not
+built yet; nothing here may describe a capability as existing when it does not.
+
+## The layers this repository owns
+
+| Layer             | Location     | What it proves                                                               | What it cannot prove                                                     | Runs in CI |
+| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------- |
+| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                          | yes        |
+| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — all background jobs are switched off during the run | yes        |
+| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                                 | no         |
+
+The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
+payout, ledger booking — is **not** testable from this repository. It belongs to the integration
+layer in `DFXswiss/api`, which runs against a real database. Do not try to cover it from here.
+
+## Current state — measured
+
+### Unit suite — `npm run test`
+
+Measured on `develop` at `3ca38b33`, 2026-08-10, Node 20, with
+`npm test -- --coverage`:
+
+| Metric     | Coverage | Absolute     |
+| ---------- | -------- | ------------ |
+| Statements | 18.12 %  | 2 572/14 191 |
+| Branches   | 17.31 %  | 2 054/11 861 |
+| Functions  | 14.42 %  | 667/4 624    |
+| Lines      | 18.60 %  | 2 369/12 736 |
+
+947 tests passing across 80 suites, 352 files instrumented.
+
+Read that number together with the coverage rule in
+[CONTRIBUTING.md](../CONTRIBUTING.md#coverage): every file a pull request touches must reach 100 % on
+all four metrics, and CI does not enforce it — it is a review gate. With the repository at 18 %, that
+means touching a long-neglected file makes its whole coverage your obligation. Plan for it rather
+than discovering it in review.
+
+### Full-stack E2E — `npm run e2e:stack`
+
+Introduced by pull request #1288. **Until that is merged, this layer does not exist on `develop`.**
+
+Measured on the pull request head `acb6814a` in CI: 223 tests, 219 passing, 3 skipped, 1 failing, in
+9.6 minutes on a single worker. The failing one is the route gate, correctly: the merge target has a
+route the registry does not claim yet.
+
+What the harness runs for real: Postgres, the API, this frontend, a browser. What it fakes: every
+external provider, on two levels — the API mocks its own outbound calls, and the Docker network it
+sits on has no route to the internet at all. The second level is the load-bearing one, because around
+twenty integrations use vendor SDKs, `graphql-request`, ethers providers or bare `fetch` and bypass
+the API's central HTTP wrapper entirely.
+
+Details, including the factories and the states that are deliberately not achievable, are in
+`e2e-stack/README.md` and `e2e-stack/docs/test-data.md`.
+
+### Route coverage is enforced, not tracked by hand
+
+The suite reads the route definitions out of `src/App.tsx`, resolves nested paths, and fails when a
+route is claimed by no test file or by more than one — and, on a full run, when a claimed route was
+never actually opened by the browser. Adding a route therefore means adding a claim in
+`e2e-stack/specs/registry/` and a test that navigates there.
+
+This is the pattern the reality declaration follows too: **measure the run, do not trust the
+declaration.** Anything the parser cannot resolve is a hard failure rather than a silent omission.
+
+## Reality declaration — hard requirement
+
+Full definition, including all seven categories that count as a fake and the five mandatory fields
+per entry, is in `DFXswiss/api` under `docs/test-architecture.md`. The short form that binds every
+pull request here:
+
+Whenever you introduce, remove or change a fake — a faked external provider, a disabled cron job, a
+schema built without the migration chain, state written directly with SQL, a placeholder value that
+looks real, a suppressed side effect, or a seed correction that bends reality — the declaration
+changes in the same pull request, and each entry says in one plain sentence what a green run does
+**not** prove. A pull request that adds a fake without its declaration is incomplete regardless of
+whether CI is green.
+
+Write the declaration entry **before** building the fake. Reversed, it becomes documentation written
+from memory, with omissions.
+
+## Known gaps
+
+- **No layer here verifies a payment end to end.** Every cron job is disabled in the harness, so the
+  processing chain never executes; transaction states are inserted with SQL instead. What is verified
+  is the synchronous path: interaction, HTTP, validation, authorisation, persistence, display.
+- **The harness does not exercise the migration chain.** It builds the schema from the entities,
+  because one migration requires a seed row that does not exist at migration time on a fresh
+  database. Migrations are covered in `DFXswiss/api` instead.
+- **The harness lives in the wrong repository.** It tests the API as much as this frontend, and
+  `DFXswiss/api` has to check this repository out to obtain it. See the target below.
+- **The suite is serialised.** All specs share one database and one API instance with no per-test
+  isolation, so it runs on a single worker with retries disabled — deliberately, since a retry would
+  mask exactly the order-dependent failure this arrangement produces. It bounds how far the suite can
+  grow.
+
+## Target architecture
+
+_Target — not built yet._ In the order the work should happen:
+
+1. **Per-worker isolation** (a schema or database per worker), so the suite can be parallelised. Cheap
+   while it is small.
+2. **Move the harness out of this repository** — into `DFXswiss/api` or a repository of its own,
+   consuming published frontend and API images by tag instead of sibling checkouts. The stage depends
+   on the applications, never the reverse.
+3. **Adopt a coverage ratchet for the unit layer**, replacing a rule that CI cannot enforce with one
+   that can only move upward.
+
+Each step is additive; none requires discarding what exists.
+
+## Keeping this document honest
+
+Every number carries the commit it was measured on and the command that produces it. When a layer
+changes what it proves, or a fake is added, removed or altered, this document changes in the same
+pull request.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -10,11 +10,11 @@ built yet; nothing here may describe a capability as existing when it does not.
 
 ## The layers this repository owns
 
-| Layer                             | Location                             | What it proves                                                               | What it cannot prove                                                     | Runs in CI                |
-| --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------- |
-| Unit                              | `src/`                               | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                          | yes                       |
-| Full-stack E2E _(not yet merged)_ | `e2e-stack/` — absent on this branch | the seam between frontend, API and database: screens, contracts, persistence | any money movement — all background jobs are switched off during the run | only once #1288 is merged |
-| Visual regression                 | `e2e/`                               | appearance against committed screenshot baselines                            | function                                                                 | no                        |
+| Layer             | Location     | What it proves                                                               | What it cannot prove                                               | Runs in CI |
+| ----------------- | ------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------- |
+| Unit              | `src/`       | the logic of a component, hook or utility, with its surroundings replaced    | that any two parts fit together                                    | yes        |
+| Full-stack E2E    | `e2e-stack/` | the seam between frontend, API and database: screens, contracts, persistence | any money movement — every process-gated job is off during the run | yes        |
+| Visual regression | `e2e/`       | appearance against committed screenshot baselines                            | function                                                           | no         |
 
 The processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity,
 payout, ledger booking — is **not** testable from this repository. It belongs to the integration
@@ -44,32 +44,28 @@ than discovering it in review.
 
 ### Full-stack E2E — `npm run e2e:stack`
 
-**This layer does not exist on this branch.** It arrives with pull request #1288; `e2e-stack/`, its
-registry and its route-coverage gate are absent until that merges. Everything in this section
-describes the state on that pull request, not the state here, and each paragraph below is written
-accordingly.
+This layer arrived with #1288 and lives in `e2e-stack/`.
 
-Measured on the pull-request head `acb6814a` in CI: 223 tests, 219 passing, 3 skipped, 1 failing, in
-9.6 minutes on a single worker. The failing one is the route gate, correctly: the merge target has a
-route the registry does not claim yet.
+Measured on the head of that pull request, `acb6814a`, in CI: 223 tests, of which 219 passed, 3 were
+skipped and 1 failed, in 9.6 minutes on a single worker. The failure was the route gate doing its job —
+the merge target had gained a route the registry did not claim yet. Re-measure after any change to the
+suite; the number of tests is not pinned anywhere.
 
-On that pull request the harness runs the following for real: Postgres, the API, this frontend, a
-browser. It fakes every external provider, on two levels — the API mocks its own outbound calls, and
-the Docker network it sits on has no route to the internet at all. The second level is the
-load-bearing one, because around twenty integrations use vendor SDKs, `graphql-request`, ethers
-providers or bare `fetch` and bypass the API's central HTTP wrapper entirely.
+The harness runs the following for real: Postgres, the API, this frontend, a browser. It fakes every
+external provider, on two levels — the API mocks its own outbound calls, and the Docker network it sits
+on has no route to the internet at all. The second level is the load-bearing one, because around twenty
+integrations use vendor SDKs, `graphql-request`, ethers providers or bare `fetch` and bypass the API's
+central HTTP wrapper entirely.
 
-Once #1288 is merged, the details — the factories and the states that are deliberately not
-achievable — will live in `e2e-stack/README.md` and `e2e-stack/docs/test-data.md`. Neither path
-resolves before then.
+The details — the factories and the states that are deliberately not achievable — are in
+`e2e-stack/README.md` and `e2e-stack/docs/test-data.md`.
 
-### Route coverage, once #1288 is merged
+### Route coverage is enforced, not tracked by hand
 
-_The gate described here ships with #1288 and does not run on this branch._ It reads the route
-definitions out of `src/App.tsx` — which does already carry the nested, exported route list — resolves
-nested paths, and fails when a route is claimed by no test file or by more than one, and on a full run
-also when a claimed route was never actually opened by the browser. Adding a route will therefore mean
-adding a claim in `e2e-stack/specs/registry/` and a test that navigates there.
+The gate reads the route definitions out of `src/App.tsx`, resolves nested paths, and fails when a route
+is claimed by no test file or by more than one, and on a full run also when a claimed route was never
+actually opened by the browser. Adding a route therefore means adding a claim in
+`e2e-stack/specs/registry/` and a test that navigates there.
 
 That gate is the pattern the reality declaration follows: **measure the run, do not trust the
 declaration.** Anything its parser cannot resolve is a hard failure rather than a silent omission.
@@ -92,13 +88,13 @@ from memory, with omissions.
 
 ## Known gaps
 
-All four points below concern the full-stack harness from #1288 and therefore describe that pull
-request's state rather than this branch, where the layer is absent altogether — which makes the first
-point true here in an even stronger sense.
+All four points below concern the full-stack harness.
 
-- **No layer here verifies a payment end to end.** Every cron job is disabled in the harness, so the
-  processing chain never executes; transaction states are inserted with SQL instead. What is verified
-  is the synchronous path: interaction, HTTP, validation, authorisation, persistence, display.
+- **No layer here verifies a payment end to end.** The harness sets `DISABLED_PROCESSES=*`, which
+  switches off every process-gated cron job in the API, so the processing chain never executes;
+  transaction states are inserted with SQL instead. What is verified is the synchronous path:
+  interaction, HTTP, validation, authorisation, persistence, display. (A cron without a `process` field
+  is not covered by that switch and keeps running — see the companion document in `DFXswiss/api`.)
 - **The harness does not exercise the migration chain.** It builds the schema from the entities,
   because one migration requires a seed row that does not exist at migration time on a fresh
   database. Migrations are covered in `DFXswiss/api` instead.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -69,9 +69,11 @@ The gate reads the route definitions out of `src/App.tsx`, resolves nested paths
 has no registry claim or more than one — including two claims inside the same registry file — or when
 the spec file a claim names does not exist. When `E2E_FULL_RUN=1` is set, it additionally fails for a
 claimed route the browser never opened. That flag is declared by the run, not measured from it, so it may
-only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it exactly when it was
-given no arguments, and the CI workflow sets it for its own unfiltered invocation. Adding a route
-therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates there.
+only be set when the run really covers every spec: `e2e-stack/scripts/run.sh` sets it when it was given
+no arguments and clears it otherwise — clearing matters because `e2e-stack/compose.tests.yml` forwards
+whatever the caller's environment holds — and the CI workflow sets it for its own unfiltered invocation.
+Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a test that navigates
+there.
 
 That gate is the pattern the reality declaration follows: **measure the run, do not trust the
 declaration.** Anything its parser cannot resolve is a hard failure rather than a silent omission.

--- a/docs/test-architecture.md
+++ b/docs/test-architecture.md
@@ -24,17 +24,17 @@ layer in `DFXswiss/api`, which runs against a real database. Do not try to cover
 
 ### Unit suite — `npm run test`
 
-Measured on `develop` at `3ca38b33`, 2026-08-10, Node 20, with
+Measured on `develop` at `4e9544a9`, 2026-08-10, Node 20, with
 `npm test -- --coverage`:
 
 | Metric     | Coverage | Absolute     |
 | ---------- | -------- | ------------ |
-| Statements | 18.12 %  | 2 572/14 191 |
+| Statements | 18.15 %  | 2 578/14 198 |
 | Branches   | 17.31 %  | 2 054/11 861 |
-| Functions  | 14.42 %  | 667/4 624    |
-| Lines      | 18.60 %  | 2 369/12 736 |
+| Functions  | 14.44 %  | 668/4 626    |
+| Lines      | 18.63 %  | 2 375/12 742 |
 
-947 tests passing across 80 suites, 352 files instrumented.
+950 tests passing across 81 suites, 353 files instrumented.
 
 Read that number together with the coverage rule in `CONTRIBUTING.md`, section
 "Coverage": every file a pull request touches must reach 100 % on
@@ -63,9 +63,11 @@ The details — the factories and the states that are deliberately not achievabl
 ### Route coverage is enforced, not tracked by hand
 
 The gate reads the route definitions out of `src/App.tsx`, resolves nested paths, and fails when a route
-is claimed by no test file or by more than one, and on a full run also when a claimed route was never
-actually opened by the browser. Adding a route therefore means adding a claim in
-`e2e-stack/specs/registry/` and a test that navigates there.
+has no registry claim or more than one — including two claims inside the same registry file — or when
+the spec file a claim names does not exist. When `E2E_FULL_RUN=1` is set, it additionally fails for a
+claimed route the browser never opened; note that this flag is self-declared by the run, not a measured
+completeness check. Adding a route therefore means adding a claim in `e2e-stack/specs/registry/` and a
+test that navigates there.
 
 That gate is the pattern the reality declaration follows: **measure the run, do not trust the
 declaration.** Anything its parser cannot resolve is a hard failure rather than a silent omission.

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -26,7 +26,7 @@ log_info "Running e2e tests..."
 # The filtered branch clears the variable rather than just not setting it: compose.tests.yml forwards
 # ${E2E_FULL_RUN:-}, so a value inherited from the caller's environment would otherwise survive and
 # make a filtered run declare itself complete.
-if [ "$#" -eq 0 ]; then
+if [[ "$#" -eq 0 ]]; then
   E2E_FULL_RUN=1 compose run --rm tests
 else
   log_info "Arguments given: running a filtered subset, so the route gate checks ownership only."

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -23,9 +23,12 @@ log_info "Running e2e tests..."
 # recording it would be checked against can only ever be partial, so the gate would report routes as
 # never opened just because their specs were filtered out. Any argument here narrows the run, so the
 # flag is set only when there is none — and a filtered run says so instead of failing obscurely later.
+# The filtered branch clears the variable rather than just not setting it: compose.tests.yml forwards
+# ${E2E_FULL_RUN:-}, so a value inherited from the caller's environment would otherwise survive and
+# make a filtered run declare itself complete.
 if [ "$#" -eq 0 ]; then
   E2E_FULL_RUN=1 compose run --rm tests
 else
   log_info "Arguments given: running a filtered subset, so the route gate checks ownership only."
-  compose run --rm tests "$@"
+  E2E_FULL_RUN= compose run --rm tests "$@"
 fi

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -18,6 +18,14 @@ fi
 
 build_tests_image
 log_info "Running e2e tests..."
-# Declares that every spec is in scope, which is what lets the coverage gate check that each route
-# was actually opened rather than merely claimed. A filtered run must not set this.
-E2E_FULL_RUN=1 compose run --rm tests "$@"
+# E2E_FULL_RUN declares that every spec is in scope, which is what lets the coverage gate check that
+# each route was actually opened rather than merely claimed. A filtered run must not set it: the
+# recording it would be checked against can only ever be partial, so the gate would report routes as
+# never opened just because their specs were filtered out. Any argument here narrows the run, so the
+# flag is set only when there is none — and a filtered run says so instead of failing obscurely later.
+if [ "$#" -eq 0 ]; then
+  E2E_FULL_RUN=1 compose run --rm tests
+else
+  log_info "Arguments given: running a filtered subset, so the route gate checks ownership only."
+  compose run --rm tests "$@"
+fi


### PR DESCRIPTION
Documents the test layers this repository owns with measured numbers, links to the canonical cross-repository description, and makes a reality declaration mandatory whenever a test setup replaces something real with a fake.

## Why

The unit suite, the full-stack harness and the visual-regression suite answer three different questions, and what each one fakes was described across several files. The practical consequence: a full-stack run can be green while no layer verifies a payment end to end, because every process-gated background job is switched off during that run. That should be readable in one place instead of measured.

## What this adds

`docs/test-architecture.md` for the three layers this repository owns, stating for each what it proves, what it deliberately does not prove, and whether it runs in CI. It also states plainly that the processing chain behind the API — incoming transfers, AML, purchase calculation, liquidity, payout, ledger booking — is not testable from here and belongs to the integration layer in `DFXswiss/api`.

Current state is separated from target architecture, and every number carries the commit it was measured on plus the command that reproduces it. Measured on `develop` at `4e9544a9`:

| Metric     | Coverage | Absolute     |
| ---------- | -------- | ------------ |
| Statements | 18.15 %  | 2 578/14 198 |
| Branches   | 17.31 %  | 2 054/11 861 |
| Functions  | 14.44 %  | 668/4 626    |
| Lines      | 18.63 %  | 2 375/12 742 |

That number is what the existing coverage rule has to be read against: every file a pull request touches must reach 100 % on all four metrics, and CI does not enforce it — it is a review gate. At 18 %, touching a long-neglected file makes its whole coverage an obligation, which is worth planning for rather than discovering in review.

## Written against a moving target

The document was first written while #1288 was still open, so every mention of the full-stack layer was a forward reference. #1288 has since been merged, this branch was rebased onto it, and the document now describes that layer as present, with the unit figures re-measured on the merged develop: `e2e-stack/`, its registry and the route gate are on `develop`. The figures for the suite keep the commit they were measured on — the head of that pull request — with a note to re-measure after changes.

Both references between the two files are plain paths rather than markdown links, on purpose: the handbook build renders every markdown file to HTML, and its integrity check then requires every relative reference beginning with `docs/`, `assets/` or `screenshots/` to exist in that output — which a reference to a `.md` file never does. That check turned the container-smoke job red once during this work. References outside those three prefixes are unaffected, which is why the existing link to `e2e-stack/README.md` is fine.

## The reality declaration

Whenever a pull request introduces, removes or changes a fake — a faked external provider, a disabled cron job, a schema built without the migration chain, state written directly with SQL, a placeholder value that looks real, a suppressed side effect, or a seed correction that bends reality — the declaration changes in the same pull request, and each entry says in one plain sentence what a green run does **not** prove. The entry is written before the fake is built; reversed, it becomes documentation written from memory, with omissions.

The full definition lives in `DFXswiss/api` so the two repositories cannot drift apart on it. The measurement principle follows the route gate already used here: verify what the run actually did, not what someone declared.

## Also fixes the full-run flag

`e2e-stack/scripts/run.sh` set `E2E_FULL_RUN=1` on every invocation while forwarding `"$@"` — the very way a filter reaches Playwright. So `npm run e2e:stack -- --grep x` declared a full run and executed a subset, and the route-coverage gate then checked its claim list against a navigation recording that could only be partial, reporting routes as never opened because their specs had been filtered out. The comment directly above that line already stated the rule the line broke.

The flag is now set only when no arguments were given, and a filtered run says so in its log. CI is unaffected: `e2e-stack.yml` does not use `run.sh` and sets the variable itself for its own unfiltered invocation. The documentation names both sources of the flag, so rule and implementation can be checked against each other.

This was found while reviewing the documentation of that gate. It is fixed here rather than deferred, because a defect in code a pull request touches gets fixed in that pull request.

## Coverage

None of the three files this pull request touches is instrumented by Jest: `collectCoverageFrom` in `package.json` covers `src/**/*.{ts,tsx,js,jsx}` minus declarations, while the changes are `CONTRIBUTING.md`, `docs/test-architecture.md` and `e2e-stack/scripts/run.sh`. There are therefore no per-file coverage figures to state, and no under-fulfilment of the 100 % rule to declare.

## Scope

Documentation only — no code, no workflow and no test changes.

