### PR TITLE
4fd00f34 - Close the E2E gate-integrity holes and bind route coverage to its claim

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,13 @@ playwright-report
 # image from this directory. Without this line the whole of it travels to the Docker daemon as
 # build context on every image build.
 api-repo
+# Gitignore does not protect the Docker build context: context is whatever is on disk, not what
+# Git tracks. An untracked or gitignored .env still reaches the daemon and lands in builder
+# layers — and CRA (frontend / frontend-widget) bakes any REACT_APP_* values it finds in a .env
+# file into the JS bundle at build time. e2e-stack/scripts/up.sh also writes
+# e2e-stack/.env.generated with build-time-resolved values before `compose build frontend`; that
+# file must stay out of the context too.
+.env
+**/.env
+**/.env.*
+e2e-stack/.env.generated

--- a/e2e-stack/docs/test-data.md
+++ b/e2e-stack/docs/test-data.md
@@ -218,6 +218,8 @@ the "level 50 but no limit granted" case instead.
 
 Deletes every row tracked during this process (`{ table, id }`) in reverse creation order, descending into rows that reference them by foreign key first — including rows the application itself wrote and no test registered. Returns `{ deleted, errors }` on success and stays silent; if any delete fails, the failed references are re-registered for the next call and it throws an `AggregateError`, so the spec file that caused the leftover goes red rather than an unrelated one later against the shared database.
 
+A table that cannot be addressed by an exact single-column `id` primary key is not bulk-deleted when another table references it, or when the candidate rows are actually referenced through a self-referencing foreign key (declaring an unused self-FK in the schema is not enough). Cleanup leaves all matching rows in that table untouched and fails loudly with `table "<table>" is referenced by other tables but has no primary key of exactly the single column "id": cleanup can only SELECT/recurse by id, so this table's own descendants cannot be discovered and no rows were deleted for it` or `table "<table>" is referenced by itself via a self-referencing foreign key but has no primary key of exactly the single column "id": cleanup cannot safely bulk delete its rows because self-referencing descendants could be orphaned instead of removed`.
+
 ### Helpers
 
 - `requireId` validates every create-response id and every id passed to `track()` / `trackRow()`.

--- a/e2e-stack/docs/test-data.md
+++ b/e2e-stack/docs/test-data.md
@@ -170,7 +170,7 @@ the "level 50 but no limit granted" case instead.
 |                   |                                                                                       |
 | ----------------- | ------------------------------------------------------------------------------------- |
 | **Path**          | API `POST /v1/support/issue`                                                          |
-| **Returns**       | `{ supportIssueId?, uid, messageId? }`                                                |
+| **Returns**       | `{ supportIssueId, uid, messageId? }`                                                 |
 | **Options**       | `type` (default `GenericIssue`), `reason` (default `Other`), `name`, `message`, `tag` |
 | **Preconditions** | User must have **mail** (factory sets it if missing)                                  |
 
@@ -220,6 +220,10 @@ Deletes every row tracked during this process (`{ table, id }`) in reverse creat
 
 ### Helpers
 
+- `requireId` validates every create-response id and every id passed to `track()` / `trackRow()`.
+  It throws unless the value is a positive integer, so a successful API response with a missing
+  or invalid id cannot register a nonexistent cleanup row or let a test assert against data that
+  was never written.
 - `requireUnusedDeposit(blockchain)` — throws if no free deposit.
 - `ensurePersonalDataComplete(userDataId)` — SQL fill for `isDataComplete`.
 - `e2eMail(tag?)`, `TEST_IBAN`, `resetFactoryCounter()`.

--- a/e2e-stack/docs/test-data.md
+++ b/e2e-stack/docs/test-data.md
@@ -220,6 +220,8 @@ Deletes every row tracked during this process (`{ table, id }`) in reverse creat
 
 A table that cannot be addressed by an exact single-column `id` primary key is not bulk-deleted when another table references it, or when the candidate rows are actually referenced through a self-referencing foreign key (declaring an unused self-FK in the schema is not enough). Cleanup leaves all matching rows in that table untouched and fails loudly with `table "<table>" is referenced by other tables but has no primary key of exactly the single column "id": cleanup can only SELECT/recurse by id, so this table's own descendants cannot be discovered and no rows were deleted for it` or `table "<table>" is referenced by itself via a self-referencing foreign key but has no primary key of exactly the single column "id": cleanup cannot safely bulk delete its rows because self-referencing descendants could be orphaned instead of removed`.
 
+The self-reference check is deliberately conservative for a key spanning several columns: the catalogue carries no constraint identity to group pairs by, so each column pair is probed on its own. That can refuse a delete which the full key would have allowed, never allow one it would have refused.
+
 ### Helpers
 
 - `requireId` validates every create-response id and every id passed to `track()` / `trackRow()`.

--- a/e2e-stack/docs/test-data.md
+++ b/e2e-stack/docs/test-data.md
@@ -216,7 +216,7 @@ the "level 50 but no limit granted" case instead.
 
 ### `cleanupCreatedData()`
 
-Deletes every row tracked during this process (`{ table, id }`) in reverse creation order. Best-effort; returns `{ deleted, errors }`.
+Deletes every row tracked during this process (`{ table, id }`) in reverse creation order, descending into rows that reference them by foreign key first — including rows the application itself wrote and no test registered. Returns `{ deleted, errors }` on success and stays silent; if any delete fails, the failed references are re-registered for the next call and it throws an `AggregateError`, so the spec file that caused the leftover goes red rather than an unrelated one later against the shared database.
 
 ### Helpers
 

--- a/e2e-stack/playwright.config.ts
+++ b/e2e-stack/playwright.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
   // exactly the failure a retry hides, because the second attempt runs against the state the first
   // one left behind. A flake here is a report about the harness that has to stay visible.
   retries: 0,
+  // A committed test.only would silently shrink the suite — and with it the coverage-gate
+  // project — to a fraction of its claims while the run still reports green. This harness is a
+  // gate and must not be self-disableable.
+  forbidOnly: true,
   timeout: 60000,
   expect: { timeout: 15000 },
   reporter: [['list'], ['html', { open: 'never', outputFolder: './playwright-report' }]],

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -19,13 +19,30 @@ fi
 build_tests_image
 log_info "Running e2e tests..."
 # Declares that every spec is in scope, which is what lets the coverage gate check that each route
-# was actually opened rather than merely claimed. A filtered run must not set this — "$@" is
-# exactly how a --grep/--grep-invert reaches Playwright, and claiming full coverage on a run that
-# skipped most specs would compare claims against a navigation record that was never complete. A
-# filtered run instead only gets the gate's ownership check (route-coverage.spec.ts, the
+# was actually opened rather than merely claimed. Only real filters flip this off: --grep /
+# --grep-invert (and their =value forms) or a positional spec-file path pattern. Other flags
+# (--reporter, --workers, …) do not filter which specs run and must not drop the full-run check.
+# A filtered run instead only gets the gate's ownership check (route-coverage.spec.ts, the
 # `E2E_FULL_RUN !== '1'` branch), which prints that loudly instead of claiming coverage.
-if [[ $# -eq 0 ]]; then
-  E2E_FULL_RUN=1 compose run --rm tests
+is_filtered_run() {
+  for arg in "$@"; do
+    case "$arg" in
+      --grep|--grep=*|--grep-invert|--grep-invert=*) return 0 ;;
+      -*) ;;
+      *) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+if [[ $# -eq 0 ]] || ! is_filtered_run "$@"; then
+  E2E_FULL_RUN=1 compose run --rm tests "$@"
 else
+  # A real filter is present (--grep/--grep-invert or a spec-file pattern) — this run legitimately
+  # covers only part of the suite. Explicitly clear any E2E_FULL_RUN inherited from the calling
+  # shell so a filtered local run cannot accidentally claim full coverage. CI does not go through
+  # run.sh at all — the workflow sets E2E_FULL_RUN itself (see .github/workflows/e2e-stack.yml) —
+  # so this heuristic is a local/dev safety net only, not part of the merge gate.
+  unset E2E_FULL_RUN
   compose run --rm tests "$@"
 fi

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -24,10 +24,22 @@ log_info "Running e2e tests..."
 # (--reporter, --workers, …) do not filter which specs run and must not drop the full-run check.
 # A filtered run instead only gets the gate's ownership check (route-coverage.spec.ts, the
 # `E2E_FULL_RUN !== '1'` branch), which prints that loudly instead of claiming coverage.
+# Flags that take their value as the NEXT argument. Without skipping that value, `--workers 1`
+# would leave a bare `1` to be read as a positional spec pattern, and a genuinely complete run
+# would lose the full-run check - the opposite of the mistake this function exists to prevent.
 is_filtered_run() {
+  local skip_value=0
   for arg in "$@"; do
+    if [[ $skip_value -eq 1 ]]; then
+      skip_value=0
+      continue
+    fi
     case "$arg" in
-      --grep|--grep=*|--grep-invert|--grep-invert=*) return 0 ;;
+      --grep|--grep-invert) return 0 ;;
+      --grep=*|--grep-invert=*) return 0 ;;
+      --workers|--reporter|--project|--timeout|--repeat-each|--retries|--shard|--output|--max-failures|--config|-j|-c)
+        skip_value=1
+        ;;
       -*) ;;
       *) return 0 ;;
     esac

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -35,9 +35,15 @@ is_filtered_run() {
       continue
     fi
     case "$arg" in
-      --grep|--grep-invert) return 0 ;;
-      --grep=*|--grep-invert=*) return 0 ;;
-      --workers|--reporter|--project|--timeout|--repeat-each|--retries|--shard|--output|--max-failures|--config|-j|-c)
+      # Real filters: they decide which tests run at all. --project is one of them here, and it is
+      # the sharpest: the coverage gate lives in its own `coverage-gate` project (playwright.config.ts),
+      # so `--project chromium` runs the suite without ever running the gate. --list executes nothing.
+      --grep|--grep-invert|--project|--shard) return 0 ;;
+      --grep=*|--grep-invert=*|--project=*|--shard=*) return 0 ;;
+      --list) return 0 ;;
+      # Value-taking flags that do not change which tests run. Their value must be skipped, or a bare
+      # `1` from `--workers 1` would be read below as a positional spec pattern.
+      --workers|--reporter|--timeout|--repeat-each|--retries|--output|--max-failures|--config|-j|-c)
         skip_value=1
         ;;
       -*) ;;

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -19,14 +19,15 @@ fi
 build_tests_image
 log_info "Running e2e tests..."
 # Declares that every spec is in scope, which is what lets the coverage gate check that each route
-# was actually opened rather than merely claimed. Only real filters flip this off: --grep /
-# --grep-invert (and their =value forms) or a positional spec-file path pattern. Other flags
-# (--reporter, --workers, …) do not filter which specs run and must not drop the full-run check.
-# A filtered run instead only gets the gate's ownership check (route-coverage.spec.ts, the
-# `E2E_FULL_RUN !== '1'` branch), which prints that loudly instead of claiming coverage.
-# Flags that take their value as the NEXT argument. Without skipping that value, `--workers 1`
-# would leave a bare `1` to be read as a positional spec pattern, and a genuinely complete run
-# would lose the full-run check - the opposite of the mistake this function exists to prevent.
+# was actually opened rather than merely claimed. A filtered run instead gets only the gate's
+# ownership check (route-coverage.spec.ts, the `E2E_FULL_RUN !== '1'` branch), which says so loudly
+# instead of claiming coverage.
+#
+# The check below is an allowlist on purpose. Listing filters and treating everything else as
+# complete was tried twice here and was wrong twice: --project, --shard, --last-failed and
+# --only-changed were all missed in turn, and each omission let a partial run declare itself
+# complete. An allowlist fails the other way - an unrecognised flag costs the strict navigation
+# check on a local run, which is the harmless direction.
 is_filtered_run() {
   local skip_value=0
   for arg in "$@"; do
@@ -35,23 +36,19 @@ is_filtered_run() {
       continue
     fi
     case "$arg" in
-      # Real filters: they decide which tests run at all. --project is the sharpest: the coverage
-      # gate lives in its own `coverage-gate` project (playwright.config.ts), so `--project chromium`
-      # runs the suite without ever running the gate. It is refused whatever value it carries -
-      # `--project coverage-gate` does pull the whole dependency chain and is effectively complete,
-      # but treating one project name as "complete" would be a rule nobody can see from the call
-      # site; the documented way to run only the gate is `--grep @coverage-gate`.
-      --grep|--grep-invert|--project|--shard) return 0 ;;
-      --grep=*|--grep-invert=*|--project=*|--shard=*) return 0 ;;
-      # --last-failed and --only-changed select a subset from run history or the working tree;
-      # --list executes nothing at all.
-      --list|--last-failed|--only-changed|--only-changed=*) return 0 ;;
-      # Value-taking flags that do not change which tests run. Their value must be skipped, or a bare
-      # `1` from `--workers 1` would be read below as a positional spec pattern.
-      --workers|--reporter|--timeout|--global-timeout|--repeat-each|--retries|--output|--max-failures|--config|-j|-c)
-        skip_value=1
-        ;;
-      -*) ;;
+      # The ONLY flags that leave the run complete. Everything else counts as a filter, including
+      # flags Playwright may add after this was written: guessing wrong in that direction merely
+      # drops the strict navigation check, while guessing wrong the other way lets a partial run
+      # claim full coverage - which is the whole failure this gate exists to prevent. --project is
+      # deliberately not on this list even for `--project coverage-gate`, which does pull the entire
+      # dependency chain: encoding one project name as "complete" would be a rule invisible from the
+      # call site, and the documented way to run only the gate is `--grep @coverage-gate`.
+      --workers=*|--reporter=*|--timeout=*|--global-timeout=*|--repeat-each=*|--retries=*) ;;
+      --output=*|--max-failures=*|--config=*|--trace=*|--tsconfig=*|--quiet|--pass-with-no-tests) ;;
+      # Same flags in their separate-value form: skip the value too, or a bare `1` from
+      # `--workers 1` would be read below as a positional spec pattern.
+      --workers|--reporter|--timeout|--global-timeout|--repeat-each|--retries) skip_value=1 ;;
+      --output|--max-failures|--config|--trace|--tsconfig|-j|-c) skip_value=1 ;;
       *) return 0 ;;
     esac
   done

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -61,11 +61,12 @@ is_filtered_run() {
 if [[ $# -eq 0 ]] || ! is_filtered_run "$@"; then
   E2E_FULL_RUN=1 compose run --rm tests "$@"
 else
-  # A real filter is present (--grep/--grep-invert or a spec-file pattern) — this run legitimately
-  # covers only part of the suite. Explicitly clear any E2E_FULL_RUN inherited from the calling
-  # shell so a filtered local run cannot accidentally claim full coverage. CI does not go through
-  # run.sh at all — the workflow sets E2E_FULL_RUN itself (see .github/workflows/e2e-stack.yml) —
-  # so this heuristic is a local/dev safety net only, not part of the merge gate.
-  unset E2E_FULL_RUN
-  compose run --rm tests "$@"
+  # A real filter is present — this run legitimately covers only part of the suite. The variable is
+  # passed empty rather than merely left unset: compose.tests.yml forwards ${E2E_FULL_RUN:-}, so a
+  # value exported by the calling shell would otherwise survive into the container and let a
+  # filtered run declare itself complete. CI does not go through run.sh at all — the workflow sets
+  # E2E_FULL_RUN itself (see .github/workflows/e2e-stack.yml) — so this is a local/dev safety net,
+  # not part of the merge gate.
+  log_info "Filter argument given: running a subset, so the route gate checks ownership only."
+  E2E_FULL_RUN= compose run --rm tests "$@"
 fi

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -42,13 +42,16 @@ is_filtered_run() {
       # claim full coverage - which is the whole failure this gate exists to prevent. --project is
       # deliberately not on this list even for `--project coverage-gate`, which does pull the entire
       # dependency chain: encoding one project name as "complete" would be a rule invisible from the
-      # call site, and the documented way to run only the gate is `--grep @coverage-gate`.
+      # call site, and the documented way to run only the gate is `--grep @coverage-gate`. `--config`
+      # and `-c` are off the list for the same reason: another config can set its own testDir,
+      # testMatch or project list and drop the coverage-gate project entirely, so a flag that can
+      # replace the whole selection cannot be one that promises the selection is complete.
       --workers=*|--reporter=*|--timeout=*|--global-timeout=*|--repeat-each=*|--retries=*) ;;
-      --output=*|--max-failures=*|--config=*|--trace=*|--tsconfig=*|--quiet|--pass-with-no-tests) ;;
+      --output=*|--max-failures=*|--trace=*|--tsconfig=*|--quiet|--pass-with-no-tests|--headed) ;;
       # Same flags in their separate-value form: skip the value too, or a bare `1` from
       # `--workers 1` would be read below as a positional spec pattern.
       --workers|--reporter|--timeout|--global-timeout|--repeat-each|--retries) skip_value=1 ;;
-      --output|--max-failures|--config|--trace|--tsconfig|-j|-c) skip_value=1 ;;
+      --output|--max-failures|--trace|--tsconfig|-j) skip_value=1 ;;
       *) return 0 ;;
     esac
   done

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -35,15 +35,20 @@ is_filtered_run() {
       continue
     fi
     case "$arg" in
-      # Real filters: they decide which tests run at all. --project is one of them here, and it is
-      # the sharpest: the coverage gate lives in its own `coverage-gate` project (playwright.config.ts),
-      # so `--project chromium` runs the suite without ever running the gate. --list executes nothing.
+      # Real filters: they decide which tests run at all. --project is the sharpest: the coverage
+      # gate lives in its own `coverage-gate` project (playwright.config.ts), so `--project chromium`
+      # runs the suite without ever running the gate. It is refused whatever value it carries -
+      # `--project coverage-gate` does pull the whole dependency chain and is effectively complete,
+      # but treating one project name as "complete" would be a rule nobody can see from the call
+      # site; the documented way to run only the gate is `--grep @coverage-gate`.
       --grep|--grep-invert|--project|--shard) return 0 ;;
       --grep=*|--grep-invert=*|--project=*|--shard=*) return 0 ;;
-      --list) return 0 ;;
+      # --last-failed and --only-changed select a subset from run history or the working tree;
+      # --list executes nothing at all.
+      --list|--last-failed|--only-changed|--only-changed=*) return 0 ;;
       # Value-taking flags that do not change which tests run. Their value must be skipped, or a bare
       # `1` from `--workers 1` would be read below as a positional spec pattern.
-      --workers|--reporter|--timeout|--repeat-each|--retries|--output|--max-failures|--config|-j|-c)
+      --workers|--reporter|--timeout|--global-timeout|--repeat-each|--retries|--output|--max-failures|--config|-j|-c)
         skip_value=1
         ;;
       -*) ;;

--- a/e2e-stack/scripts/run.sh
+++ b/e2e-stack/scripts/run.sh
@@ -18,17 +18,14 @@ fi
 
 build_tests_image
 log_info "Running e2e tests..."
-# E2E_FULL_RUN declares that every spec is in scope, which is what lets the coverage gate check that
-# each route was actually opened rather than merely claimed. A filtered run must not set it: the
-# recording it would be checked against can only ever be partial, so the gate would report routes as
-# never opened just because their specs were filtered out. Any argument here narrows the run, so the
-# flag is set only when there is none — and a filtered run says so instead of failing obscurely later.
-# The filtered branch clears the variable rather than just not setting it: compose.tests.yml forwards
-# ${E2E_FULL_RUN:-}, so a value inherited from the caller's environment would otherwise survive and
-# make a filtered run declare itself complete.
-if [[ "$#" -eq 0 ]]; then
+# Declares that every spec is in scope, which is what lets the coverage gate check that each route
+# was actually opened rather than merely claimed. A filtered run must not set this — "$@" is
+# exactly how a --grep/--grep-invert reaches Playwright, and claiming full coverage on a run that
+# skipped most specs would compare claims against a navigation record that was never complete. A
+# filtered run instead only gets the gate's ownership check (route-coverage.spec.ts, the
+# `E2E_FULL_RUN !== '1'` branch), which prints that loudly instead of claiming coverage.
+if [[ $# -eq 0 ]]; then
   E2E_FULL_RUN=1 compose run --rm tests
 else
-  log_info "Arguments given: running a filtered subset, so the route gate checks ownership only."
-  E2E_FULL_RUN= compose run --rm tests "$@"
+  compose run --rm tests "$@"
 fi

--- a/e2e-stack/specs/factories.spec.ts
+++ b/e2e-stack/specs/factories.spec.ts
@@ -9,7 +9,7 @@
 
 import { test, expect } from '@playwright/test';
 import { required } from './fixtures';
-import { queryOne } from './fixtures/db';
+import { queryOne, withDb } from './fixtures/db';
 import {
   cleanupCreatedData,
   createBankAccount,
@@ -26,6 +26,7 @@ import {
   createTransaction,
   createUser,
   TEST_IBAN,
+  trackRow,
 } from './fixtures/factories';
 
 test.describe.configure({ mode: 'serial' });
@@ -33,6 +34,21 @@ test.describe.configure({ mode: 'serial' });
 test.describe('e2e factories', () => {
   test.afterAll(async () => {
     await cleanupCreatedData();
+  });
+
+  test('trackRow rejects invalid ids before registering cleanup data', () => {
+    const invalidIds: Array<{ label: string; value: number }> = [
+      { label: 'zero', value: 0 },
+      { label: 'negative', value: -7 },
+      { label: 'string', value: 'not-an-id' as unknown as number },
+    ];
+
+    for (const { label, value } of invalidIds) {
+      expect(
+        () => trackRow('table_that_does_not_exist_for_require_id_test', value),
+        `${label} id must be rejected`,
+      ).toThrow(/expected a finite positive integer/);
+    }
   });
 
   test('createUser registers a wallet user and optional KYC level', async () => {
@@ -253,5 +269,74 @@ test.describe('e2e factories', () => {
       [entry.userDataId],
     );
     expect(row?.phoneCallStatus).toBe('Unavailable');
+  });
+
+  // The raw inserts below bypass createTransaction() on purpose, and that is the whole point of the
+  // test: every factory tracks each row it writes, so a chain built through them would be deleted
+  // by its own top-level registrations even if the recursion were broken. Writing the children
+  // directly reproduces what the application does in production — rows appear under a tracked row
+  // that no test registered — and only the descent into the foreign keys can remove them.
+  //
+  // Last test in the block by necessity: it calls cleanupCreatedData() itself, which empties the
+  // process-wide registry that the earlier tests share.
+  test('cleanup recursively deletes untracked database children of a tracked user', async () => {
+    const user = await createUser({ tag: 'spec-recursive-cleanup' });
+
+    const { transactionId, bankTxId } = await withDb(async (client) => {
+      const transactionInsert = await client.query<{ id: number }>(
+        `INSERT INTO transaction
+           ("sourceType", type, uid, "amountInChf", assets, "amlCheck", "userId", "userDataId", "eventDate", "outputDate")
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         RETURNING id`,
+        [
+          'BankTx',
+          'BuyCrypto',
+          `T${String(user.userId).padStart(16, '0')}`,
+          100,
+          'CHF',
+          'Pass',
+          user.userId,
+          user.userDataId,
+          new Date(),
+          new Date(),
+        ],
+      );
+      const transactionId = required(
+        transactionInsert.rows[0],
+        'raw transaction insert must return an id',
+      ).id;
+
+      const bankTxInsert = await client.query<{ id: number }>(
+        `INSERT INTO bank_tx
+           ("accountServiceRef", amount, currency, "creditDebitIndicator", iban, type,
+            "bookingDate", "valueDate", "transactionId", name)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         RETURNING id`,
+        [
+          `e2e-recursive-cleanup-${transactionId}`,
+          100,
+          'CHF',
+          'CRDT',
+          TEST_IBAN,
+          'BuyCrypto',
+          new Date(),
+          new Date(),
+          transactionId,
+          'E2E Recursive Cleanup',
+        ],
+      );
+      const bankTxId = required(bankTxInsert.rows[0], 'raw bank_tx insert must return an id').id;
+
+      return { transactionId, bankTxId };
+    });
+
+    await cleanupCreatedData();
+
+    const transaction = await queryOne<{ id: number }>(`SELECT id FROM transaction WHERE id = $1`, [
+      transactionId,
+    ]);
+    const bankTx = await queryOne<{ id: number }>(`SELECT id FROM bank_tx WHERE id = $1`, [bankTxId]);
+    expect(transaction).toBeUndefined();
+    expect(bankTx).toBeUndefined();
   });
 });

--- a/e2e-stack/specs/factories.spec.ts
+++ b/e2e-stack/specs/factories.spec.ts
@@ -25,6 +25,8 @@ import {
   createSwap,
   createTransaction,
   createUser,
+  getForeignKeys,
+  resetForeignKeysCache,
   TEST_IBAN,
   trackRow,
 } from './fixtures/factories';
@@ -271,14 +273,59 @@ test.describe('e2e factories', () => {
     expect(row?.phoneCallStatus).toBe('Unavailable');
   });
 
+  // Without this regression test, joining key_column_usage to constraint_column_usage only by
+  // constraint name could reintroduce a four-entry cross product instead of preserving the two
+  // ordinal child-to-parent column pairs in a composite foreign key.
+  test('getForeignKeys preserves composite foreign-key column ordinality', async () => {
+    try {
+      await withDb(async (client) => {
+        await client.query(
+          `CREATE TABLE e2e_spec_fk_ordinal_parent (
+             x integer NOT NULL,
+             y integer NOT NULL,
+             PRIMARY KEY (x, y)
+           )`,
+        );
+        await client.query(
+          `CREATE TABLE e2e_spec_fk_ordinal_child (
+             a integer NOT NULL,
+             b integer NOT NULL,
+             FOREIGN KEY (a, b) REFERENCES e2e_spec_fk_ordinal_parent (x, y)
+           )`,
+        );
+      });
+
+      resetForeignKeysCache();
+      const foreignKeys = await getForeignKeys();
+      const childPairs = foreignKeys
+        .filter((foreignKey) => foreignKey.table === 'e2e_spec_fk_ordinal_child')
+        .map((foreignKey) => ({
+          column: foreignKey.column,
+          referencedColumn: foreignKey.referencedColumn,
+        }))
+        .sort((left, right) => left.column.localeCompare(right.column));
+
+      expect(childPairs).toEqual([
+        { column: 'a', referencedColumn: 'x' },
+        { column: 'b', referencedColumn: 'y' },
+      ]);
+    } finally {
+      await withDb(async (client) => {
+        await client.query(`DROP TABLE IF EXISTS e2e_spec_fk_ordinal_child`);
+        await client.query(`DROP TABLE IF EXISTS e2e_spec_fk_ordinal_parent`);
+      });
+      resetForeignKeysCache();
+    }
+  });
+
   // The raw inserts below bypass createTransaction() on purpose, and that is the whole point of the
   // test: every factory tracks each row it writes, so a chain built through them would be deleted
   // by its own top-level registrations even if the recursion were broken. Writing the children
   // directly reproduces what the application does in production — rows appear under a tracked row
   // that no test registered — and only the descent into the foreign keys can remove them.
   //
-  // Last test in the block by necessity: it calls cleanupCreatedData() itself, which empties the
-  // process-wide registry that the earlier tests share.
+  // The cleanup-focused tests must stay at the end of the block: they call cleanupCreatedData()
+  // themselves, which empties the process-wide registry that the earlier tests share.
   test('cleanup recursively deletes untracked database children of a tracked user', async () => {
     const user = await createUser({ tag: 'spec-recursive-cleanup' });
 
@@ -338,5 +385,190 @@ test.describe('e2e factories', () => {
     const bankTx = await queryOne<{ id: number }>(`SELECT id FROM bank_tx WHERE id = $1`, [bankTxId]);
     expect(transaction).toBeUndefined();
     expect(bankTx).toBeUndefined();
+  });
+
+  // Without this regression test, the mere schema presence of a self-referencing foreign key
+  // could block a safe bulk delete even though none of the candidate rows is actually referenced.
+  test('cleanup bulk-deletes a non-id-addressable child with an unused self foreign key', async () => {
+    let parentId: number | undefined;
+    let registryDrained = false;
+
+    try {
+      await withDb(async (client) => {
+        await client.query(
+          `CREATE TABLE e2e_spec_unused_self_parent (
+             id serial PRIMARY KEY
+           )`,
+        );
+        await client.query(
+          `CREATE TABLE e2e_spec_unused_self_child (
+             parent_id integer NOT NULL REFERENCES e2e_spec_unused_self_parent (id),
+             code text NOT NULL UNIQUE,
+             predecessor_code text REFERENCES e2e_spec_unused_self_child (code),
+             PRIMARY KEY (parent_id, code)
+           )`,
+        );
+      });
+      resetForeignKeysCache();
+
+      parentId = await withDb(async (client) => {
+        const parentInsert = await client.query<{ id: number }>(
+          `INSERT INTO e2e_spec_unused_self_parent DEFAULT VALUES RETURNING id`,
+        );
+        const insertedParentId = required(
+          parentInsert.rows[0],
+          'self-reference parent insert must return an id',
+        ).id;
+        await client.query(
+          `INSERT INTO e2e_spec_unused_self_child (parent_id, code, predecessor_code)
+           VALUES ($1, $2, $3)`,
+          [insertedParentId, 'A', null],
+        );
+        return insertedParentId;
+      });
+
+      trackRow('e2e_spec_unused_self_parent', parentId);
+      await cleanupCreatedData();
+      registryDrained = true;
+
+      const parent = await queryOne<{ id: number }>(
+        `SELECT id FROM e2e_spec_unused_self_parent WHERE id = $1`,
+        [parentId],
+      );
+      const child = await queryOne<{ code: string }>(
+        `SELECT code FROM e2e_spec_unused_self_child WHERE parent_id = $1`,
+        [parentId],
+      );
+      expect(parent).toBeUndefined();
+      expect(child).toBeUndefined();
+    } finally {
+      try {
+        if (!registryDrained && parentId !== undefined) {
+          await withDb(async (client) => {
+            await client.query(
+              `DELETE FROM e2e_spec_unused_self_child WHERE parent_id = $1`,
+              [parentId],
+            );
+            await client.query(
+              `DELETE FROM e2e_spec_unused_self_parent WHERE id = $1`,
+              [parentId],
+            );
+          });
+          await cleanupCreatedData();
+        }
+      } finally {
+        await withDb(async (client) => {
+          await client.query(`DROP TABLE IF EXISTS e2e_spec_unused_self_child`);
+          await client.query(`DROP TABLE IF EXISTS e2e_spec_unused_self_parent`);
+        });
+        resetForeignKeysCache();
+      }
+    }
+  });
+
+  // Without this regression test, an overly permissive row check could allow a bulk delete even
+  // though a candidate row is genuinely referenced through the table's self foreign key.
+  test('cleanup rejects a non-id-addressable child with an actual self reference', async () => {
+    let parentId: number | undefined;
+    let registryDrained = false;
+
+    try {
+      await withDb(async (client) => {
+        await client.query(
+          `CREATE TABLE e2e_spec_actual_self_parent (
+             id serial PRIMARY KEY
+           )`,
+        );
+        await client.query(
+          `CREATE TABLE e2e_spec_actual_self_child (
+             parent_id integer NOT NULL REFERENCES e2e_spec_actual_self_parent (id),
+             code text NOT NULL UNIQUE,
+             predecessor_code text REFERENCES e2e_spec_actual_self_child (code),
+             PRIMARY KEY (parent_id, code)
+           )`,
+        );
+      });
+      resetForeignKeysCache();
+
+      parentId = await withDb(async (client) => {
+        const parentInsert = await client.query<{ id: number }>(
+          `INSERT INTO e2e_spec_actual_self_parent DEFAULT VALUES RETURNING id`,
+        );
+        const insertedParentId = required(
+          parentInsert.rows[0],
+          'self-reference parent insert must return an id',
+        ).id;
+        await client.query(
+          `INSERT INTO e2e_spec_actual_self_child (parent_id, code, predecessor_code)
+           VALUES ($1, $2, $3), ($1, $4, $5)`,
+          [insertedParentId, 'A', null, 'B', 'A'],
+        );
+        return insertedParentId;
+      });
+
+      trackRow('e2e_spec_actual_self_parent', parentId);
+      let cleanupError: unknown;
+      try {
+        await cleanupCreatedData();
+      } catch (error) {
+        cleanupError = error;
+      }
+
+      expect(cleanupError).toBeInstanceOf(AggregateError);
+      if (!(cleanupError instanceof AggregateError)) {
+        throw new Error('cleanup must throw AggregateError for an actual self reference');
+      }
+      expect(cleanupError.message).toContain(
+        'referenced by itself via a self-referencing foreign key',
+      );
+
+      const parent = await queryOne<{ id: number }>(
+        `SELECT id FROM e2e_spec_actual_self_parent WHERE id = $1`,
+        [parentId],
+      );
+      const childCount = await queryOne<{ count: number }>(
+        `SELECT count(*)::integer AS count
+         FROM e2e_spec_actual_self_child
+         WHERE parent_id = $1`,
+        [parentId],
+      );
+      expect(parent?.id).toBe(parentId);
+      expect(childCount?.count).toBe(2);
+
+      await withDb(async (client) => {
+        await client.query(
+          `DELETE FROM e2e_spec_actual_self_child WHERE parent_id = $1`,
+          [parentId],
+        );
+        await client.query(
+          `DELETE FROM e2e_spec_actual_self_parent WHERE id = $1`,
+          [parentId],
+        );
+      });
+      await cleanupCreatedData();
+      registryDrained = true;
+    } finally {
+      try {
+        if (!registryDrained && parentId !== undefined) {
+          await withDb(async (client) => {
+            await client.query(
+              `DELETE FROM e2e_spec_actual_self_child WHERE parent_id = $1`,
+              [parentId],
+            );
+            await client.query(
+              `DELETE FROM e2e_spec_actual_self_parent WHERE id = $1`,
+              [parentId],
+            );
+          });
+          await cleanupCreatedData();
+        }
+      } finally {
+        await withDb(async (client) => {
+          await client.query(`DROP TABLE IF EXISTS e2e_spec_actual_self_child`);
+          await client.query(`DROP TABLE IF EXISTS e2e_spec_actual_self_parent`);
+        });
+        resetForeignKeysCache();
+      }
+    }
   });
 });

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -699,8 +699,8 @@ export async function createUser(options: CreateUserOptions = {}): Promise<Creat
   }
   // Registration order is the deletion order, reversed: cleanupCreatedData() below deletes in
   // reverse registration order. user.userDataId -> user_data.id is NOT NULL with
-  // ON DELETE NO ACTION, so the dependent row (user_data) must be registered LAST here to be
-  // deleted FIRST during cleanup — before the "user" row that references it.
+  // ON DELETE NO ACTION, so user_data is registered first and its dependent user row last. The
+  // reverse cleanup order then deletes user before the user_data row it depends on.
   // Only register when this call created the account (preExisting was empty).
   if (!preExisting) {
     track('user_data', userRow.userDataId);
@@ -1639,11 +1639,6 @@ let tableKeyInfoPromise: Promise<TableKeyInfo> | null = null;
 interface TableKeyInfo {
   /** Tables whose primary key is exactly the single column `id` — SELECT/recurse by id is safe. */
   idAddressable: Set<string>;
-  /**
-   * Tables that have a primary key, but not exactly `{ id }` (composite or differently named).
-   * Cleanup cannot SELECT/recurse them by id and must not treat them as silent leaves either.
-   */
-  nonIdPrimaryKey: Set<string>;
 }
 
 type RowResult = { deletedSelf: boolean; failed: boolean };
@@ -1659,6 +1654,11 @@ type RowResult = { deletedSelf: boolean; failed: boolean };
  * snapshotting `created`: reordering alone would still lose a second-run snapshot once retries
  * are possible; resetting the promise alone would still lose the first snapshot if created was
  * already cleared. Both are required.
+ *
+ * `constraint_column_usage` does not preserve per-column ordinal correspondence with
+ * `key_column_usage` for multi-column constraints. Joining them only by constraint name produces
+ * the cross product of every column on both sides, so this query uses `pg_constraint`'s
+ * `conkey`/`confkey` arrays and pairs their entries by ordinality instead.
  */
 async function getForeignKeys(): Promise<ForeignKeyRef[]> {
   if (!foreignKeysPromise) {
@@ -1668,16 +1668,25 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
       referenced_table: string;
       referenced_column: string;
     }>(
-      `SELECT tc.table_name, kcu.column_name,
-              ccu.table_name AS referenced_table,
-              ccu.column_name AS referenced_column
-       FROM information_schema.table_constraints tc
-       JOIN information_schema.key_column_usage kcu
-         ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
-       JOIN information_schema.constraint_column_usage ccu
-         ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
-       WHERE tc.constraint_type = 'FOREIGN KEY'
-         AND tc.table_schema = 'public'`,
+      `SELECT child_table.relname AS table_name,
+              child_attribute.attname AS column_name,
+              parent_table.relname AS referenced_table,
+              parent_attribute.attname AS referenced_column
+       FROM pg_constraint con
+       JOIN pg_class child_table ON child_table.oid = con.conrelid
+       JOIN pg_namespace child_schema
+         ON child_schema.oid = child_table.relnamespace AND child_schema.nspname = 'public'
+       JOIN pg_class parent_table ON parent_table.oid = con.confrelid
+       JOIN pg_namespace parent_schema
+         ON parent_schema.oid = parent_table.relnamespace AND parent_schema.nspname = 'public'
+       JOIN LATERAL unnest(con.conkey) WITH ORDINALITY AS child_key(attnum, position) ON true
+       JOIN LATERAL unnest(con.confkey) WITH ORDINALITY AS parent_key(attnum, position)
+         ON parent_key.position = child_key.position
+       JOIN pg_attribute child_attribute
+         ON child_attribute.attrelid = con.conrelid AND child_attribute.attnum = child_key.attnum
+       JOIN pg_attribute parent_attribute
+         ON parent_attribute.attrelid = con.confrelid AND parent_attribute.attnum = parent_key.attnum
+       WHERE con.contype = 'f'`,
     )
       .then((rows) =>
         rows.map((r) => ({
@@ -1701,12 +1710,13 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
  * not poison every later cleanup in the same process.
  *
  * - PK is exactly `{ id }` → id-addressable (SELECT/recurse by id).
- * - PK exists but is not exactly `{ id }` → nonIdPrimaryKey (diagnostics only).
- * - No primary key at all → in neither set.
+ * - Any other primary-key shape, or no primary key at all, is not id-addressable.
  *
- * Leaf-ness is NOT decided here. A table that is not id-addressable is a leaf only when no OTHER
- * table references it — a self-referencing foreign key does not count; if something does, its descendants exist and cannot be reached by id, which is an
- * error rather than a leaf. See deleteRowAndDescendants for that decision.
+ * Leaf-ness is NOT decided here. A table that is not id-addressable is a leaf only when neither
+ * another table nor the table itself references it. With existing rows, either kind of reference
+ * makes the table unresolvable because descendants cannot be reached by id; self-references are
+ * reported separately rather than being described as references from other tables. See
+ * deleteRowAndDescendants for that decision.
  */
 async function getTableKeyInfo(): Promise<TableKeyInfo> {
   if (!tableKeyInfoPromise) {
@@ -1726,15 +1736,12 @@ async function getTableKeyInfo(): Promise<TableKeyInfo> {
           else columnsByTable.set(row.table_name, [row.column_name]);
         }
         const idAddressable = new Set<string>();
-        const nonIdPrimaryKey = new Set<string>();
         for (const [tableName, columns] of columnsByTable) {
           if (columns.length === 1 && columns[0] === 'id') {
             idAddressable.add(tableName);
-          } else {
-            nonIdPrimaryKey.add(tableName);
           }
         }
-        return { idAddressable, nonIdPrimaryKey };
+        return { idAddressable };
       })
       .catch((e) => {
         tableKeyInfoPromise = null;
@@ -1755,13 +1762,14 @@ async function getTableKeyInfo(): Promise<TableKeyInfo> {
  *
  * Three independent FK checks must stay separate (parent side vs child side):
  * - (i) Parent side: FK points at a non-`id` column → unresolvable from the id we hold → error.
- * - (ii) Child is not addressable by `id` AND another table references it → its descendants exist and
- *   cannot be reached, which must not pass as a silent leaf → error once per such table, no DELETE
- *   attempt, and only when a row for this parent actually exists.
- * - (iii) Child is not addressable by `id` and no other table references it → true leaf: DELETE matching
- *   rows by FK column and stop. Both (ii) and (iii) cover tables with no primary key as well as
- *   tables with a composite one; what separates them is whether anything points at the table, not
- *   the shape of its key. The first matching branch continues before later ones run.
+ * - (ii) Child is not addressable by `id` AND another table or the table itself references it →
+ *   its descendants exist and cannot be reached, which must not pass as a silent leaf → error
+ *   once per such table, no DELETE attempt, and only when a row for this parent actually exists.
+ * - (iii) Child is not addressable by `id` and neither another table nor the table itself
+ *   references it → true leaf: DELETE matching rows by FK column and stop. Both (ii) and (iii)
+ *   cover tables with no primary key as well as tables with a composite one; what separates them
+ *   is whether anything points at the table, not the shape of its key. The first matching branch
+ *   continues before later ones run.
  *
  * `visitedResults` is shared across the entire cleanupCreatedData() invocation. Values are either
  * `'in-progress'` (this row is still on an ancestor frame's stack — a genuine FK cycle) or a
@@ -1830,25 +1838,27 @@ async function deleteRowAndDescendants(
 
     const col = needsQuote(fk.column) ? `"${fk.column}"` : fk.column;
 
-    // (ii) Child cannot be addressed by id AND is itself referenced by something else. Only that
-    // combination is unresolvable: the table has descendants, and they cannot be found without
-    // addressing its rows by id. What decides leaf-ness is whether anything points at the table —
-    // not the shape of its key. A table with no primary key at all can still be referenced through
-    // a UNIQUE column, and a composite-key table nothing points at (a plain join table like
+    // (ii) Child cannot be addressed by id AND is itself referenced by another table or by itself.
+    // Only that combination is unresolvable: the table has descendants, and they cannot be found
+    // without addressing its rows by id. What decides leaf-ness is whether anything points at the
+    // table — not the shape of its key. A table with no primary key at all can still be referenced
+    // through a UNIQUE column, and a composite-key table nothing points at (a plain join table like
     // mros_transactions_transaction) has no descendants to lose.
     //
     // Reported only when a row actually exists for this parent. Keying it on the schema alone would
     // fail every cleanup of a parent whose child table happens to be empty for it — the same
     // mistake, one branch over, that made this whole case wrong before.
-    // Referenced by something OTHER than itself. A self-referencing foreign key puts a table into
-    // this map on its own, which would make every such table look unresolvable even when nothing
-    // else points at it — and the error would claim it is "referenced by other tables", which would
-    // not be true.
+    // Keep other-table and self-reference detection separate. Both prevent a safe bulk-leaf
+    // delete, but only the former can truthfully be reported as "referenced by other tables"; a
+    // self-only reference needs wording that explains the orphaned-descendant risk instead.
     const referencedByOthers = (childrenByReferencedTable.get(fk.table) ?? []).some(
       (child) => child.table !== fk.table,
     );
+    const referencedBySelf = (childrenByReferencedTable.get(fk.table) ?? []).some(
+      (child) => child.table === fk.table,
+    );
 
-    if (!tableKeyInfo.idAddressable.has(fk.table) && referencedByOthers) {
+    if (!tableKeyInfo.idAddressable.has(fk.table) && (referencedByOthers || referencedBySelf)) {
       let hasRows: boolean;
       try {
         const probe = await queryRows<{ one: number }>(
@@ -1865,20 +1875,29 @@ async function deleteRowAndDescendants(
       if (hasRows) {
         if (!reportedNonIdPrimaryKeyTables.has(fk.table)) {
           reportedNonIdPrimaryKeyTables.add(fk.table);
-          errors.push(
-            `table "${fk.table}" is referenced by other tables but has no primary key of exactly ` +
-              `the single column "id": cleanup can only SELECT/recurse by id, so this table's own ` +
-              `descendants cannot be discovered and no rows were deleted for it`,
-          );
+          if (referencedByOthers) {
+            errors.push(
+              `table "${fk.table}" is referenced by other tables but has no primary key of exactly ` +
+                `the single column "id": cleanup can only SELECT/recurse by id, so this table's own ` +
+                `descendants cannot be discovered and no rows were deleted for it`,
+            );
+          } else {
+            errors.push(
+              `table "${fk.table}" is referenced by itself via a self-referencing foreign key but ` +
+                `has no primary key of exactly the single column "id": cleanup cannot safely bulk ` +
+                `delete its rows because self-referencing descendants could be orphaned instead of removed`,
+            );
+          }
         }
         failed = true;
       }
       continue;
     }
 
-    // (iii) Child cannot be addressed by id and no other table references it: a true leaf. The parent-side
-    // check above passed, so delete its rows by the foreign key column and stop.
-    if (!tableKeyInfo.idAddressable.has(fk.table)) {
+    // (iii) Child cannot be addressed by id and neither another table nor the table itself
+    // references it: a true leaf. The parent-side check above passed, so delete its rows by the
+    // foreign key column and stop.
+    if (!tableKeyInfo.idAddressable.has(fk.table) && !referencedByOthers && !referencedBySelf) {
       try {
         await withDb(async (client) => {
           await client.query(
@@ -2019,11 +2038,10 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
   }
 
   if (failed.length > 0) {
-    // `failed` was accumulated while iterating `snapshot`, which is already the reverse of the
-    // original registration order — so `failed` itself is in reverse-of-reverse, i.e. it needs
-    // one more reverse() to land back in original registration order before re-entering
-    // `created`. The next cleanupCreatedData() call reverses `created` again, so this is what
-    // makes that second reversal produce a correct, FK-respecting retry order.
+    // `failed` was accumulated in `snapshot` order, which is the reverse of the original
+    // registration order. Reverse it once before restoring it to `created`; the next
+    // cleanupCreatedData() call reverses `created` into the same FK-respecting retry order in
+    // which these references failed during this attempt.
     created.push(...failed.reverse());
   }
 

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1701,9 +1701,12 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
  * not poison every later cleanup in the same process.
  *
  * - PK is exactly `{ id }` → id-addressable (SELECT/recurse by id).
- * - PK exists but is not exactly `{ id }` → nonIdPrimaryKey (kept for diagnostics; leaf-ness is
- *   decided by whether anything references the table, not by the shape of its key).
- * - No primary key at all → true leaf (neither set; DELETE by FK and stop).
+ * - PK exists but is not exactly `{ id }` → nonIdPrimaryKey (diagnostics only).
+ * - No primary key at all → in neither set.
+ *
+ * Leaf-ness is NOT decided here. A table that is not id-addressable is a leaf only when nothing
+ * references it; if something does, its descendants exist and cannot be reached by id, which is an
+ * error rather than a leaf. See deleteRowAndDescendants for that decision.
  */
 async function getTableKeyInfo(): Promise<TableKeyInfo> {
   if (!tableKeyInfoPromise) {
@@ -1750,22 +1753,25 @@ async function getTableKeyInfo(): Promise<TableKeyInfo> {
  * known to belong to a row this cleanup is responsible for — so the walk can never reach another
  * account's rows or seed/master data, no matter how deep it goes.
  *
- * Three independent FK checks must stay separate (parent side vs child-side key shape):
+ * Three independent FK checks must stay separate (parent side vs child side):
  * - (i) Parent side: FK points at a non-`id` column → unresolvable from the id we hold → error.
- * - (ii) Child has a primary key but not exactly `{ id }` → cannot SELECT/recurse by id and must
- *   not be treated as a silent leaf either → error once per such table, no DELETE attempt.
- * - (iii) Child has no primary key at all → true leaf: DELETE matching rows by FK column and stop
- *   (nothing can reference those rows by id). A table can hit any combination of (i)/(ii); (iii)
- *   is the remaining no-PK case. The first matching branch continues before later ones run.
+ * - (ii) Child is not addressable by `id` AND something references it → its descendants exist and
+ *   cannot be reached, which must not pass as a silent leaf → error once per such table, no DELETE
+ *   attempt, and only when a row for this parent actually exists.
+ * - (iii) Child is not addressable by `id` and nothing references it → true leaf: DELETE matching
+ *   rows by FK column and stop. Both (ii) and (iii) cover tables with no primary key as well as
+ *   tables with a composite one; what separates them is whether anything points at the table, not
+ *   the shape of its key. The first matching branch continues before later ones run.
  *
  * `visitedResults` is shared across the entire cleanupCreatedData() invocation. Values are either
  * `'in-progress'` (this row is still on an ancestor frame's stack — a genuine FK cycle) or a
  * finished `RowResult` (the real first-visit outcome). That distinguishes:
- * - Cycle: return `{ deletedSelf: false, failed: true }` without recursing. The ancestor frame
- *   that owns this row still runs its own real DELETE later in its own turn and pushes any real
- *   failure into `errors` independently of what this branch returns — nothing is silently lost —
- *   but THIS branch genuinely cannot confirm the row is gone, so it must not report
- *   `deletedSelf: true`.
+ * - Cycle: return `{ deletedSelf: false, failed: false }` without recursing. This branch cannot
+ *   confirm the row is gone, so it must not report `deletedSelf: true` — but it must not report a
+ *   failure either: the throw at the end is driven by `errors`, so a `failed` without a matching
+ *   entry there would re-queue the reference while cleanupCreatedData stayed silent about why. The
+ *   ancestor frame that owns this row runs its own real DELETE later and records its own outcome,
+ *   with a message.
  * - Diamond (two paths reach the same row): return the cached finished result as-is, not a
  *   fabricated success, so a failed first visit is not rewritten as success on the second path.
  *
@@ -1834,7 +1840,15 @@ async function deleteRowAndDescendants(
     // Reported only when a row actually exists for this parent. Keying it on the schema alone would
     // fail every cleanup of a parent whose child table happens to be empty for it — the same
     // mistake, one branch over, that made this whole case wrong before.
-    if (!tableKeyInfo.idAddressable.has(fk.table) && childrenByReferencedTable.has(fk.table)) {
+    // Referenced by something OTHER than itself. A self-referencing foreign key puts a table into
+    // this map on its own, which would make every such table look unresolvable even when nothing
+    // else points at it — and the error would claim it is "referenced by other tables", which would
+    // not be true.
+    const referencedByOthers = (childrenByReferencedTable.get(fk.table) ?? []).some(
+      (child) => child.table !== fk.table,
+    );
+
+    if (!tableKeyInfo.idAddressable.has(fk.table) && referencedByOthers) {
       let hasRows: boolean;
       try {
         const probe = await queryRows<{ one: number }>(

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -197,10 +197,24 @@ interface CreatedRef {
 
 const created: CreatedRef[] = [];
 
-function track(table: string, id: number | undefined | null): void {
-  if (id != null && Number.isFinite(Number(id))) {
-    created.push({ table, id: Number(id) });
+/**
+ * Require a finite positive numeric id. A 2xx response without a usable id is a broken API
+ * contract, not a missing caller precondition — fail loud so the test cannot assert on a ghost row
+ * or leave an untracked DB row behind cleanup.
+ */
+function requireId(value: unknown, factory: string, field: string): number {
+  const n = Number(value);
+  if (value == null || !Number.isFinite(n) || n <= 0) {
+    throw new Error(
+      `${factory}: expected a finite positive ${field}, got ${JSON.stringify(value)} — ` +
+        `a 2xx without a usable id is a broken API contract, not a missing caller precondition`,
+    );
   }
+  return n;
+}
+
+function track(table: string, id: number | undefined | null): void {
+  created.push({ table, id: requireId(id, 'track', `id for table "${table}"`) });
 }
 
 /**
@@ -785,8 +799,9 @@ export async function createBankAccount(
   if (options.label) body.label = options.label;
 
   const res = await apiPost<{ id: number; iban: string }>('bankAccount', body, { jwt });
-  track('bank_data', res.id);
-  return { bankAccountId: res.id, iban: res.iban ?? iban };
+  const bankAccountId = requireId(res.id, 'createBankAccount', 'id');
+  track('bank_data', bankAccountId);
+  return { bankAccountId, iban: res.iban ?? iban };
 }
 
 // ---------------------------------------------------------------------------
@@ -812,15 +827,17 @@ export async function createBuy(jwt: string, options: CreateBuyOptions = {}): Pr
       },
       { jwt },
     );
-    track('buy', res.routeId);
-    return { buyId: res.routeId, routeId: res.routeId, assetId: asset.id };
+    const routeId = requireId(res.routeId, 'createBuy', 'routeId');
+    track('buy', routeId);
+    return { buyId: routeId, routeId, assetId: asset.id };
   }
 
   // Default: POST /buy with CreateBuyDto { asset } — creates the buy route without pricing.
   // Chosen over paymentInfos because ENVIRONMENT=loc mocks outbound HTTP and price feeds often fail.
   const res = await apiPost<{ id: number }>('buy', { asset: { id: asset.id } }, { jwt });
-  track('buy', res.id);
-  return { buyId: res.id, assetId: asset.id };
+  const buyId = requireId(res.id, 'createBuy', 'id');
+  track('buy', buyId);
+  return { buyId, assetId: asset.id };
 }
 
 // ---------------------------------------------------------------------------
@@ -854,8 +871,9 @@ export async function createSell(jwt: string, options: CreateSellOptions = {}): 
     },
     { jwt },
   );
-  track('deposit_route', res.id);
-  return { sellId: res.id, iban: res.iban ?? iban, bankAccountId };
+  const sellId = requireId(res.id, 'createSell', 'id');
+  track('deposit_route', sellId);
+  return { sellId, iban: res.iban ?? iban, bankAccountId };
 }
 
 // ---------------------------------------------------------------------------
@@ -880,8 +898,9 @@ export async function createSwap(jwt: string, options: CreateSwapOptions = {}): 
     },
     { jwt },
   );
-  track('deposit_route', res.id);
-  return { swapId: res.id, assetId: asset.id };
+  const swapId = requireId(res.id, 'createSwap', 'id');
+  track('deposit_route', swapId);
+  return { swapId, assetId: asset.id };
 }
 
 async function userFromJwt(jwt: string): Promise<{ id: number; userDataId: number; address: string }> {
@@ -1261,9 +1280,13 @@ export async function createSupportIssue(
   );
 
   const issueRow = await queryOne<{ id: number }>(`SELECT id FROM support_issue WHERE uid = $1 LIMIT 1`, [res.uid]);
+  // CreateSupportIssueResult declares supportIssueId as optional, and this lookup is by uid rather
+  // than by a returned id — so "no row" is a shape this factory is written to tolerate, not a
+  // contract breach like a missing id in a 2xx body. Register only what is there.
   if (issueRow) track('support_issue', issueRow.id);
 
   const msgId = res.messages?.[0]?.id;
+  // messages is optional on the API response type; no first message means nothing to register.
   if (msgId) track('support_message', msgId);
 
   return {
@@ -1445,16 +1468,19 @@ export async function createLimitRequest(options: CreateLimitRequestOptions = {}
     if (issueRow) {
       // Parent (limit_request) first, then support_issue (child), then support_message (child of
       // issue) last — cleanupCreatedData deletes in reverse registration order (LIFO).
-      if (issueRow.limitRequestId) track('limit_request', issueRow.limitRequestId);
-      track('support_issue', issueRow.id);
-      const msgId = res.messages?.[0]?.id;
-      if (msgId != null) track('support_message', msgId);
+      // Track the id we actually return (issue row or response body), not only issueRow.limitRequestId,
+      // so a row resolved from res.limitRequest?.id is still registered for cleanup.
       const limitRequestId = issueRow.limitRequestId ?? res.limitRequest?.id;
       if (limitRequestId == null) {
         throw new Error(
           `createLimitRequest: API created support_issue ${issueRow.id} (uid ${res.uid}) without a limit_request id`,
         );
       }
+      track('limit_request', limitRequestId);
+      track('support_issue', issueRow.id);
+      const msgId = res.messages?.[0]?.id;
+      // messages is optional on the API response type; no message id means nothing to register.
+      if (msgId != null) track('support_message', msgId);
       return {
         limitRequestId,
         supportIssueId: issueRow.id,

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1626,6 +1626,12 @@ export async function createCallQueueEntry(
 // 12. cleanupCreatedData
 // ---------------------------------------------------------------------------
 
+/**
+ * One column pair of one foreign key. A key over several columns appears as several entries.
+ *
+ * Exported, like `getForeignKeys` below, only so `factories.spec.ts` can assert that a composite
+ * key keeps its column ordinality — nothing outside this module uses either at runtime.
+ */
 export interface ForeignKeyRef {
   table: string; // child table containing the FK column
   column: string; // FK column on the child table

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1645,17 +1645,22 @@ async function getUserDependentTables(): Promise<UserDependentTable[]> {
  * "user_data" row, first clears the API's own untracked dependent rows for exactly that row's id
  * (see getUserDependentTables) — scoped to that one id, so it can never touch another account's
  * rows or seed/master data — then deletes the row itself.
- * Best-effort: failures on individual deletes are collected and do not abort the rest.
  *
- * Every `test.afterAll` in this suite calls this function and discards the return value — a
- * failed delete would otherwise leave rows behind for whichever spec file runs next in the same
- * shared database with no trace of why. Logging here — in addition to the existing
- * `{ deleted, errors }` return value, which a caller that does check it can still use — is the
- * cheapest way to surface a failed cleanup without touching all fifteen call sites or aborting
- * the run: a leftover row must never fail the unrelated test that happens to run next.
+ * In a shared database, a row that fails to delete is not a cosmetic problem: it is state the
+ * next spec file inherits, and it can make that unrelated file fail (or pass) for reasons that
+ * have nothing to do with what it actually tests. So a failed delete here throws instead of being
+ * swallowed — the file that caused the leftover goes red, not whichever file happens to run next.
+ * References whose delete failed — including a "user"/"user_data" row whose own DELETE succeeded
+ * but left one of its dependent rows behind — are re-registered into `created`, in their original
+ * registration order, so the next call to cleanupCreatedData() retries them. A successful cleanup
+ * stays completely silent (no console.log/console.warn either way).
+ *
+ * Every `test.afterAll` in this suite calls this function and discards the resolved value; the
+ * throw is what actually surfaces a failed cleanup to the test runner.
  */
 export async function cleanupCreatedData(): Promise<{ deleted: number; errors: string[] }> {
   const errors: string[] = [];
+  const failed: CreatedRef[] = [];
   let deleted = 0;
   const snapshot = [...created].reverse();
   created.length = 0;
@@ -1666,6 +1671,8 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
   const dependents = await getUserDependentTables();
 
   for (const ref of snapshot) {
+    let refFailed = false;
+
     if (ref.table === 'user' || ref.table === 'user_data') {
       for (const dep of dependents) {
         if (dep.referencedTable !== ref.table) continue;
@@ -1676,6 +1683,7 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
           });
         } catch (e) {
           errors.push(`${dep.table}.${dep.column}=${ref.id}: ${e instanceof Error ? e.message : String(e)}`);
+          refFailed = true;
         }
       }
     }
@@ -1687,11 +1695,26 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
       deleted += 1;
     } catch (e) {
       errors.push(`${ref.table}#${ref.id}: ${e instanceof Error ? e.message : String(e)}`);
+      refFailed = true;
     }
+
+    if (refFailed) failed.push(ref);
+  }
+
+  if (failed.length > 0) {
+    // `failed` was accumulated while iterating `snapshot`, which is already the reverse of the
+    // original registration order — so `failed` itself is in reverse-of-reverse, i.e. it needs one
+    // more reverse() to land back in original registration order before re-entering `created`.
+    // The next cleanupCreatedData() call reverses `created` again, so this is what makes that
+    // second reversal produce a correct, FK-respecting retry order.
+    created.push(...failed.reverse());
   }
 
   if (errors.length > 0) {
-    console.warn(`cleanupCreatedData: ${errors.length} row(s) could not be deleted:\n  ${errors.join('\n  ')}`);
+    throw new AggregateError(
+      errors.map((message) => new Error(message)),
+      `cleanupCreatedData: ${errors.length} row(s) failed to delete and were re-queued for the next cleanup: ${errors.join('; ')}`,
+    );
   }
 
   return { deleted, errors };

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1626,7 +1626,7 @@ export async function createCallQueueEntry(
 // 12. cleanupCreatedData
 // ---------------------------------------------------------------------------
 
-interface ForeignKeyRef {
+export interface ForeignKeyRef {
   table: string; // child table containing the FK column
   column: string; // FK column on the child table
   referencedTable: string; // parent table the FK points at
@@ -1660,7 +1660,7 @@ type RowResult = { deletedSelf: boolean; failed: boolean };
  * the cross product of every column on both sides, so this query uses `pg_constraint`'s
  * `conkey`/`confkey` arrays and pairs their entries by ordinality instead.
  */
-async function getForeignKeys(): Promise<ForeignKeyRef[]> {
+export async function getForeignKeys(): Promise<ForeignKeyRef[]> {
   if (!foreignKeysPromise) {
     foreignKeysPromise = queryRows<{
       table_name: string;
@@ -1712,10 +1712,10 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
  * - PK is exactly `{ id }` → id-addressable (SELECT/recurse by id).
  * - Any other primary-key shape, or no primary key at all, is not id-addressable.
  *
- * Leaf-ness is NOT decided here. A table that is not id-addressable is a leaf only when neither
- * another table nor the table itself references it. With existing rows, either kind of reference
- * makes the table unresolvable because descendants cannot be reached by id; self-references are
- * reported separately rather than being described as references from other tables. See
+ * Leaf-ness is NOT decided here. A table that is not id-addressable cannot be bulk-deleted when
+ * another table references it, or when candidate rows are actually referenced through a self-FK,
+ * because descendants cannot be reached by id. Self-references are checked row-by-row and reported
+ * separately rather than being described as references from other tables. See
  * deleteRowAndDescendants for that decision.
  */
 async function getTableKeyInfo(): Promise<TableKeyInfo> {
@@ -1752,6 +1752,46 @@ async function getTableKeyInfo(): Promise<TableKeyInfo> {
 }
 
 /**
+ * Check whether any row in the candidate bulk-delete batch is actually referenced through one
+ * of the table's self-referencing foreign-key column pairs. Referencers inside the same batch
+ * count too: cleanup must not assume a safe execution order for a multi-row DELETE.
+ *
+ * Composite self-referencing constraints are intentionally checked one column pair at a time.
+ * ForeignKeyRef is a flat, ordinally paired representation without constraint identity, so a
+ * fully grouped composite check is outside this helper's scope and independent probes can be
+ * conservatively false-positive for such a constraint.
+ */
+async function hasSelfReferencedRows(
+  table: string,
+  candidateColumn: string,
+  candidateValue: number,
+  selfFks: ForeignKeyRef[],
+): Promise<boolean> {
+  const candidateColumnSql = needsQuote(candidateColumn)
+    ? `"${candidateColumn}"`
+    : candidateColumn;
+
+  for (const selfFk of selfFks) {
+    const selfColumnSql = needsQuote(selfFk.column) ? `"${selfFk.column}"` : selfFk.column;
+    const selfReferencedColumnSql = needsQuote(selfFk.referencedColumn)
+      ? `"${selfFk.referencedColumn}"`
+      : selfFk.referencedColumn;
+    const probe = await queryRows<{ one: number }>(
+      `SELECT 1 AS one
+       FROM ${tableSql(table)} referenced
+       JOIN ${tableSql(table)} referencer
+         ON referencer.${selfColumnSql} = referenced.${selfReferencedColumnSql}
+       WHERE referenced.${candidateColumnSql} = $1
+       LIMIT 1`,
+      [candidateValue],
+    );
+    if (probe.length > 0) return true;
+  }
+
+  return false;
+}
+
+/**
  * Recursively deletes a row and every row that transitively references it via a foreign key.
  *
  * For (table, id): find every FK pointing at this table; for each child row with that FK equal
@@ -1762,14 +1802,15 @@ async function getTableKeyInfo(): Promise<TableKeyInfo> {
  *
  * Three independent FK checks must stay separate (parent side vs child side):
  * - (i) Parent side: FK points at a non-`id` column → unresolvable from the id we hold → error.
- * - (ii) Child is not addressable by `id` AND another table or the table itself references it →
- *   its descendants exist and cannot be reached, which must not pass as a silent leaf → error
- *   once per such table, no DELETE attempt, and only when a row for this parent actually exists.
- * - (iii) Child is not addressable by `id` and neither another table nor the table itself
- *   references it → true leaf: DELETE matching rows by FK column and stop. Both (ii) and (iii)
- *   cover tables with no primary key as well as tables with a composite one; what separates them
- *   is whether anything points at the table, not the shape of its key. The first matching branch
- *   continues before later ones run.
+ * - (ii) Child is not addressable by `id` AND either another table references it or rows in the
+ *   candidate bulk-delete batch are actually referenced through a self-FK → its descendants
+ *   cannot be reached, which must not pass as a silent leaf → error once per such table and no
+ *   DELETE attempt. The other-table check is schema-based; the self-reference check is row-based.
+ * - (iii) Child is not addressable by `id`, is not referenced by another table, and has no actual
+ *   self-reference involving the candidate rows → leaf for this deletion: DELETE matching rows by
+ *   FK column and stop. Both (ii) and (iii) cover tables with no primary key as well as tables with
+ *   a composite one; what separates them is whether this bulk delete could strand descendants,
+ *   not the shape of the key. The first matching branch continues before later ones run.
  *
  * `visitedResults` is shared across the entire cleanupCreatedData() invocation. Values are either
  * `'in-progress'` (this row is still on an ancestor frame's stack — a genuine FK cycle) or a
@@ -1838,27 +1879,28 @@ async function deleteRowAndDescendants(
 
     const col = needsQuote(fk.column) ? `"${fk.column}"` : fk.column;
 
-    // (ii) Child cannot be addressed by id AND is itself referenced by another table or by itself.
-    // Only that combination is unresolvable: the table has descendants, and they cannot be found
-    // without addressing its rows by id. What decides leaf-ness is whether anything points at the
-    // table — not the shape of its key. A table with no primary key at all can still be referenced
-    // through a UNIQUE column, and a composite-key table nothing points at (a plain join table like
-    // mros_transactions_transaction) has no descendants to lose.
+    // (ii) Child cannot be addressed by id AND is referenced by another table, or candidate rows
+    // are actually referenced through one of the table's self-FKs. Only those combinations are
+    // unresolvable: the table has descendants, and they cannot be found without addressing its
+    // rows by id. A table with no primary key at all can still be referenced through a UNIQUE
+    // column, and a composite-key table with no relevant descendants (a plain join table like
+    // mros_transactions_transaction) can still be bulk-deleted safely.
     //
     // Reported only when a row actually exists for this parent. Keying it on the schema alone would
     // fail every cleanup of a parent whose child table happens to be empty for it — the same
     // mistake, one branch over, that made this whole case wrong before.
-    // Keep other-table and self-reference detection separate. Both prevent a safe bulk-leaf
-    // delete, but only the former can truthfully be reported as "referenced by other tables"; a
-    // self-only reference needs wording that explains the orphaned-descendant risk instead.
+    // Keep other-table and self-reference detection separate. The former remains schema-based;
+    // the latter must inspect candidate rows so a merely declared but unused self-FK does not
+    // block a safe bulk delete. When a self-reference is present, its error wording explains the
+    // orphaned-descendant risk rather than claiming another table is involved.
     const referencedByOthers = (childrenByReferencedTable.get(fk.table) ?? []).some(
       (child) => child.table !== fk.table,
     );
-    const referencedBySelf = (childrenByReferencedTable.get(fk.table) ?? []).some(
+    const selfFks = (childrenByReferencedTable.get(fk.table) ?? []).filter(
       (child) => child.table === fk.table,
     );
 
-    if (!tableKeyInfo.idAddressable.has(fk.table) && (referencedByOthers || referencedBySelf)) {
+    if (!tableKeyInfo.idAddressable.has(fk.table) && (referencedByOthers || selfFks.length > 0)) {
       let hasRows: boolean;
       try {
         const probe = await queryRows<{ one: number }>(
@@ -1872,32 +1914,48 @@ async function deleteRowAndDescendants(
         continue;
       }
 
-      if (hasRows) {
+      if (!hasRows) continue;
+
+      if (referencedByOthers) {
         if (!reportedNonIdPrimaryKeyTables.has(fk.table)) {
           reportedNonIdPrimaryKeyTables.add(fk.table);
-          if (referencedByOthers) {
-            errors.push(
-              `table "${fk.table}" is referenced by other tables but has no primary key of exactly ` +
-                `the single column "id": cleanup can only SELECT/recurse by id, so this table's own ` +
-                `descendants cannot be discovered and no rows were deleted for it`,
-            );
-          } else {
-            errors.push(
-              `table "${fk.table}" is referenced by itself via a self-referencing foreign key but ` +
-                `has no primary key of exactly the single column "id": cleanup cannot safely bulk ` +
-                `delete its rows because self-referencing descendants could be orphaned instead of removed`,
-            );
-          }
+          errors.push(
+            `table "${fk.table}" is referenced by other tables but has no primary key of exactly ` +
+              `the single column "id": cleanup can only SELECT/recurse by id, so this table's own ` +
+              `descendants cannot be discovered and no rows were deleted for it`,
+          );
         }
         failed = true;
+        continue;
       }
-      continue;
+
+      let selfReferenced: boolean;
+      try {
+        selfReferenced = await hasSelfReferencedRows(fk.table, fk.column, id, selfFks);
+      } catch (e) {
+        errors.push(`${fk.table}.${fk.column}=${id}: ${e instanceof Error ? e.message : String(e)}`);
+        failed = true;
+        continue;
+      }
+
+      if (selfReferenced) {
+        if (!reportedNonIdPrimaryKeyTables.has(fk.table)) {
+          reportedNonIdPrimaryKeyTables.add(fk.table);
+          errors.push(
+            `table "${fk.table}" is referenced by itself via a self-referencing foreign key but ` +
+              `has no primary key of exactly the single column "id": cleanup cannot safely bulk ` +
+              `delete its rows because self-referencing descendants could be orphaned instead of removed`,
+          );
+        }
+        failed = true;
+        continue;
+      }
     }
 
-    // (iii) Child cannot be addressed by id and neither another table nor the table itself
-    // references it: a true leaf. The parent-side check above passed, so delete its rows by the
-    // foreign key column and stop.
-    if (!tableKeyInfo.idAddressable.has(fk.table) && !referencedByOthers && !referencedBySelf) {
+    // (iii) Child cannot be addressed by id and is not referenced by another table. It is either a
+    // schema-level leaf or its declared self-FKs do not actually involve any candidate row. The
+    // parent-side check and, when needed, the row probe above passed, so bulk-delete by FK column.
+    if (!tableKeyInfo.idAddressable.has(fk.table) && !referencedByOthers) {
       try {
         await withDb(async (client) => {
           await client.query(
@@ -2068,4 +2126,13 @@ export function resetFactoryCounter(): void {
   factoryTagStartApplied = false;
   factoryWalletStartPromise = null;
   factoryTagStartPromise = null;
+}
+
+/**
+ * Clear the memoized public-schema foreign-key catalog for tests that create or drop tables at
+ * runtime. Production callers do not need this because their schema remains stable during a run;
+ * rejection still clears the cache automatically so a later catalog load can retry.
+ */
+export function resetForeignKeysCache(): void {
+  foreignKeysPromise = null;
 }

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1627,6 +1627,7 @@ interface ForeignKeyRef {
 }
 
 let foreignKeysPromise: Promise<ForeignKeyRef[]> | null = null;
+let tablesWithIdPromise: Promise<Set<string>> | null = null;
 
 /**
  * Discovers every foreign key in the public schema from Postgres's catalog, once per process.
@@ -1665,6 +1666,21 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
 }
 
 /**
+ * Public-schema tables that have a column literally named `id`. Memoized once per process —
+ * used to treat pure join tables (no own id) as leaves in the delete graph.
+ */
+async function getTablesWithId(): Promise<Set<string>> {
+  if (!tablesWithIdPromise) {
+    tablesWithIdPromise = queryRows<{ table_name: string }>(
+      `SELECT table_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public' AND column_name = 'id'`,
+    ).then((rows) => new Set(rows.map((r) => r.table_name)));
+  }
+  return tablesWithIdPromise;
+}
+
+/**
  * Recursively deletes a row and every row that transitively references it via a foreign key.
  *
  * For (table, id): find every FK pointing at this table; for each child row with that FK equal
@@ -1672,6 +1688,13 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
  * row. Every DELETE is scoped to a concrete id — either the row's own id or a parent id already
  * known to belong to a row this cleanup is responsible for — so the walk can never reach another
  * account's rows or seed/master data, no matter how deep it goes.
+ *
+ * Two independent FK checks must stay separate (parent side vs child side):
+ * - Parent side: FK points at a non-`id` column → unresolvable from the id we hold → error.
+ * - Child side: child table has no `id` of its own → cannot SELECT/recurse by id → delete
+ *   matching rows by FK column and treat the table as a leaf (nothing further can reference
+ *   it by id). A table can fail either check, both, or neither; the first branch continues
+ *   before the second is evaluated.
  *
  * `visited` is shared across the entire cleanupCreatedData() invocation. (a) Recursion is finite
  * because the set only grows, is bounded by the number of distinct (table, id) pairs that exist,
@@ -1695,6 +1718,7 @@ async function deleteRowAndDescendants(
   visited: Set<string>,
   errors: string[],
   unhandledForeignKeys: Set<string>,
+  tablesWithId: Set<string>,
 ): Promise<{ deletedSelf: boolean; failed: boolean }> {
   const visitKey = `${table}#${id}`;
   if (visited.has(visitKey)) {
@@ -1724,6 +1748,27 @@ async function deleteRowAndDescendants(
     }
 
     const col = needsQuote(fk.column) ? `"${fk.column}"` : fk.column;
+
+    // Child has no own `id`: pure join / composite-key table. Parent-side check above already
+    // passed (FK targets `id`); this is only about whether child rows are addressable for
+    // recursion. Delete by FK column and stop — nothing can reference these rows by id.
+    if (!tablesWithId.has(fk.table)) {
+      try {
+        await withDb(async (client) => {
+          await client.query(
+            `DELETE FROM ${tableSql(fk.table)} WHERE ${col} = $1`,
+            [id],
+          );
+        });
+      } catch (e) {
+        errors.push(
+          `${fk.table}.${fk.column}=${id}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+        failed = true;
+      }
+      continue;
+    }
+
     let childRows: { id: unknown }[];
     try {
       childRows = await queryRows<{ id: unknown }>(
@@ -1755,6 +1800,7 @@ async function deleteRowAndDescendants(
         visited,
         errors,
         unhandledForeignKeys,
+        tablesWithId,
       );
       if (childResult.failed) failed = true;
     }
@@ -1808,6 +1854,7 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
   // No catch: failing to load the FK graph would leave dependents behind for the next spec on a
   // shared database — silently, since callers of cleanupCreatedData do not read the return value.
   const foreignKeys = await getForeignKeys();
+  const tablesWithId = await getTablesWithId();
   const childrenByReferencedTable = new Map<string, ForeignKeyRef[]>();
   for (const fk of foreignKeys) {
     const list = childrenByReferencedTable.get(fk.referencedTable);
@@ -1827,6 +1874,7 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
       visited,
       errors,
       unhandledForeignKeys,
+      tablesWithId,
     );
     if (result.deletedSelf) deleted += 1;
     if (result.failed) failed.push(ref);

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1292,7 +1292,9 @@ export async function createSupportIssue(
 
   const msgId = res.messages?.[0]?.id;
   // messages is optional on the API response type; no first message means nothing to register.
-  if (msgId) track('support_message', msgId);
+  // `!= null` and not truthiness: a 0 or an empty string is a broken id, and it belongs in
+  // requireId's hands rather than being read as absence. Same rule as createLimitRequest below.
+  if (msgId != null) track('support_message', msgId);
 
   return {
     supportIssueId: issueRow.id,
@@ -1699,7 +1701,8 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
  * not poison every later cleanup in the same process.
  *
  * - PK is exactly `{ id }` → id-addressable (SELECT/recurse by id).
- * - PK exists but is not exactly `{ id }` → nonIdPrimaryKey (unresolvable for this cleanup).
+ * - PK exists but is not exactly `{ id }` → nonIdPrimaryKey (kept for diagnostics; leaf-ness is
+ *   decided by whether anything references the table, not by the shape of its key).
  * - No primary key at all → true leaf (neither set; DELETE by FK and stop).
  */
 async function getTableKeyInfo(): Promise<TableKeyInfo> {
@@ -1784,9 +1787,13 @@ async function deleteRowAndDescendants(
   const visitKey = `${table}#${id}`;
   const cached = visitedResults.get(visitKey);
   if (cached === 'in-progress') {
-    // Genuine cycle: row is still on an ancestor frame. That ancestor still owns the real DELETE;
-    // this branch cannot claim the row is gone.
-    return { deletedSelf: false, failed: true };
+    // Genuine cycle: the row is still on an ancestor frame, which owns its real DELETE. This branch
+    // cannot claim the row is gone, but it must not claim a failure either — reporting `failed`
+    // without a matching entry in `errors` would re-queue the reference while cleanupCreatedData
+    // stays silent, because the throw is driven by `errors`. Whether the cycle really resolves is
+    // decided by the ancestor's own DELETE: it either succeeds (a cascade broke the cycle) or fails
+    // against the constraint and is recorded there, with a message.
+    return { deletedSelf: false, failed: false };
   }
   if (cached !== undefined) {
     // Diamond: return the real first-visit outcome, not an unconditional success.
@@ -1817,30 +1824,46 @@ async function deleteRowAndDescendants(
 
     const col = needsQuote(fk.column) ? `"${fk.column}"` : fk.column;
 
-    // (ii) Child has a PK that is not exactly `{ id }` AND is itself referenced by something else.
-    // Only that combination is unresolvable: the table has descendants, and they cannot be found
-    // without addressing its rows by id. A composite-key table nothing points at — a plain join
-    // table like mros_transactions_transaction — has no descendants to lose, so it is a leaf and
-    // falls through to (iii), which deletes its rows by the foreign key column. Keying this on the
-    // schema alone would report an error for every transaction ever cleaned up, while nothing was
-    // actually left behind.
-    // Report once per distinct table (not per FK column) and skip all DELETE attempts for it.
-    if (tableKeyInfo.nonIdPrimaryKey.has(fk.table) && childrenByReferencedTable.has(fk.table)) {
-      if (!reportedNonIdPrimaryKeyTables.has(fk.table)) {
-        reportedNonIdPrimaryKeyTables.add(fk.table);
-        errors.push(
-          `table "${fk.table}" has a primary key that is not exactly the single column "id": ` +
-            `cleanup can only SELECT/recurse by id, so this table's own descendants cannot be ` +
-            `discovered and no rows were deleted for it`,
+    // (ii) Child cannot be addressed by id AND is itself referenced by something else. Only that
+    // combination is unresolvable: the table has descendants, and they cannot be found without
+    // addressing its rows by id. What decides leaf-ness is whether anything points at the table —
+    // not the shape of its key. A table with no primary key at all can still be referenced through
+    // a UNIQUE column, and a composite-key table nothing points at (a plain join table like
+    // mros_transactions_transaction) has no descendants to lose.
+    //
+    // Reported only when a row actually exists for this parent. Keying it on the schema alone would
+    // fail every cleanup of a parent whose child table happens to be empty for it — the same
+    // mistake, one branch over, that made this whole case wrong before.
+    if (!tableKeyInfo.idAddressable.has(fk.table) && childrenByReferencedTable.has(fk.table)) {
+      let hasRows: boolean;
+      try {
+        const probe = await queryRows<{ one: number }>(
+          `SELECT 1 AS one FROM ${tableSql(fk.table)} WHERE ${col} = $1 LIMIT 1`,
+          [id],
         );
+        hasRows = probe.length > 0;
+      } catch (e) {
+        errors.push(`${fk.table}.${fk.column}=${id}: ${e instanceof Error ? e.message : String(e)}`);
+        failed = true;
+        continue;
       }
-      failed = true;
+
+      if (hasRows) {
+        if (!reportedNonIdPrimaryKeyTables.has(fk.table)) {
+          reportedNonIdPrimaryKeyTables.add(fk.table);
+          errors.push(
+            `table "${fk.table}" is referenced by other tables but has no primary key of exactly ` +
+              `the single column "id": cleanup can only SELECT/recurse by id, so this table's own ` +
+              `descendants cannot be discovered and no rows were deleted for it`,
+          );
+        }
+        failed = true;
+      }
       continue;
     }
 
-    // (iii) Child cannot be addressed by id — no primary key, or a composite one nothing references
-    // (case (ii) already caught the referenced ones). Either way it is a leaf: parent-side check
-    // above passed, so delete its rows by the foreign key column and stop.
+    // (iii) Child cannot be addressed by id and nothing references it: a true leaf. The parent-side
+    // check above passed, so delete its rows by the foreign key column and stop.
     if (!tableKeyInfo.idAddressable.has(fk.table)) {
       try {
         await withDb(async (client) => {

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -198,19 +198,19 @@ interface CreatedRef {
 const created: CreatedRef[] = [];
 
 /**
- * Require a finite positive numeric id. A 2xx response without a usable id is a broken API
+ * Require a genuine positive integer id. A 2xx response without a usable id is a broken API
  * contract, not a missing caller precondition — fail loud so the test cannot assert on a ghost row
  * or leave an untracked DB row behind cleanup.
  */
 function requireId(value: unknown, factory: string, field: string): number {
-  const n = Number(value);
-  if (value == null || !Number.isFinite(n) || n <= 0) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
     throw new Error(
-      `${factory}: expected a finite positive ${field}, got ${JSON.stringify(value)} — ` +
-        `a 2xx without a usable id is a broken API contract, not a missing caller precondition`,
+      `${factory}: expected a finite positive integer ${field}, got ${JSON.stringify(value)} ` +
+        `(typeof ${typeof value}) — a 2xx without a usable id is a broken API contract, not a ` +
+        `missing caller precondition`,
     );
   }
-  return n;
+  return value;
 }
 
 function track(table: string, id: number | undefined | null): void {
@@ -391,7 +391,7 @@ export interface CreateSupportIssueOptions {
 }
 
 export interface CreateSupportIssueResult {
-  supportIssueId?: number;
+  supportIssueId: number;
   uid: string;
   messageId?: number;
 }
@@ -1279,18 +1279,23 @@ export async function createSupportIssue(
     { jwt },
   );
 
+  // A 2xx from POST /support/issue must produce a findable support_issue row; missing it is a
+  // broken API contract, not a shape this factory can tolerate.
   const issueRow = await queryOne<{ id: number }>(`SELECT id FROM support_issue WHERE uid = $1 LIMIT 1`, [res.uid]);
-  // CreateSupportIssueResult declares supportIssueId as optional, and this lookup is by uid rather
-  // than by a returned id — so "no row" is a shape this factory is written to tolerate, not a
-  // contract breach like a missing id in a 2xx body. Register only what is there.
-  if (issueRow) track('support_issue', issueRow.id);
+  if (!issueRow) {
+    throw new Error(
+      `createSupportIssue: POST /support/issue answered 2xx (uid ${res.uid}) but produced no ` +
+        `findable support_issue row`,
+    );
+  }
+  track('support_issue', issueRow.id);
 
   const msgId = res.messages?.[0]?.id;
   // messages is optional on the API response type; no first message means nothing to register.
   if (msgId) track('support_message', msgId);
 
   return {
-    supportIssueId: issueRow?.id,
+    supportIssueId: issueRow.id,
     uid: res.uid,
     messageId: msgId,
   };
@@ -1627,13 +1632,31 @@ interface ForeignKeyRef {
 }
 
 let foreignKeysPromise: Promise<ForeignKeyRef[]> | null = null;
-let tablesWithIdPromise: Promise<Set<string>> | null = null;
+let tableKeyInfoPromise: Promise<TableKeyInfo> | null = null;
+
+interface TableKeyInfo {
+  /** Tables whose primary key is exactly the single column `id` — SELECT/recurse by id is safe. */
+  idAddressable: Set<string>;
+  /**
+   * Tables that have a primary key, but not exactly `{ id }` (composite or differently named).
+   * Cleanup cannot SELECT/recurse them by id and must not treat them as silent leaves either.
+   */
+  nonIdPrimaryKey: Set<string>;
+}
+
+type RowResult = { deletedSelf: boolean; failed: boolean };
 
 /**
  * Discovers every foreign key in the public schema from Postgres's catalog, once per process.
  * Memoized: the schema does not change mid-run, and re-querying on every cleanup would add
  * pointless round trips. Grouping by referencedTable is done cheaply inside cleanupCreatedData
  * from this flat list — it does not need its own cache.
+ *
+ * On rejection the memoized promise is cleared so a later call re-queries instead of replaying
+ * the same failure forever. That pairs with cleanupCreatedData loading catalogs *before*
+ * snapshotting `created`: reordering alone would still lose a second-run snapshot once retries
+ * are possible; resetting the promise alone would still lose the first snapshot if created was
+ * already cleared. Both are required.
  */
 async function getForeignKeys(): Promise<ForeignKeyRef[]> {
   if (!foreignKeysPromise) {
@@ -1653,31 +1676,66 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
          ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
        WHERE tc.constraint_type = 'FOREIGN KEY'
          AND tc.table_schema = 'public'`,
-    ).then((rows) =>
-      rows.map((r) => ({
-        table: r.table_name,
-        column: r.column_name,
-        referencedTable: r.referenced_table,
-        referencedColumn: r.referenced_column,
-      })),
-    );
+    )
+      .then((rows) =>
+        rows.map((r) => ({
+          table: r.table_name,
+          column: r.column_name,
+          referencedTable: r.referenced_table,
+          referencedColumn: r.referenced_column,
+        })),
+      )
+      .catch((e) => {
+        foreignKeysPromise = null;
+        throw e;
+      });
   }
   return foreignKeysPromise;
 }
 
 /**
- * Public-schema tables that have a column literally named `id`. Memoized once per process —
- * used to treat pure join tables (no own id) as leaves in the delete graph.
+ * Classify every public-schema table by its actual primary key (not by column name heuristics).
+ * Memoized once per process; reject-then-reset like getForeignKeys so a failed catalog load does
+ * not poison every later cleanup in the same process.
+ *
+ * - PK is exactly `{ id }` → id-addressable (SELECT/recurse by id).
+ * - PK exists but is not exactly `{ id }` → nonIdPrimaryKey (unresolvable for this cleanup).
+ * - No primary key at all → true leaf (neither set; DELETE by FK and stop).
  */
-async function getTablesWithId(): Promise<Set<string>> {
-  if (!tablesWithIdPromise) {
-    tablesWithIdPromise = queryRows<{ table_name: string }>(
-      `SELECT table_name
-       FROM information_schema.columns
-       WHERE table_schema = 'public' AND column_name = 'id'`,
-    ).then((rows) => new Set(rows.map((r) => r.table_name)));
+async function getTableKeyInfo(): Promise<TableKeyInfo> {
+  if (!tableKeyInfoPromise) {
+    tableKeyInfoPromise = queryRows<{ table_name: string; column_name: string }>(
+      `SELECT tc.table_name, kcu.column_name
+       FROM information_schema.table_constraints tc
+       JOIN information_schema.key_column_usage kcu
+         ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
+       WHERE tc.constraint_type = 'PRIMARY KEY'
+         AND tc.table_schema = 'public'`,
+    )
+      .then((rows) => {
+        const columnsByTable = new Map<string, string[]>();
+        for (const row of rows) {
+          const cols = columnsByTable.get(row.table_name);
+          if (cols) cols.push(row.column_name);
+          else columnsByTable.set(row.table_name, [row.column_name]);
+        }
+        const idAddressable = new Set<string>();
+        const nonIdPrimaryKey = new Set<string>();
+        for (const [tableName, columns] of columnsByTable) {
+          if (columns.length === 1 && columns[0] === 'id') {
+            idAddressable.add(tableName);
+          } else {
+            nonIdPrimaryKey.add(tableName);
+          }
+        }
+        return { idAddressable, nonIdPrimaryKey };
+      })
+      .catch((e) => {
+        tableKeyInfoPromise = null;
+        throw e;
+      });
   }
-  return tablesWithIdPromise;
+  return tableKeyInfoPromise;
 }
 
 /**
@@ -1689,49 +1747,59 @@ async function getTablesWithId(): Promise<Set<string>> {
  * known to belong to a row this cleanup is responsible for — so the walk can never reach another
  * account's rows or seed/master data, no matter how deep it goes.
  *
- * Two independent FK checks must stay separate (parent side vs child side):
- * - Parent side: FK points at a non-`id` column → unresolvable from the id we hold → error.
- * - Child side: child table has no `id` of its own → cannot SELECT/recurse by id → delete
- *   matching rows by FK column and treat the table as a leaf (nothing further can reference
- *   it by id). A table can fail either check, both, or neither; the first branch continues
- *   before the second is evaluated.
+ * Three independent FK checks must stay separate (parent side vs child-side key shape):
+ * - (i) Parent side: FK points at a non-`id` column → unresolvable from the id we hold → error.
+ * - (ii) Child has a primary key but not exactly `{ id }` → cannot SELECT/recurse by id and must
+ *   not be treated as a silent leaf either → error once per such table, no DELETE attempt.
+ * - (iii) Child has no primary key at all → true leaf: DELETE matching rows by FK column and stop
+ *   (nothing can reference those rows by id). A table can hit any combination of (i)/(ii); (iii)
+ *   is the remaining no-PK case. The first matching branch continues before later ones run.
  *
- * `visited` is shared across the entire cleanupCreatedData() invocation. (a) Recursion is finite
- * because the set only grows, is bounded by the number of distinct (table, id) pairs that exist,
- * and a pair already in it is never re-entered. (b) Skipping an already-visited pair cannot
- * silently lose a delete: either that pair was already fully processed on an earlier branch
- * (nothing left to do), or it is still an ancestor on the current recursion stack — a genuine,
- * structurally unresolvable FK cycle (some column would need to be nulled first, which is out of
- * scope). In that case the pair's own DELETE is still attempted where it is owned in the
- * recursion and fails with a normal Postgres FK-violation error, reported like any other failed
- * delete.
+ * `visitedResults` is shared across the entire cleanupCreatedData() invocation. Values are either
+ * `'in-progress'` (this row is still on an ancestor frame's stack — a genuine FK cycle) or a
+ * finished `RowResult` (the real first-visit outcome). That distinguishes:
+ * - Cycle: return `{ deletedSelf: false, failed: true }` without recursing. The ancestor frame
+ *   that owns this row still runs its own real DELETE later in its own turn and pushes any real
+ *   failure into `errors` independently of what this branch returns — nothing is silently lost —
+ *   but THIS branch genuinely cannot confirm the row is gone, so it must not report
+ *   `deletedSelf: true`.
+ * - Diamond (two paths reach the same row): return the cached finished result as-is, not a
+ *   fabricated success, so a failed first visit is not rewritten as success on the second path.
  *
  * Returns whether this row's own DELETE succeeded, and whether anything in its subtree failed
- * (including unhandled non-id foreign keys). A deeper failure does not skip the attempt to
- * delete this row or its independent siblings — maximize what gets cleaned up, collect every
- * error.
+ * (including unhandled foreign keys / non-id primary keys). A deeper failure does not skip the
+ * attempt to delete this row or its independent siblings — maximize what gets cleaned up, collect
+ * every error.
  */
 async function deleteRowAndDescendants(
   table: string,
   id: number,
   childrenByReferencedTable: Map<string, ForeignKeyRef[]>,
-  visited: Set<string>,
+  visitedResults: Map<string, 'in-progress' | RowResult>,
   errors: string[],
   unhandledForeignKeys: Set<string>,
-  tablesWithId: Set<string>,
-): Promise<{ deletedSelf: boolean; failed: boolean }> {
+  reportedNonIdPrimaryKeyTables: Set<string>,
+  tableKeyInfo: TableKeyInfo,
+): Promise<RowResult> {
   const visitKey = `${table}#${id}`;
-  if (visited.has(visitKey)) {
-    return { deletedSelf: true, failed: false };
+  const cached = visitedResults.get(visitKey);
+  if (cached === 'in-progress') {
+    // Genuine cycle: row is still on an ancestor frame. That ancestor still owns the real DELETE;
+    // this branch cannot claim the row is gone.
+    return { deletedSelf: false, failed: true };
   }
-  visited.add(visitKey);
+  if (cached !== undefined) {
+    // Diamond: return the real first-visit outcome, not an unconditional success.
+    return cached;
+  }
+  visitedResults.set(visitKey, 'in-progress');
 
   let failed = false;
   const fks = childrenByReferencedTable.get(table) ?? [];
 
   for (const fk of fks) {
     if (fk.referencedColumn !== 'id') {
-      // Cleanup addresses every row by id only; a FK to a non-id parent column cannot be
+      // (i) Cleanup addresses every row by id only; a FK to a non-id parent column cannot be
       // resolved from the id we hold. Surface once per distinct child-table.column so a human
       // reading AggregateError knows which constraint needs an explicit fix.
       const unhandledKey = `${fk.table}.${fk.column}`;
@@ -1749,10 +1817,24 @@ async function deleteRowAndDescendants(
 
     const col = needsQuote(fk.column) ? `"${fk.column}"` : fk.column;
 
-    // Child has no own `id`: pure join / composite-key table. Parent-side check above already
-    // passed (FK targets `id`); this is only about whether child rows are addressable for
-    // recursion. Delete by FK column and stop — nothing can reference these rows by id.
-    if (!tablesWithId.has(fk.table)) {
+    // (ii) Child has a PK that is not exactly `{ id }` — not a safe leaf and not addressable.
+    // Report once per distinct table (not per FK column) and skip all DELETE attempts for it.
+    if (tableKeyInfo.nonIdPrimaryKey.has(fk.table)) {
+      if (!reportedNonIdPrimaryKeyTables.has(fk.table)) {
+        reportedNonIdPrimaryKeyTables.add(fk.table);
+        errors.push(
+          `table "${fk.table}" has a primary key that is not exactly the single column "id": ` +
+            `cleanup can only SELECT/recurse by id, so this table's own descendants cannot be ` +
+            `discovered and no rows were deleted for it`,
+        );
+      }
+      failed = true;
+      continue;
+    }
+
+    // (iii) Child has no primary key at all: true leaf. Parent-side check above already passed
+    // (FK targets `id`). Delete by FK column and stop — nothing can reference these rows by id.
+    if (!tableKeyInfo.idAddressable.has(fk.table)) {
       try {
         await withDb(async (client) => {
           await client.query(
@@ -1797,10 +1879,11 @@ async function deleteRowAndDescendants(
         fk.table,
         childId,
         childrenByReferencedTable,
-        visited,
+        visitedResults,
         errors,
         unhandledForeignKeys,
-        tablesWithId,
+        reportedNonIdPrimaryKeyTables,
+        tableKeyInfo,
       );
       if (childResult.failed) failed = true;
     }
@@ -1817,7 +1900,9 @@ async function deleteRowAndDescendants(
     failed = true;
   }
 
-  return { deletedSelf, failed };
+  const result: RowResult = { deletedSelf, failed };
+  visitedResults.set(visitKey, result);
+  return result;
 }
 
 /**
@@ -1848,13 +1933,20 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
   const errors: string[] = [];
   const failed: CreatedRef[] = [];
   let deleted = 0;
+
+  // Load catalogs BEFORE snapshotting/clearing `created`. If either await throws, the refs stay
+  // in `created` for a later retry. Combined with the reject-then-reset memoization in
+  // getForeignKeys/getTableKeyInfo: (a) alone still loses a second-run snapshot once (b) allows
+  // retries after a process-lifetime failure; (b) alone still loses the first snapshot if
+  // `created` was already cleared. Both are required.
+  // No catch: failing to load the FK/key catalog would leave dependents behind for the next spec
+  // on a shared database — silently, since callers of cleanupCreatedData do not read the return.
+  const foreignKeys = await getForeignKeys();
+  const tableKeyInfo = await getTableKeyInfo();
+
   const snapshot = [...created].reverse();
   created.length = 0;
 
-  // No catch: failing to load the FK graph would leave dependents behind for the next spec on a
-  // shared database — silently, since callers of cleanupCreatedData do not read the return value.
-  const foreignKeys = await getForeignKeys();
-  const tablesWithId = await getTablesWithId();
   const childrenByReferencedTable = new Map<string, ForeignKeyRef[]>();
   for (const fk of foreignKeys) {
     const list = childrenByReferencedTable.get(fk.referencedTable);
@@ -1863,18 +1955,20 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
   }
 
   // Shared across every top-level ref in this invocation — not reset per ref or per recurse.
-  const visited = new Set<string>();
+  const visitedResults = new Map<string, 'in-progress' | RowResult>();
   const unhandledForeignKeys = new Set<string>();
+  const reportedNonIdPrimaryKeyTables = new Set<string>();
 
   for (const ref of snapshot) {
     const result = await deleteRowAndDescendants(
       ref.table,
       ref.id,
       childrenByReferencedTable,
-      visited,
+      visitedResults,
       errors,
       unhandledForeignKeys,
-      tablesWithId,
+      reportedNonIdPrimaryKeyTables,
+      tableKeyInfo,
     );
     if (result.deletedSelf) deleted += 1;
     if (result.failed) failed.push(ref);

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1817,9 +1817,15 @@ async function deleteRowAndDescendants(
 
     const col = needsQuote(fk.column) ? `"${fk.column}"` : fk.column;
 
-    // (ii) Child has a PK that is not exactly `{ id }` — not a safe leaf and not addressable.
+    // (ii) Child has a PK that is not exactly `{ id }` AND is itself referenced by something else.
+    // Only that combination is unresolvable: the table has descendants, and they cannot be found
+    // without addressing its rows by id. A composite-key table nothing points at — a plain join
+    // table like mros_transactions_transaction — has no descendants to lose, so it is a leaf and
+    // falls through to (iii), which deletes its rows by the foreign key column. Keying this on the
+    // schema alone would report an error for every transaction ever cleaned up, while nothing was
+    // actually left behind.
     // Report once per distinct table (not per FK column) and skip all DELETE attempts for it.
-    if (tableKeyInfo.nonIdPrimaryKey.has(fk.table)) {
+    if (tableKeyInfo.nonIdPrimaryKey.has(fk.table) && childrenByReferencedTable.has(fk.table)) {
       if (!reportedNonIdPrimaryKeyTables.has(fk.table)) {
         reportedNonIdPrimaryKeyTables.add(fk.table);
         errors.push(
@@ -1832,8 +1838,9 @@ async function deleteRowAndDescendants(
       continue;
     }
 
-    // (iii) Child has no primary key at all: true leaf. Parent-side check above already passed
-    // (FK targets `id`). Delete by FK column and stop — nothing can reference these rows by id.
+    // (iii) Child cannot be addressed by id — no primary key, or a composite one nothing references
+    // (case (ii) already caught the referenced ones). Either way it is a leaf: parent-side check
+    // above passed, so delete its rows by the foreign key column and stop.
     if (!tableKeyInfo.idAddressable.has(fk.table)) {
       try {
         await withDb(async (client) => {

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1704,8 +1704,8 @@ async function getForeignKeys(): Promise<ForeignKeyRef[]> {
  * - PK exists but is not exactly `{ id }` → nonIdPrimaryKey (diagnostics only).
  * - No primary key at all → in neither set.
  *
- * Leaf-ness is NOT decided here. A table that is not id-addressable is a leaf only when nothing
- * references it; if something does, its descendants exist and cannot be reached by id, which is an
+ * Leaf-ness is NOT decided here. A table that is not id-addressable is a leaf only when no OTHER
+ * table references it — a self-referencing foreign key does not count; if something does, its descendants exist and cannot be reached by id, which is an
  * error rather than a leaf. See deleteRowAndDescendants for that decision.
  */
 async function getTableKeyInfo(): Promise<TableKeyInfo> {
@@ -1755,10 +1755,10 @@ async function getTableKeyInfo(): Promise<TableKeyInfo> {
  *
  * Three independent FK checks must stay separate (parent side vs child side):
  * - (i) Parent side: FK points at a non-`id` column → unresolvable from the id we hold → error.
- * - (ii) Child is not addressable by `id` AND something references it → its descendants exist and
+ * - (ii) Child is not addressable by `id` AND another table references it → its descendants exist and
  *   cannot be reached, which must not pass as a silent leaf → error once per such table, no DELETE
  *   attempt, and only when a row for this parent actually exists.
- * - (iii) Child is not addressable by `id` and nothing references it → true leaf: DELETE matching
+ * - (iii) Child is not addressable by `id` and no other table references it → true leaf: DELETE matching
  *   rows by FK column and stop. Both (ii) and (iii) cover tables with no primary key as well as
  *   tables with a composite one; what separates them is whether anything points at the table, not
  *   the shape of its key. The first matching branch continues before later ones run.
@@ -1770,8 +1770,8 @@ async function getTableKeyInfo(): Promise<TableKeyInfo> {
  *   confirm the row is gone, so it must not report `deletedSelf: true` — but it must not report a
  *   failure either: the throw at the end is driven by `errors`, so a `failed` without a matching
  *   entry there would re-queue the reference while cleanupCreatedData stayed silent about why. The
- *   ancestor frame that owns this row runs its own real DELETE later and records its own outcome,
- *   with a message.
+ *   ancestor frame that owns this row runs its own real DELETE later: it either succeeds, or fails
+ *   against the constraint and records that failure in `errors` with a message.
  * - Diamond (two paths reach the same row): return the cached finished result as-is, not a
  *   fabricated success, so a failed first visit is not rewritten as success on the second path.
  *
@@ -1876,7 +1876,7 @@ async function deleteRowAndDescendants(
       continue;
     }
 
-    // (iii) Child cannot be addressed by id and nothing references it: a true leaf. The parent-side
+    // (iii) Child cannot be addressed by id and no other table references it: a true leaf. The parent-side
     // check above passed, so delete its rows by the foreign key column and stop.
     if (!tableKeyInfo.idAddressable.has(fk.table)) {
       try {

--- a/e2e-stack/specs/fixtures/factories.ts
+++ b/e2e-stack/specs/fixtures/factories.ts
@@ -1619,67 +1619,181 @@ export async function createCallQueueEntry(
 // 12. cleanupCreatedData
 // ---------------------------------------------------------------------------
 
-interface UserDependentTable {
-  table: string;
-  column: string;
-  referencedTable: 'user' | 'user_data';
+interface ForeignKeyRef {
+  table: string; // child table containing the FK column
+  column: string; // FK column on the child table
+  referencedTable: string; // parent table the FK points at
+  referencedColumn: string; // parent column the FK points at
 }
 
-let userDependentTablesPromise: Promise<UserDependentTable[]> | null = null;
+let foreignKeysPromise: Promise<ForeignKeyRef[]> | null = null;
 
 /**
- * Discovers every table with a foreign key pointing at "user" or user_data straight from
- * Postgres's own catalog, instead of a hand-maintained list — the API writes rows into several
- * of these (ip_log on every login; kyc_log / kyc_step / transaction_request on mail-set /
- * KYC-level / personal-data completion) that no factory tracks, so cleanupCreatedData's own
- * DELETE of "user"/"user_data" below always failed on them even with the correct user/user_data
- * delete order. Scoped deliberately to direct references to "user"/user_data only — not a
- * general recursive schema walk, which would risk reaching into chains other factories already
- * track and order correctly (transaction/buy_crypto/deposit_route etc.). Queried once per
- * process and memoized; the schema does not change mid-run.
+ * Discovers every foreign key in the public schema from Postgres's catalog, once per process.
+ * Memoized: the schema does not change mid-run, and re-querying on every cleanup would add
+ * pointless round trips. Grouping by referencedTable is done cheaply inside cleanupCreatedData
+ * from this flat list — it does not need its own cache.
  */
-async function getUserDependentTables(): Promise<UserDependentTable[]> {
-  if (!userDependentTablesPromise) {
-    userDependentTablesPromise = queryRows<{
+async function getForeignKeys(): Promise<ForeignKeyRef[]> {
+  if (!foreignKeysPromise) {
+    foreignKeysPromise = queryRows<{
       table_name: string;
       column_name: string;
       referenced_table: string;
+      referenced_column: string;
     }>(
-      `SELECT tc.table_name, kcu.column_name, ccu.table_name AS referenced_table
+      `SELECT tc.table_name, kcu.column_name,
+              ccu.table_name AS referenced_table,
+              ccu.column_name AS referenced_column
        FROM information_schema.table_constraints tc
        JOIN information_schema.key_column_usage kcu
          ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema
        JOIN information_schema.constraint_column_usage ccu
          ON tc.constraint_name = ccu.constraint_name AND tc.table_schema = ccu.table_schema
        WHERE tc.constraint_type = 'FOREIGN KEY'
-         AND tc.table_schema = 'public'
-         AND ccu.table_name IN ('user', 'user_data')
-         AND tc.table_name NOT IN ('user', 'user_data')`,
+         AND tc.table_schema = 'public'`,
     ).then((rows) =>
       rows.map((r) => ({
         table: r.table_name,
         column: r.column_name,
-        referencedTable: r.referenced_table as 'user' | 'user_data',
+        referencedTable: r.referenced_table,
+        referencedColumn: r.referenced_column,
       })),
     );
   }
-  return userDependentTablesPromise;
+  return foreignKeysPromise;
 }
 
 /**
- * Deletes rows this module created, in reverse order, to respect FKs. For every "user" /
- * "user_data" row, first clears the API's own untracked dependent rows for exactly that row's id
- * (see getUserDependentTables) — scoped to that one id, so it can never touch another account's
- * rows or seed/master data — then deletes the row itself.
+ * Recursively deletes a row and every row that transitively references it via a foreign key.
+ *
+ * For (table, id): find every FK pointing at this table; for each child row with that FK equal
+ * to id, recurse first (which deletes that child and its own descendants); finally delete this
+ * row. Every DELETE is scoped to a concrete id — either the row's own id or a parent id already
+ * known to belong to a row this cleanup is responsible for — so the walk can never reach another
+ * account's rows or seed/master data, no matter how deep it goes.
+ *
+ * `visited` is shared across the entire cleanupCreatedData() invocation. (a) Recursion is finite
+ * because the set only grows, is bounded by the number of distinct (table, id) pairs that exist,
+ * and a pair already in it is never re-entered. (b) Skipping an already-visited pair cannot
+ * silently lose a delete: either that pair was already fully processed on an earlier branch
+ * (nothing left to do), or it is still an ancestor on the current recursion stack — a genuine,
+ * structurally unresolvable FK cycle (some column would need to be nulled first, which is out of
+ * scope). In that case the pair's own DELETE is still attempted where it is owned in the
+ * recursion and fails with a normal Postgres FK-violation error, reported like any other failed
+ * delete.
+ *
+ * Returns whether this row's own DELETE succeeded, and whether anything in its subtree failed
+ * (including unhandled non-id foreign keys). A deeper failure does not skip the attempt to
+ * delete this row or its independent siblings — maximize what gets cleaned up, collect every
+ * error.
+ */
+async function deleteRowAndDescendants(
+  table: string,
+  id: number,
+  childrenByReferencedTable: Map<string, ForeignKeyRef[]>,
+  visited: Set<string>,
+  errors: string[],
+  unhandledForeignKeys: Set<string>,
+): Promise<{ deletedSelf: boolean; failed: boolean }> {
+  const visitKey = `${table}#${id}`;
+  if (visited.has(visitKey)) {
+    return { deletedSelf: true, failed: false };
+  }
+  visited.add(visitKey);
+
+  let failed = false;
+  const fks = childrenByReferencedTable.get(table) ?? [];
+
+  for (const fk of fks) {
+    if (fk.referencedColumn !== 'id') {
+      // Cleanup addresses every row by id only; a FK to a non-id parent column cannot be
+      // resolved from the id we hold. Surface once per distinct child-table.column so a human
+      // reading AggregateError knows which constraint needs an explicit fix.
+      const unhandledKey = `${fk.table}.${fk.column}`;
+      if (!unhandledForeignKeys.has(unhandledKey)) {
+        unhandledForeignKeys.add(unhandledKey);
+        errors.push(
+          `unhandled foreign key ${fk.table}.${fk.column} -> ` +
+            `${fk.referencedTable}.${fk.referencedColumn}: cleanup only resolves rows by id ` +
+            `and cannot follow a reference to "${fk.referencedTable}.${fk.referencedColumn}"`,
+        );
+      }
+      failed = true;
+      continue;
+    }
+
+    const col = needsQuote(fk.column) ? `"${fk.column}"` : fk.column;
+    let childRows: { id: unknown }[];
+    try {
+      childRows = await queryRows<{ id: unknown }>(
+        `SELECT id FROM ${tableSql(fk.table)} WHERE ${col} = $1`,
+        [id],
+      );
+    } catch (e) {
+      errors.push(
+        `${fk.table}.${fk.column}=${id}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      failed = true;
+      continue;
+    }
+
+    for (const childRow of childRows) {
+      const childId = Number(childRow.id);
+      if (!Number.isFinite(childId) || childId <= 0) {
+        errors.push(
+          `${fk.table}.${fk.column}=${id}: expected a finite positive id, got ` +
+            `${JSON.stringify(childRow.id)}`,
+        );
+        failed = true;
+        continue;
+      }
+      const childResult = await deleteRowAndDescendants(
+        fk.table,
+        childId,
+        childrenByReferencedTable,
+        visited,
+        errors,
+        unhandledForeignKeys,
+      );
+      if (childResult.failed) failed = true;
+    }
+  }
+
+  let deletedSelf = false;
+  try {
+    await withDb(async (client) => {
+      await client.query(`DELETE FROM ${tableSql(table)} WHERE id = $1`, [id]);
+    });
+    deletedSelf = true;
+  } catch (e) {
+    errors.push(`${table}#${id}: ${e instanceof Error ? e.message : String(e)}`);
+    failed = true;
+  }
+
+  return { deletedSelf, failed };
+}
+
+/**
+ * Deletes rows this module created, in reverse registration order, to respect FKs. Before
+ * deleting any tracked row, recursively deletes every row that transitively references it —
+ * discovered from the public-schema foreign-key graph (see getForeignKeys), not a hand-picked
+ * table list — so application-written children the factories never registered (e.g.
+ * support_message under support_issue under user_data, buy_crypto under bank_tx under
+ * transaction) are cleared too.
+ *
+ * Every DELETE is scoped to a concrete id (the row itself, or a foreign-key value equal to a
+ * parent id this run is already deleting). The walk therefore cannot touch another account's
+ * rows or seed/master data, no matter how deep it goes.
  *
  * In a shared database, a row that fails to delete is not a cosmetic problem: it is state the
  * next spec file inherits, and it can make that unrelated file fail (or pass) for reasons that
- * have nothing to do with what it actually tests. So a failed delete here throws instead of being
- * swallowed — the file that caused the leftover goes red, not whichever file happens to run next.
- * References whose delete failed — including a "user"/"user_data" row whose own DELETE succeeded
- * but left one of its dependent rows behind — are re-registered into `created`, in their original
- * registration order, so the next call to cleanupCreatedData() retries them. A successful cleanup
- * stays completely silent (no console.log/console.warn either way).
+ * have nothing to do with what it actually tests. So a failed delete here throws instead of
+ * being swallowed — the file that caused the leftover goes red, not whichever file happens to
+ * run next. Top-level references for which anything failed (own delete, a delete underneath, or
+ * an unhandled non-id foreign key reached while processing them) are re-registered into
+ * `created`, in their original registration order, so the next call to cleanupCreatedData()
+ * retries them. A successful cleanup stays completely silent (no console.log/console.warn).
  *
  * Every `test.afterAll` in this suite calls this function and discards the resolved value; the
  * throw is what actually surfaces a failed cleanup to the test runner.
@@ -1691,48 +1805,39 @@ export async function cleanupCreatedData(): Promise<{ deleted: number; errors: s
   const snapshot = [...created].reverse();
   created.length = 0;
 
-  // No catch: an empty dependency list would make cleanup delete nothing for user/user_data and
-  // leave rows behind for the next spec on a shared database — silently, since the caller of
-  // cleanupCreatedData does not read what it returns.
-  const dependents = await getUserDependentTables();
+  // No catch: failing to load the FK graph would leave dependents behind for the next spec on a
+  // shared database — silently, since callers of cleanupCreatedData do not read the return value.
+  const foreignKeys = await getForeignKeys();
+  const childrenByReferencedTable = new Map<string, ForeignKeyRef[]>();
+  for (const fk of foreignKeys) {
+    const list = childrenByReferencedTable.get(fk.referencedTable);
+    if (list) list.push(fk);
+    else childrenByReferencedTable.set(fk.referencedTable, [fk]);
+  }
+
+  // Shared across every top-level ref in this invocation — not reset per ref or per recurse.
+  const visited = new Set<string>();
+  const unhandledForeignKeys = new Set<string>();
 
   for (const ref of snapshot) {
-    let refFailed = false;
-
-    if (ref.table === 'user' || ref.table === 'user_data') {
-      for (const dep of dependents) {
-        if (dep.referencedTable !== ref.table) continue;
-        const col = needsQuote(dep.column) ? `"${dep.column}"` : dep.column;
-        try {
-          await withDb(async (client) => {
-            await client.query(`DELETE FROM ${tableSql(dep.table)} WHERE ${col} = $1`, [ref.id]);
-          });
-        } catch (e) {
-          errors.push(`${dep.table}.${dep.column}=${ref.id}: ${e instanceof Error ? e.message : String(e)}`);
-          refFailed = true;
-        }
-      }
-    }
-
-    try {
-      await withDb(async (client) => {
-        await client.query(`DELETE FROM ${tableSql(ref.table)} WHERE id = $1`, [ref.id]);
-      });
-      deleted += 1;
-    } catch (e) {
-      errors.push(`${ref.table}#${ref.id}: ${e instanceof Error ? e.message : String(e)}`);
-      refFailed = true;
-    }
-
-    if (refFailed) failed.push(ref);
+    const result = await deleteRowAndDescendants(
+      ref.table,
+      ref.id,
+      childrenByReferencedTable,
+      visited,
+      errors,
+      unhandledForeignKeys,
+    );
+    if (result.deletedSelf) deleted += 1;
+    if (result.failed) failed.push(ref);
   }
 
   if (failed.length > 0) {
     // `failed` was accumulated while iterating `snapshot`, which is already the reverse of the
-    // original registration order — so `failed` itself is in reverse-of-reverse, i.e. it needs one
-    // more reverse() to land back in original registration order before re-entering `created`.
-    // The next cleanupCreatedData() call reverses `created` again, so this is what makes that
-    // second reversal produce a correct, FK-respecting retry order.
+    // original registration order — so `failed` itself is in reverse-of-reverse, i.e. it needs
+    // one more reverse() to land back in original registration order before re-entering
+    // `created`. The next cleanupCreatedData() call reverses `created` again, so this is what
+    // makes that second reversal produce a correct, FK-respecting retry order.
     created.push(...failed.reverse());
   }
 

--- a/e2e-stack/specs/fixtures/index.ts
+++ b/e2e-stack/specs/fixtures/index.ts
@@ -116,15 +116,15 @@ async function isolateFromExternalHosts(page: Page): Promise<void> {
  * openScreen, which loginAs + openScreen already provide. Add one back only with a test that uses it.
  */
 export const test = base.extend<AuthFixtures>({
-  page: async ({ page }, use) => {
+  page: async ({ page }, use, testInfo) => {
     await isolateFromExternalHosts(page);
-    // Record where the browser actually went. The coverage gate reads this back and requires every
-    // route in App.tsx to have been navigated to by some test — a claim in the registry that points
-    // at a file which never opens the route would otherwise satisfy it.
+    // Record where the browser actually went, together with the spec file that drove the page.
+    // The coverage gate requires every claimed route to have been opened by the claiming suite —
+    // not merely by any suite that happened to land on the same path.
     page.on('framenavigated', (frame) => {
       if (frame !== page.mainFrame()) return;
       try {
-        recordVisitedRoute(new URL(frame.url()).pathname);
+        recordVisitedRoute(new URL(frame.url()).pathname, testInfo.file);
       } catch {
         // about:blank and similar non-URL navigations carry no path to record.
       }

--- a/e2e-stack/specs/fixtures/routes.ts
+++ b/e2e-stack/specs/fixtures/routes.ts
@@ -12,6 +12,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
+import type { RouteClaim } from '../registry/types';
 
 /** Compare-ready pathname: one trailing slash removed, except on the root path. */
 export function normPath(p: string): string {
@@ -308,4 +309,44 @@ export function routeMatches(route: string, visited: string): boolean {
     })
     .join('/');
   return new RegExp(`^${pattern}$`).test(normPath(visited));
+}
+
+export interface RouteVisitEvaluation {
+  neverOpened: string[];
+  wrongSuite: string[];
+  correctlyOpened: string[];
+}
+
+/** Classify claimed routes by whether, and by which spec file, each route was visited. */
+export function evaluateClaimedRouteVisits(
+  realRoutes: Iterable<string>,
+  claimByPath: Map<string, RouteClaim>,
+  visited: VisitedRoute[],
+  specsDir: string,
+): RouteVisitEvaluation {
+  const neverOpened: string[] = [];
+  const wrongSuite: string[] = [];
+  const correctlyOpened: string[] = [];
+
+  // Unclaimed routes are reported by the ownership check, so do not double-count them here.
+  for (const route of [...realRoutes].sort()) {
+    const claim = claimByPath.get(route);
+    if (!claim) continue;
+
+    const matching = visited.filter((entry) => routeMatches(route, entry.path));
+    const canonicalClaimSpec = specClaimName(path.join(specsDir, claim.spec));
+    const byClaimer = matching.filter((entry) => entry.specFile === canonicalClaimSpec);
+    if (matching.length === 0) {
+      neverOpened.push(route);
+    } else if (byClaimer.length === 0) {
+      const openers = [...new Set(matching.map((entry) => entry.specFile))].sort();
+      wrongSuite.push(
+        `${route} (claimed by ${claim.spec}, opened by: ${openers.join(', ')})`,
+      );
+    } else {
+      correctlyOpened.push(route);
+    }
+  }
+
+  return { neverOpened, wrongSuite, correctlyOpened };
 }

--- a/e2e-stack/specs/fixtures/routes.ts
+++ b/e2e-stack/specs/fixtures/routes.ts
@@ -232,12 +232,17 @@ export interface VisitedRoute {
 }
 
 /**
- * Reduce Playwright's absolute testInfo.file to the form registry claims use (claim.spec, e.g.
- * "buy.spec.ts"). route-coverage.spec.ts resolves a claim as path.join(<specs dir>, claim.spec), so
- * the inverse is the path relative to that same directory — not the bare basename, which would
- * stop matching the moment a suite moves into a subdirectory and would silently make its claims
- * look unvisited. Recording and evaluation must derive this form identically, which is why both
- * sides call this one function.
+ * Reduce an absolute spec-file path to the form registry claims use (claim.spec, e.g.
+ * "buy.spec.ts" or "subdir/buy.spec.ts"). The result is the path relative to the specs/
+ * directory — not the bare basename, which would stop matching the moment a suite moves into a
+ * subdirectory and would silently make its claims look unvisited.
+ *
+ * Both sides of the coverage gate go through this one function rather than comparing raw strings:
+ * - Recording (`recordVisitedRoute`) calls it directly with Playwright's absolute `testInfo.file`.
+ * - Evaluation (route-coverage.spec.ts) first resolves `claim.spec` to an absolute path via
+ *   `path.join(<specs dir>, claim.spec)` — the same resolution the existence check already uses —
+ *   then passes that absolute path here, so a claim written as `./buy.spec.ts` canonicalizes to
+ *   the same relative form the recording side stored.
  */
 export function specClaimName(specFilePath: string): string {
   return path.relative(path.join(__dirname, '..'), specFilePath);

--- a/e2e-stack/specs/fixtures/routes.ts
+++ b/e2e-stack/specs/fixtures/routes.ts
@@ -218,34 +218,72 @@ export function resolveAppSourcePath(): string {
 }
 
 /**
- * Where the browser fixture records the paths it navigated to, and where the coverage gate reads
- * them back. Written as one path per line so parallel appends cannot corrupt each other and a
- * crashed run still leaves everything up to that point.
+ * Where the browser fixture records the navigations it made, and where the coverage gate reads
+ * them back. Written as one line per navigation (`pathname\tspecFile`) so parallel appends cannot
+ * corrupt each other and a crashed run still leaves everything up to that point.
  */
 export function visitedRoutesPath(): string {
   return path.join(process.env.E2E_ARTIFACT_DIR ?? '/work/test-results', 'visited-routes.log');
 }
 
+export interface VisitedRoute {
+  path: string;
+  specFile: string;
+}
+
+/**
+ * Reduce Playwright's absolute testInfo.file to the form registry claims use (claim.spec, e.g.
+ * "buy.spec.ts"). route-coverage.spec.ts resolves a claim as path.join(<specs dir>, claim.spec), so
+ * the inverse is the path relative to that same directory — not the bare basename, which would
+ * stop matching the moment a suite moves into a subdirectory and would silently make its claims
+ * look unvisited. Recording and evaluation must derive this form identically, which is why both
+ * sides call this one function.
+ */
+export function specClaimName(specFilePath: string): string {
+  return path.relative(path.join(__dirname, '..'), specFilePath);
+}
+
 /** Records one navigation. Errors are swallowed: a test must not fail over bookkeeping. */
-export function recordVisitedRoute(pathname: string): void {
+export function recordVisitedRoute(pathname: string, specFilePath: string): void {
   try {
     const file = visitedRoutesPath();
     fs.mkdirSync(path.dirname(file), { recursive: true });
-    fs.appendFileSync(file, `${normPath(pathname)}\n`);
+    fs.appendFileSync(file, `${normPath(pathname)}\t${specClaimName(specFilePath)}\n`);
   } catch {
     // Nothing to do here — the gate reports an empty recording as missing coverage, which is the
     // outcome that matters, and a broken artifact directory already fails the run elsewhere.
   }
 }
 
-export function readVisitedRoutes(): string[] {
+/**
+ * Reads the navigation log. Empty lines (trailing newline from appendFileSync) are skipped.
+ * A non-empty line that is not exactly `path\tspecFile` fails loud with file, line number and raw
+ * content so a malformed artifact is never silently treated as missing coverage.
+ */
+export function readVisitedRoutes(): VisitedRoute[] {
   const file = visitedRoutesPath();
   if (!fs.existsSync(file)) return [];
-  return fs
-    .readFileSync(file, 'utf8')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  const result: VisitedRoute[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === '') continue;
+    const tab = line.indexOf('\t');
+    if (tab <= 0 || tab === line.length - 1) {
+      throw new Error(
+        `Malformed visited-routes entry in ${file} at line ${i + 1}: expected path\\tspecFile, got ${JSON.stringify(line)}`,
+      );
+    }
+    const pathField = line.slice(0, tab);
+    const specFile = line.slice(tab + 1);
+    if (pathField === '' || specFile === '' || specFile.includes('\t')) {
+      throw new Error(
+        `Malformed visited-routes entry in ${file} at line ${i + 1}: expected path\\tspecFile, got ${JSON.stringify(line)}`,
+      );
+    }
+    result.push({ path: pathField, specFile });
+  }
+  return result;
 }
 
 /**

--- a/e2e-stack/specs/route-coverage.spec.ts
+++ b/e2e-stack/specs/route-coverage.spec.ts
@@ -295,27 +295,60 @@ test('every app route is claimed by exactly one registry entry @coverage-gate', 
   }
 
   // The checks above are about ownership: every route belongs to exactly one suite, and that suite
-  // exists. They say nothing about whether anything opened the route — a claim pointing at a spec
-  // that never navigates there satisfies all of them. The browser fixture records every navigation
-  // it makes, and this compares that recording against the route list, which is what turns
-  // ownership into coverage.
+  // exists. Ownership alone is a claim, not coverage — a registry entry that points at a file which
+  // never navigates there used to pass as long as some other suite happened to open the same path.
+  // The browser fixture records every navigation with the driving spec file, and on a full run this
+  // requires each claimed route to have been opened by the suite that claims it.
   //
   // Only on a full run: a filtered run (a single spec file while working on it) legitimately visits
   // a fraction of the routes, and failing there would train people to ignore this gate. run.sh and
   // both CI workflows set the flag; a partial run says so rather than checking nothing quietly.
   if (process.env.E2E_FULL_RUN === '1') {
     const visited = readVisitedRoutes();
-    const unvisited = [...real].filter((route) => !visited.some((v) => routeMatches(route, v))).sort();
     if (visited.length === 0) {
       messages.push(
         `No navigations were recorded (${visitedRoutesPath()} is empty or missing), so route coverage ` +
           `could not be checked at all on a run that declared itself complete.`,
       );
-    } else if (unvisited.length > 0) {
-      messages.push(
-        `Routes claimed but never opened (${unvisited.length}) — the claiming suite must navigate ` +
-          `there:\n  - ${unvisited.join('\n  - ')}`,
-      );
+    } else {
+      // Collisions already fail loadRegistryClaims, so path → claim is unique here.
+      const claimByPath = new Map<string, RouteClaim>();
+      for (const claim of claims) {
+        claimByPath.set(claim.path, claim);
+      }
+
+      const neverOpened: string[] = [];
+      const wrongSuite: string[] = [];
+      // Unclaimed routes are reported only via `unclaimed` above — do not double-count them here.
+      for (const route of [...real].sort()) {
+        const claim = claimByPath.get(route);
+        if (!claim) continue;
+
+        const matching = visited.filter((v) => routeMatches(route, v.path));
+        const byClaimer = matching.filter((v) => v.specFile === claim.spec);
+        if (matching.length === 0) {
+          neverOpened.push(route);
+        } else if (byClaimer.length === 0) {
+          const openers = [...new Set(matching.map((v) => v.specFile))].sort();
+          wrongSuite.push(
+            `${route} (claimed by ${claim.spec}, opened by: ${openers.join(', ')})`,
+          );
+        }
+      }
+
+      if (neverOpened.length > 0) {
+        messages.push(
+          `Routes claimed but never opened (${neverOpened.length}) — the claiming suite must navigate ` +
+            `there:\n  - ${neverOpened.join('\n  - ')}`,
+        );
+      }
+      if (wrongSuite.length > 0) {
+        messages.push(
+          `Routes opened by the wrong suite (${wrongSuite.length}) — either add a navigation in the ` +
+            `claiming suite or reassign the claim to a suite that actually opens the route:\n  - ` +
+            `${wrongSuite.join('\n  - ')}`,
+        );
+      }
     }
   } else {
     console.log(

--- a/e2e-stack/specs/route-coverage.spec.ts
+++ b/e2e-stack/specs/route-coverage.spec.ts
@@ -16,7 +16,7 @@ import * as path from 'path';
 import * as ts from 'typescript';
 import { expect, test } from '@playwright/test';
 import type { RouteClaim } from './registry/types';
-import { readVisitedRoutes, routeMatches, visitedRoutesPath } from './fixtures/routes';
+import { readVisitedRoutes, routeMatches, specClaimName, visitedRoutesPath } from './fixtures/routes';
 
 const APP_SOURCE_PATH = '/work/app-source/App.tsx';
 
@@ -325,7 +325,8 @@ test('every app route is claimed by exactly one registry entry @coverage-gate', 
         if (!claim) continue;
 
         const matching = visited.filter((v) => routeMatches(route, v.path));
-        const byClaimer = matching.filter((v) => v.specFile === claim.spec);
+        const canonicalClaimSpec = specClaimName(path.join(__dirname, claim.spec));
+        const byClaimer = matching.filter((v) => v.specFile === canonicalClaimSpec);
         if (matching.length === 0) {
           neverOpened.push(route);
         } else if (byClaimer.length === 0) {

--- a/e2e-stack/specs/route-coverage.spec.ts
+++ b/e2e-stack/specs/route-coverage.spec.ts
@@ -16,7 +16,12 @@ import * as path from 'path';
 import * as ts from 'typescript';
 import { expect, test } from '@playwright/test';
 import type { RouteClaim } from './registry/types';
-import { readVisitedRoutes, routeMatches, specClaimName, visitedRoutesPath } from './fixtures/routes';
+import {
+  evaluateClaimedRouteVisits,
+  readVisitedRoutes,
+  specClaimName,
+  visitedRoutesPath,
+} from './fixtures/routes';
 
 const APP_SOURCE_PATH = '/work/app-source/App.tsx';
 
@@ -252,6 +257,28 @@ async function loadRegistryClaims(registryDir: string): Promise<{ claims: RouteC
   return { claims, byPath };
 }
 
+test('a claimed route opened only by another suite is reported as wrong-suite coverage', () => {
+  const route = '/synthetic/:id';
+  const claim: RouteClaim = { path: route, spec: 'owner.spec.ts' };
+  const specsDir = path.join(__dirname, 'synthetic-specs');
+  const canonicalClaimSpec = specClaimName(path.join(specsDir, claim.spec));
+  const differentSpec = 'different.spec.ts';
+  expect(differentSpec).not.toBe(canonicalClaimSpec);
+
+  const result = evaluateClaimedRouteVisits(
+    [route],
+    new Map([[route, claim]]),
+    [{ path: '/synthetic/42', specFile: differentSpec }],
+    specsDir,
+  );
+
+  expect(result.wrongSuite).toEqual([
+    '/synthetic/:id (claimed by owner.spec.ts, opened by: different.spec.ts)',
+  ]);
+  expect(result.neverOpened).toEqual([]);
+  expect(result.correctlyOpened).toEqual([]);
+});
+
 test('every app route is claimed by exactly one registry entry @coverage-gate', async () => {
   const registryDir = path.join(__dirname, 'registry');
   expect(fs.existsSync(APP_SOURCE_PATH), `App.tsx missing at ${APP_SOURCE_PATH}`).toBe(true);
@@ -317,25 +344,12 @@ test('every app route is claimed by exactly one registry entry @coverage-gate', 
         claimByPath.set(claim.path, claim);
       }
 
-      const neverOpened: string[] = [];
-      const wrongSuite: string[] = [];
-      // Unclaimed routes are reported only via `unclaimed` above — do not double-count them here.
-      for (const route of [...real].sort()) {
-        const claim = claimByPath.get(route);
-        if (!claim) continue;
-
-        const matching = visited.filter((v) => routeMatches(route, v.path));
-        const canonicalClaimSpec = specClaimName(path.join(__dirname, claim.spec));
-        const byClaimer = matching.filter((v) => v.specFile === canonicalClaimSpec);
-        if (matching.length === 0) {
-          neverOpened.push(route);
-        } else if (byClaimer.length === 0) {
-          const openers = [...new Set(matching.map((v) => v.specFile))].sort();
-          wrongSuite.push(
-            `${route} (claimed by ${claim.spec}, opened by: ${openers.join(', ')})`,
-          );
-        }
-      }
+      const { neverOpened, wrongSuite } = evaluateClaimedRouteVisits(
+        real,
+        claimByPath,
+        visited,
+        __dirname,
+      );
 
       if (neverOpened.length > 0) {
         messages.push(

--- a/e2e-stack/tsconfig.json
+++ b/e2e-stack/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM"],
+    // ES2021 for AggregateError, which cleanupCreatedData throws when a delete fails. Every runtime
+    // this harness runs on (the Playwright image, and the Node used by the workflow's type-check)
+    // has had it natively since Node 15 — only the type was missing. Raising the lib is the honest
+    // fix; declaring the constructor ambiently in the one file that needs it would shadow the real
+    // global the moment anyone raises the lib properly.
+    "lib": ["ES2021", "DOM"],
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
Closes the findings that were filed rather than fixed while #1288 was merged. All of them are about the trustworthiness of the gate itself: each one lets the harness report green without having checked.

## Gate integrity (#1311, #1313)

**`forbidOnly`** — the config pinned `workers: 1` and `retries: 0` but never forbade `test.only`. A committed one would have skipped the bulk of the suite *and* the `coverage-gate` project while CI stayed green.

**`.env` in the Docker build context** — the frontend build context is the repository root and the Dockerfiles `COPY . .`, but the root `.dockerignore` excluded only `node_modules`, `api-repo` and build artefacts. Gitignore does not protect a build context: an untracked `.env` still travels to the daemon and into builder layers, and CRA bakes `REACT_APP_*` values into the bundle. `up.sh` writes `e2e-stack/.env.generated` before `compose build frontend`, so this was concrete, not theoretical.

**Swallowed cleanup failures** — `cleanupCreatedData` cleared the registry *before* the deletes and only warned on failure, while every `afterAll` discards its return value. On a shared database a leftover row is state the next spec file inherits. It now throws, and failed references are re-registered in their original order so the next call retries them. Successful cleanup stays silent. The harness `tsconfig.json` moves to the ES2021 lib for the `AggregateError` type.

**`E2E_FULL_RUN` on filtered runs** — `run.sh` set the flag unconditionally while forwarding `"$@"`, which is how `--grep` reaches Playwright. A filtered run therefore declared itself complete. It now sets the flag only for a genuinely unfiltered run, decided by an **allowlist**: only flags known not to change *which* specs run leave a run complete — `--workers`, `--reporter`, `--timeout`, `--retries` and their kind, in both the `=` and the separate-value form, whose value is skipped rather than mistaken for a spec path. Everything else counts as a filter, including flags Playwright may add after this was written.

The list started as the opposite and was wrong twice: `--project`, `--shard`, `--last-failed` and `--only-changed` were each missed in turn, and every omission let a partial run declare itself complete. An allowlist fails the other way — an unrecognised flag costs the strict navigation check on a local run, which is the harmless direction. `--config` and `-c` are deliberately off it too: another config can drop the coverage-gate project entirely, so a flag that can replace the whole selection cannot be one that promises the selection is complete.

`develop` solved the same problem in parallel through #1308. Two details of that solution are better and are kept here: the variable is passed empty rather than merely left unset, because `compose.tests.yml` forwards `${E2E_FULL_RUN:-}` and a value exported by the calling shell would otherwise survive into the container; and a filtered run now says so on stdout.

## Cleaning up along the foreign keys

The throw immediately showed that cleanup had never worked completely — six spec files failed on foreign key violations from rows the application itself wrote and no test registered: `support_message` under `support_issue`, `buy_crypto` under both `bank_tx` and `buy`, `bank_tx` under `transaction`. The old helper covered two parents and descended one level.

Cleanup now reads the foreign keys once and descends into whatever references a row before deleting it, children first. Every statement still names a concrete id or foreign key value, so it can no more touch another account's rows or seed data than before. Cycles and diamonds terminate through a result map that returns what actually happened on a repeat visit rather than assuming success.

Whether a child table is a leaf is decided by whether anything references it — not by the shape of its primary key. A table with no primary key can still be referenced through a UNIQUE column; a composite-key join table nothing points at, like `mros_transactions_transaction`, has no descendants to lose and is deleted through its foreign key column. A table that is referenced but not addressable by `id` is reported through the same error path as an unresolvable foreign key, and only when a row for that parent actually exists.

## Claim-bound route coverage (#1312, #1309)

Navigation recording stored pathnames only, so the gate asked whether a route had been opened by *anyone* rather than by the suite named in `claim.spec`. Navigations now carry the spec file that drove them, and the gate matches each claim against navigations from its own file. The two failure modes are reported apart — never opened, and opened by the wrong suite — and the second names the files that did open it. Both sides derive the spec-file form through the same function, relative to `specs/`, so a suite moving into a subdirectory cannot silently make its own claims look unvisited.

## Factory id hardening (#1312, #1310)

`createLimitRequest` already refused a 2xx without an id; `createBankAccount`, `createBuy`, `createSell` and `createSwap` trusted the response body, and `track()` dropped a non-numeric id silently. A shared `requireId()` now guards every create response and `track()` itself, demanding a genuine positive integer — a stringified or fractional id is exactly the broken contract it exists to catch. `createSupportIssue` no longer tolerates a 2xx whose row it cannot find, and the one place where an absent id is legitimate says so with an explicit check rather than relying on truthiness.

One real defect surfaced on the way: `createLimitRequest` tracked `issueRow.limitRequestId` while returning `issueRow.limitRequestId ?? res.limitRequest?.id`, so a row resolved from the response body was returned but never registered for cleanup.

## Not in this pull request

Two pre-existing findings are filed separately: route coverage credits a splat claim for any navigation below it (#1315), and the module-load wallet-counter seeding has no rejection handler (#1316).

## Verification

`npx tsc --noEmit` under `e2e-stack/tsconfig.json` passes on Node 20, the version CI pins. The claim-bound gate and the recursive cleanup are only really exercised by a full stack run, which is what the `Full-stack E2E` check on this pull request does.

## What the review rounds changed

Four rounds of independent review, and the two most serious findings were in the cleanup this pull
request had just rewritten.

**A composite foreign key was paired by name, not by position.** The catalogue joined
`key_column_usage` to `constraint_column_usage` on the constraint name alone. For a key over several
columns that is a cross product: `(a, b) REFERENCES parent (x, y)` came back as four pairs, two of
which do not exist — and cleanup then used each pair on its own to find rows by that column, so it
could have found, and deleted, rows belonging to a different parent. It reads `pg_constraint` now
and pairs `conkey` to `confkey` by ordinality. Proven against a throwaway Postgres carrying one
two-column and one single-column key: the old query returns `a→x, a→y, b→x, b→y`, the new one
returns `a→x` and `b→y`, and the single-column case is identical either way.

**The first fix for self-referencing tables was itself the same mistake.** It refused to bulk-delete
as soon as the *schema* declared a foreign key onto itself — so a table that merely *can* reference
itself, holding one row whose self-reference is null, became unresolvable, and the parent delete
then failed on the foreign key. Deciding from the schema rather than from the rows present is
exactly what this pull request set out to remove. The gate now probes whether a row actually
references one of the rows about to be deleted, scoped to the one parent value. Rows in the same
batch count as referencers on purpose: a multi-row `DELETE` gives no order to rely on.

Three regression tests were added with it, each against a schema it creates and drops: composite
keys keep their ordinality, a table with an *unused* self key is cleaned up, and a table with a real
self reference is refused with its rows still present. A key spanning several columns is probed one
pair at a time, which can only refuse a delete that would have been safe, never allow one that is
not — the catalogue carries no constraint identity to group pairs by. That limit is stated in the
code and in `test-data.md`.

Also from the rounds: the claim-binding test now runs against a pure function with synthetic data,
so it can state the case the real registry cannot — a route opened, but by a different spec file
than the one claiming it. And two comments that described the opposite of the code were corrected.
